### PR TITLE
fixed calendar for empty timesheet descriptions

### DIFF
--- a/src/Calendar/TimesheetEntity.php
+++ b/src/Calendar/TimesheetEntity.php
@@ -155,7 +155,7 @@ class TimesheetEntity
     /**
      * @return string
      */
-    public function getDescription(): string
+    public function getDescription(): ?string
     {
         return $this->description;
     }

--- a/src/DataFixtures/TimesheetFixtures.php
+++ b/src/DataFixtures/TimesheetFixtures.php
@@ -66,10 +66,18 @@ class TimesheetFixtures extends Fixture implements DependentFixtureInterface
                 if ($i > self::MAX_TIMESHEETS_TOTAL) {
                     break;
                 }
+
+                $description = null;
+                if ($i % 3 == 0) {
+                    $description = $faker->text;
+                } elseif ($i % 7 == 0) {
+                    $description = '';
+                }
+
                 $entry = $this->createTimesheetEntry(
                     $user,
                     $activities[array_rand($activities)],
-                    ($i % 3 == 0 ? $faker->text : ''),
+                    $description,
                     round($i / 2),
                     true
                 );
@@ -89,7 +97,7 @@ class TimesheetFixtures extends Fixture implements DependentFixtureInterface
                 $entry = $this->createTimesheetEntry(
                     $user,
                     $activities[array_rand($activities)],
-                    $faker->text
+                    null
                 );
                 $manager->persist($entry);
             }

--- a/tests/DataFixtures/TimesheetFixtures.php
+++ b/tests/DataFixtures/TimesheetFixtures.php
@@ -97,10 +97,16 @@ class TimesheetFixtures extends Fixture
         $user = $this->user;
 
         for ($i = 0; $i < $this->amount; $i++) {
+            $description = null;
+            if ($i % 3 == 0) {
+                $description = $faker->text;
+            } elseif ($i % 2 == 0) {
+                $description = '';
+            }
             $entry = $this->createTimesheetEntry(
                 $user,
                 $activities[array_rand($activities)],
-                ($i % 3 == 0 ? $faker->text : ''),
+                $description,
                 $this->getDateTime($i)
             );
 


### PR DESCRIPTION
when the description of a timesheet entity was empty (null) the calendar didn't render the entries.