### PR TITLE
 Fix duration_short format for french translation 

### DIFF
--- a/config/packages/kimai.yaml
+++ b/config/packages/kimai.yaml
@@ -61,7 +61,7 @@ kimai:
         fr:
             date_short: 'd/m/Y'
             duration: '%%h h %%m min'
-            duration_short: '%%h:%%m h'
+            duration_short: '%%h h %%m'
         es:
             date_short: 'd.m.Y'
             duration: '%%h:%%m h'


### PR DESCRIPTION
to correct the format of the durations in the French translation

thank you 