### PR TITLE
automatically stop other time sheets when starting a new one.

### DIFF
--- a/src/Controller/TimesheetController.php
+++ b/src/Controller/TimesheetController.php
@@ -110,11 +110,11 @@ class TimesheetController extends AbstractController
     {
         $user = $this->getUser();
 
-	//Stop currently running actions.
-	$activeEntries = $this->getRepository()->getActiveEntries($user);
-	foreach ($activeEntries as $activeEntry) {
-		$this->stop($activeEntry, 'timesheet');
-	}
+        //Stop currently running actions.
+        $activeEntries = $this->getRepository()->getActiveEntries($user);
+        foreach ($activeEntries as $activeEntry) {
+                $this->stop($activeEntry, 'timesheet');
+        }
 
         try {
             $this->getRepository()->startRecording($user, $activity);


### PR DESCRIPTION
## Description
Automatically stop other time sheets when starting a new one to allow for faster switching between tasks.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] My code follows the code style
- [x] All files have a license header 
- [x] All methods have a doc header with type declarations
- [x] I have updated the documentation ~~accordingly~~ _where neccesary_
- [x] I have added tests to cover my changes _where neccesary_
