### PR TITLE
added copy invoice template action

### DIFF
--- a/src/Twig/Extensions.php
+++ b/src/Twig/Extensions.php
@@ -59,6 +59,7 @@ class Extensions extends \Twig_Extension
         'admin' => 'fas fa-wrench',
         'calendar' => 'far fa-calendar-alt',
         'customer' => 'fas fa-users',
+        'copy' => 'far fa-copy',
         'create' => 'far fa-plus-square',
         'dashboard' => 'fas fa-tachometer-alt',
         'delete' => 'far fa-trash-alt',

--- a/templates/invoice/templates.html.twig
+++ b/templates/invoice/templates.html.twig
@@ -27,6 +27,7 @@
             <td class="hidden-xs hidden-sm">{{ entry.vat }}</td>
             <td>
                 {% set actionButtons = {'edit': path('admin_invoice_template_edit', {'id' : entry.id, 'page': page})} %}
+                {% set actionButtons = actionButtons|merge({'copy': path('admin_invoice_template_copy', {'id' : entry.id, 'page': page})}) %}
                 {% set actionButtons = actionButtons|merge({'trash': path('admin_invoice_template_delete', {'id' : entry.id, 'page': page})}) %}
                 {{ widgets.button_group(actionButtons) }}
             </td>

--- a/tests/Controller/InvoiceControllerTest.php
+++ b/tests/Controller/InvoiceControllerTest.php
@@ -88,6 +88,34 @@ class InvoiceControllerTest extends ControllerBaseTest
         $this->assertHasFlashSuccess($client);
     }
 
+    public function testCopyTemplateAction()
+    {
+        $client = $this->getClientForAuthenticatedUser(User::ROLE_TEAMLEAD);
+        $em = $client->getContainer()->get('doctrine.orm.entity_manager');
+
+        $fixture = new InvoiceFixtures();
+        $this->importFixture($em, $fixture);
+
+        /** @var InvoiceTemplate $template */
+        $template = $em->getRepository(InvoiceTemplate::class)->find(1);
+
+        $this->request($client, '/invoice/template/create/1');
+        $this->assertTrue($client->getResponse()->isSuccessful());
+
+        $form = $client->getCrawler()->filter('form[name=invoice_template_form]')->form();
+        $values = $form->getPhpValues()['invoice_template_form'];
+        $this->assertEquals('Copy of ' . $template->getName(), $values['name']);
+        $this->assertEquals($template->getTitle(), $values['title']);
+        $this->assertEquals($template->getDueDays(), $values['dueDays']);
+        $this->assertEquals($template->getCalculator(), $values['calculator']);
+        $this->assertEquals($template->getVat(), $values['vat']);
+        $this->assertEquals($template->getRenderer(), $values['renderer']);
+        $this->assertEquals($template->getCompany(), $values['company']);
+        $this->assertEquals($template->getAddress(), $values['address']);
+        $this->assertEquals($template->getPaymentTerms(), $values['paymentTerms']);
+        $this->assertEquals($template->getNumberGenerator(), $values['numberGenerator']);
+    }
+
     public function testPrintAction()
     {
         $client = $this->getClientForAuthenticatedUser(User::ROLE_TEAMLEAD);

--- a/tests/Twig/ExtensionsTest.php
+++ b/tests/Twig/ExtensionsTest.php
@@ -180,7 +180,7 @@ class ExtensionsTest extends TestCase
         $icons = [
             'user', 'customer', 'project', 'activity', 'admin', 'invoice', 'timesheet', 'dashboard', 'logout', 'trash',
             'delete', 'repeat', 'edit', 'manual', 'help', 'start', 'start-small', 'stop', 'stop-small', 'filter',
-            'create', 'list', 'print', 'visibility', 'calendar', 'money', 'duration', 'download'
+            'create', 'list', 'print', 'visibility', 'calendar', 'money', 'duration', 'download', 'copy'
         ];
 
         // test pre-defined icons


### PR DESCRIPTION
Adds a new button next to each existing invoice template, which allows to create a new template from the existing one. 

Simplifies the process of creating a new template, as I assume that we most often use the same contents but only a different renderer and/or calculator.