### PR TITLE
fixed issues- & milestone links

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Looking for more information about using Kimai? Check out our more detailed [doc
 
 You can see our development roadmap for the future in the [Milestones](https://github.com/kevinpapst/kimai2/milestones) sections.
 
-Our roadmap is open for changes and input from the community, please [sent us](https://github.com/kevinpapst/kimai2/issues) your ideas and questions.
+Our roadmap is open for changes and input from the community, please [send us](https://github.com/kevinpapst/kimai2/issues) your ideas and questions.
 
 ## Installation
 


### PR DESCRIPTION
## Description
The links for Milestones and Issues in the `README.md` were linking to github-404-pages.

Fixed them by adding absolute urls to 
+ https://github.com/kevinpapst/kimai2/milestones and
+ https://github.com/kevinpapst/kimai2/issues

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] My code follows the code style
- [ ] All files have a license header 
- [ ] All methods have a doc header with type declarations
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
