### PR TITLE
Include pagination header for Timesheet list action

### DIFF
--- a/src/API/BaseApiController.php
+++ b/src/API/BaseApiController.php
@@ -18,4 +18,5 @@ abstract class BaseApiController extends AbstractController
 {
     public const DATE_FORMAT = DateTimeType::HTML5_FORMAT;
     public const DATE_FORMAT_PHP = 'Y-m-d\TH:m:s';
+    public const NEXT_PAGE_HEADER = 'Kimai-Has-Next-Page';
 }

--- a/src/API/TimesheetController.php
+++ b/src/API/TimesheetController.php
@@ -226,6 +226,7 @@ class TimesheetController extends BaseApiController
 
         /** @var Pagerfanta $data */
         $data = $this->repository->getPagerfantaForQuery($query);
+        $hasNextPage = $data->hasNextPage();
         $data = (array) $data->getCurrentPageResults();
 
         $view = new View($data, 200);
@@ -233,6 +234,10 @@ class TimesheetController extends BaseApiController
             $view->getContext()->setGroups(['Default', 'Subresource', 'Timesheet']);
         } else {
             $view->getContext()->setGroups(['Default', 'Collection', 'Timesheet']);
+        }
+
+        if ($hasNextPage) {
+            $view->setHeader(self::NEXT_PAGE_HEADER, 'true');
         }
 
         return $this->viewHandler->handle($view);


### PR DESCRIPTION
## Description
I noticed that when I am looping through the pages of Timesheets I never know what is the last page. To find that out I actually have to make a request that fails with 500. Which does not seem really the best way to me. How about Kimai would include a header saying whether the client should try to get next page? Once that header is missing, the client won't try to get any more data.

In dev environment, the 500 response actually says the reason for the failure is page out of index but in production, the message just says Internal Server Error so the client has no clue what caused the problem.

What do you think about this approach?

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] I verified that my code applies to the guidelines (`composer kimai:code-check`)
- [ ] I updated the documentation (see [here](https://github.com/kimai/www.kimai.org/tree/master/_documentation))
- [ ] I agree that this code is used in Kimai and will be published under the [MIT license](https://github.com/kevinpapst/kimai2/blob/master/LICENSE)
