### PR TITLE
added js plugin to handle native notifications

### DIFF
--- a/assets/js/KimaiLoader.js
+++ b/assets/js/KimaiLoader.js
@@ -36,6 +36,7 @@ import KimaiDatePicker from "./plugins/KimaiDatePicker";
 import KimaiConfirmationLink from "./plugins/KimaiConfirmationLink";
 import KimaiMultiUpdateTable from "./plugins/KimaiMultiUpdateTable";
 import KimaiDateUtils from "./plugins/KimaiDateUtils";
+import KimaiNotification from "./plugins/KimaiNotification";
 
 export default class KimaiLoader {
 
@@ -51,6 +52,7 @@ export default class KimaiLoader {
         kimai.registerPlugin(new KimaiEvent());
         kimai.registerPlugin(new KimaiAPI());
         kimai.registerPlugin(new KimaiAlert());
+        kimai.registerPlugin(new KimaiNotification());
         kimai.registerPlugin(new KimaiDateUtils());
         kimai.registerPlugin(new KimaiFormSelect('.selectpicker'));
         kimai.registerPlugin(new KimaiConfirmationLink('confirmation-link'));

--- a/assets/js/plugins/KimaiNotification.js
+++ b/assets/js/plugins/KimaiNotification.js
@@ -1,0 +1,83 @@
+/*
+ * This file is part of the Kimai time-tracking app.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+/*!
+ * [KIMAI] KimaiAlert: notifications for Kimai
+ */
+
+import KimaiPlugin from "../KimaiPlugin";
+
+/**
+ * In the future the "lang" and "dir" options could be set via constructor.
+ * @see https://developer.mozilla.org/de/docs/Web/API/notification
+ */
+export default class KimaiNotification extends KimaiPlugin {
+
+    getId() {
+        return 'notification';
+    }
+
+    _checkNotificationPromiseSupport() {
+        try {
+            Notification.requestPermission().then();
+        } catch(e) {
+            return false;
+        }
+
+        return true;
+    }
+
+    hasNotificationSupport() {
+        if (!window.Notification) {
+            return false;
+        }
+
+        if (Notification.permission === 'denied') {
+            return false;
+        }
+
+        if (Notification.permission === "granted") {
+            return true;
+        }
+
+        let result = false;
+
+        try {
+            Notification.requestPermission().then((permission) => {
+                if (permission === "granted") {
+                    result = true;
+                }
+            });
+        } catch (e) {
+            Notification.requestPermission(function (permission) {
+                if (permission === "granted") {
+                    result = true;
+                }
+            });
+        }
+
+        return result;
+    }
+
+    notify(title, message, icon, options) {
+        if (false === this.hasNotificationSupport()) {
+            return;
+        }
+
+        let opts = { body: message };
+
+        if (icon !== null) {
+            opts.icon = icon;
+        }
+
+        if (options !== null) {
+            opts = { ...opts, ...options};
+        }
+
+        return new Notification(title, opts);
+    }
+}


### PR DESCRIPTION
## Description

Just a technical proof of concept and a good point to start some discussions.

The included plugin is just a simple API to trigger native/desktop notification in browsers that support it.
So this feature should be seen as a "goodie" and no critical features should depend on it, at the end every user could block those notification as well.

I envision a new preference page with a collection of features that can be de-/activted:
- warn after X hours for a break
- warn about long running entries
...
- a button to de-/activate these notifications (FF only allows to ask for permissions after clicking an element)

I am sure there are a couple of issues already existing, that talk about such features.

**TODO**
- [ ] add a section on the profile page (?) to show current status and allow to re-ask for permission, in case it was declined at first
- [ ] use new "max length for entry" for a first proof of concept notification


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] I verified that my code applies to the guidelines (`composer code-check`)
- [ ] I updated the documentation (see [here](https://github.com/kimai/www.kimai.org/tree/master/_documentation))
- [x] I agree that this code is used in Kimai and will be published under the [MIT license](https://github.com/kevinpapst/kimai2/blob/master/LICENSE)
