### PR TITLE
Markdown in one-liners and team timesheets

### DIFF
--- a/src/Twig/Runtime/MarkdownExtension.php
+++ b/src/Twig/Runtime/MarkdownExtension.php
@@ -89,6 +89,10 @@ final class MarkdownExtension implements RuntimeExtensionInterface
             $addHellip = true;
         }
 
+        if ($this->isMarkdownEnabled()) {
+            $content = $this->markdown->inline($content, false);
+        }
+
         $content = explode(PHP_EOL, $content);
         $result = $content[0];
 

--- a/src/Utils/Markdown.php
+++ b/src/Utils/Markdown.php
@@ -23,7 +23,6 @@ final class Markdown
     {
         $this->parser = new ParsedownExtension();
         $this->parser->setUrlsLinked(true);
-        $this->parser->setBreaksEnabled(true);
     }
 
     /**
@@ -34,7 +33,21 @@ final class Markdown
     public function toHtml(string $text, bool $safe = true): string
     {
         $this->parser->setSafeMode($safe);
+        $this->parser->setBreaksEnabled(true);
 
         return $this->parser->text($text);
+    }
+
+    /**
+     * @param string $text
+     * @param bool $safe
+     * @return string
+     */
+    public function inline(string $text, bool $safe = true): string
+    {
+        $this->parser->setSafeMode($safe);
+        $this->parser->setBreaksEnabled(false);
+
+        return $this->parser->line($text);
     }
 }

--- a/templates/timesheet-team/index.html.twig
+++ b/templates/timesheet-team/index.html.twig
@@ -6,7 +6,7 @@
 {% set editRoute = 'admin_timesheet_edit' %}
 {% set canSeeRate = is_granted('view_rate_other_timesheet') %}
 {% set canSeeUsername = true %}
-{% set allowMarkdown = false %}
+{% set allowMarkdown = true %}
 
 {% block page_title %}{{ 'admin_timesheet.title'|trans }}{% endblock %}
 {% block page_actions %}{{ actions.timesheets_team('index') }}{% endblock %}

--- a/tests/Twig/Runtime/MarkdownExtensionTest.php
+++ b/tests/Twig/Runtime/MarkdownExtensionTest.php
@@ -81,7 +81,7 @@ class MarkdownExtensionTest extends TestCase
     public function testCommentOneLiner()
     {
         $loader = $this->createMock(ConfigLoaderInterface::class);
-        $config = new SystemConfiguration($loader, []);
+        $config = new SystemConfiguration($loader, ['timesheet' => ['markdown_content' => false]]);
         $sut = new MarkdownExtension(new Markdown(), $config);
 
         $loremIpsum = 'Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua.';
@@ -124,6 +124,46 @@ class MarkdownExtensionTest extends TestCase
         $this->assertEquals(
             'Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt &hellip;',
             $sut->commentOneLiner(implode(PHP_EOL, ['Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt', 'ssdf']))
+        );
+
+        $config = new SystemConfiguration($loader, ['timesheet' => ['markdown_content' => true]]);
+        $sut = new MarkdownExtension(new Markdown(), $config);
+
+        $markdown = '*foo bar* http://example.com foo bar and more test letters';
+
+        $this->assertEquals(
+            '<em>foo bar</em> <a href="http://example.com" target="_blank">http://example.com</a> foo bar and more test &hellip;',
+            $sut->commentOneLiner($markdown, false)
+        );
+
+        $this->assertEquals(
+            '<em>foo bar</em> <a href="http://example.com" target="_blank">http://example.com</a> foo bar and more test letters &hellip;',
+            $sut->commentOneLiner(implode(PHP_EOL, [$markdown, $loremIpsum, $loremIpsum]), true)
+        );
+
+        $this->assertEquals(
+            '<em>foo bar</em> <a href="http://example.com" target="_blank">http://example.com</a> foo bar and more test &hellip;',
+            $sut->commentOneLiner(implode(PHP_EOL, [$markdown, $loremIpsum, $loremIpsum]), false)
+        );
+
+        $this->assertEquals(
+            '<em>foo bar</em> <a href="http://example.com" target="_blank">http://example.com</a> foo bar and more test letters',
+            $sut->commentOneLiner(implode(PHP_EOL, [$markdown]), true)
+        );
+
+        $this->assertEquals(
+            '<em>foo bar</em> <a href="http://example.com" target="_blank">http://example.com</a> foo bar and more test letters &hellip;',
+            $sut->commentOneLiner(implode(PHP_EOL, [$markdown, 'new line']), true)
+        );
+
+        $this->assertEquals(
+            '<em>foo bar</em> <a href="http://example.com" target="_blank">http://example.com</a> foo bar and more test letters',
+            $sut->commentOneLiner(implode(PHP_EOL, [$markdown]))
+        );
+
+        $this->assertEquals(
+            '<em>foo bar</em> <a href="http://example.com" target="_blank">http://example.com</a> foo bar and more test letters &hellip;',
+            $sut->commentOneLiner(implode(PHP_EOL, [$markdown, 'new line']))
         );
     }
 }

--- a/tests/Utils/MarkdownTest.php
+++ b/tests/Utils/MarkdownTest.php
@@ -51,7 +51,7 @@ foo bar
 asdfasdfa
 
     ssdfsdf
-    
+
 http://example.com/foo-bar.html
 file:///home/kimai/images/beautiful-flower.png
 
@@ -63,6 +63,28 @@ aasdfasdf
 222
 EOT;
         $this->assertEquals($html, $sut->toHtml($markdown));
+    }
+
+    public function testMarkdownInline()
+    {
+        $sut = new Markdown();
+        $html = <<<'EOT'
+<em>foo</em> <a href="http://example.com" target="_blank">http://example.com</a>
+
+- foo bar
+- bar foo
+
+bar
+EOT;
+        $markdown = <<<'EOT'
+*foo* http://example.com
+
+- foo bar
+- bar foo
+
+bar
+EOT;
+        $this->assertEquals($html, $sut->inline($markdown));
     }
 
     public function testDuplicateIds()


### PR DESCRIPTION
## Description
`MarkdownExtension::commentOneLiner()` added in af9dea9226c49517f529920c4063098d9a6405cd was implemented without markdown rending. This PR adds the functionality and ensures inline rendering with use of [Parsedown::line()](https://github.com/erusev/parsedown/blob/6598f3860c2698fe2f0f1bc98212fc01d0a1893c/Parsedown.php#L1130).

Also including a fix for team timesheet descriptions. But maybe i just miss the point if it was disabled on purpose.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] I verified that my code applies to the guidelines (`composer code-check`)
- [ ] I updated the documentation (see [here](https://github.com/kimai/www.kimai.org/tree/master/_documentation))
- [x] I agree that this code is used in Kimai and will be published under the [MIT license](https://github.com/kevinpapst/kimai2/blob/master/LICENSE)
