### PR TITLE
allow timesheet duration via api

### DIFF
--- a/src/API/TimesheetController.php
+++ b/src/API/TimesheetController.php
@@ -331,6 +331,7 @@ class TimesheetController extends BaseApiController
             'allow_begin_datetime' => $mode->canUpdateTimesWithAPI(),
             'allow_end_datetime' => $mode->canUpdateTimesWithAPI(),
             'date_format' => self::DATE_FORMAT,
+            'allow_duration' => $mode->canUpdateTimesWithAPI(),
         ]);
 
         $form->submit($request->request->all(), false);
@@ -408,6 +409,7 @@ class TimesheetController extends BaseApiController
             'allow_begin_datetime' => $mode->canUpdateTimesWithAPI(),
             'allow_end_datetime' => $mode->canUpdateTimesWithAPI(),
             'date_format' => self::DATE_FORMAT,
+            'allow_duration' => $mode->canUpdateTimesWithAPI(),
         ]);
 
         $form->setData($timesheet);

--- a/src/Form/API/TimesheetApiEditForm.php
+++ b/src/Form/API/TimesheetApiEditForm.php
@@ -44,9 +44,9 @@ class TimesheetApiEditForm extends TimesheetEditForm
 
         $resolver->setDefaults([
             'csrf_protection' => false,
-            'allow_duration' => false,
             // overwritten and changed to default "true",
             // because the docs are cached without these fields otherwise
+            'allow_duration' => true,
             'include_user' => true,
             'include_exported' => true,
             'include_rate' => true,

--- a/src/Form/Type/DurationType.php
+++ b/src/Form/Type/DurationType.php
@@ -33,6 +33,10 @@ class DurationType extends AbstractType
             'constraints' => [new DurationConstraint()],
             'preset_hours' => null,
             'preset_minutes' => null,
+            'documentation' => [
+                'type' => 'string',
+                'description' => 'This field might not be available, depending on the used time-tracking mode. If you submit end and duration, duration will be ignored.',
+            ],
         ]);
     }
 


### PR DESCRIPTION
## Description

Fixes #2175 
Fixes #2139

See https://www.kimai.org/documentation/timesheet.html#duration-format for the formats accepted by duration.

**TODO**

- add API tests 
- fix validation: if end and duration are submitted, end is used later on in the process and replaces the submitted duration  - but the submitted duration is used to validate the time budget, which could lead to false negatives 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] I verified that my code applies to the guidelines (`composer code-check`)
- [ ] I updated the documentation (see [here](https://github.com/kimai/www.kimai.org/tree/master/_documentation))
- [x] I agree that this code is used in Kimai and will be published under the [MIT license](https://github.com/kevinpapst/kimai2/blob/master/LICENSE)
