### PR TITLE
set some security options on cookies

### DIFF
--- a/config/packages/framework.yaml
+++ b/config/packages/framework.yaml
@@ -12,6 +12,9 @@ framework:
 
     session:
         handler_id: App\Security\SessionHandler
+        cookie_secure: auto
+        cookie_httponly: true
+        cookie_samesite: lax
 
     #esi: ~
     #fragments: ~


### PR DESCRIPTION
## Description

The first one might be a BC break when terminating HTTPS in front of Kimai.

- cookie_secure: auto (when using https = true, with http = false) 
- cookie_httponly: true 
- cookie_samesite: lax (strict should work as well, but let's start one step after another)

## Types of changes
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] I verified that my code applies to the guidelines (`composer code-check`)
- [x] I agree that this code is used in Kimai and will be published under the [MIT license](https://github.com/kevinpapst/kimai2/blob/master/LICENSE)
