### PR TITLE
make sure that minute_increment is not zero

### DIFF
--- a/src/Controller/SystemConfigurationController.php
+++ b/src/Controller/SystemConfigurationController.php
@@ -354,10 +354,10 @@ final class SystemConfigurationController extends AbstractController
                     (new Configuration())
                         ->setName('timesheet.time_increment')
                         ->setType(MinuteIncrementType::class)
-                        ->setOptions(['deactivate' => false])
+                        ->setOptions(['deactivate' => false, 'max_one_hour' => true])
                         ->setTranslationDomain('system-configuration')
                         ->setConstraints([
-                            new GreaterThanOrEqual(['value' => 1])
+                            new Range(['min' => 1, 'max' => 60])
                         ]),
                     (new Configuration())
                         ->setName('timesheet.duration_increment')

--- a/src/Form/Type/DateTimePickerType.php
+++ b/src/Form/Type/DateTimePickerType.php
@@ -55,13 +55,20 @@ class DateTimePickerType extends AbstractType
 
     public function buildView(FormView $view, FormInterface $form, array $options)
     {
-        $view->vars['attr'] = array_merge($view->vars['attr'], [
+        $attr = array_merge($view->vars['attr'], [
             'data-datetimepicker' => 'on',
             'autocomplete' => 'off',
             'placeholder' => strtoupper($options['format']),
             'data-format' => $options['format_picker'],
-            'data-time-picker-increment' => $options['time_increment'],
         ]);
+
+        if ($options['time_increment'] !== null) {
+            if ($options['time_increment'] >= 1) {
+                $attr['data-time-picker-increment'] = $options['time_increment'];
+            }
+        }
+
+        $view->vars['attr'] = $attr;
     }
 
     /**

--- a/src/Form/Type/MinuteIncrementType.php
+++ b/src/Form/Type/MinuteIncrementType.php
@@ -26,6 +26,7 @@ class MinuteIncrementType extends AbstractType
     {
         $resolver->setDefaults([
             'deactivate' => true,
+            'max_one_hour' => false,
         ]);
 
         $resolver->setDefault('choices', function (Options $options) {
@@ -47,8 +48,11 @@ class MinuteIncrementType extends AbstractType
             $choices['30'] = '30';
             $choices['45'] = '45';
             $choices['60'] = '60';
-            $choices['90'] = '90';
-            $choices['120'] = '120';
+
+            if (!$options['max_one_hour']) {
+                $choices['90'] = '90';
+                $choices['120'] = '120';
+            }
 
             return $choices;
         });


### PR DESCRIPTION
## Description

This could cause a Javascript bug in forms that use the DateTimePickerType and the system setting `Minute selection for From & To` with the value `Use configured value of the rounding rule` and then the rounding rule being zero.

The form/browser tab would simply freeze, due to another bug in the underlying javascript date-time-picker.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] I verified that my code applies to the guidelines (`composer code-check`)
- [x] I agree that this code is used in Kimai and will be published under the [MIT license](https://github.com/kevinpapst/kimai2/blob/master/LICENSE)
