### PR TITLE
Project date-range report: allow budget-type independent project-listing

### DIFF
--- a/src/Project/ProjectStatisticService.php
+++ b/src/Project/ProjectStatisticService.php
@@ -168,7 +168,7 @@ class ProjectStatisticService
                 $qb->expr()->eq('p.budget', 0.0),
                 $qb->expr()->eq('p.timeBudget', 0)
             );
-        } else {
+        } else if (!$query->isBudgetIndependent()) {
             $qb->andWhere(
                 $qb->expr()->orX(
                     $qb->expr()->gt('p.budget', 0.0),

--- a/src/Project/ProjectStatisticService.php
+++ b/src/Project/ProjectStatisticService.php
@@ -168,7 +168,7 @@ class ProjectStatisticService
                 $qb->expr()->eq('p.budget', 0.0),
                 $qb->expr()->eq('p.timeBudget', 0)
             );
-        } else if (!$query->isBudgetIndependent()) {
+        } elseif (!$query->isBudgetIndependent()) {
             $qb->andWhere(
                 $qb->expr()->orX(
                     $qb->expr()->gt('p.budget', 0.0),

--- a/src/Reporting/ProjectDateRange/ProjectDateRangeForm.php
+++ b/src/Reporting/ProjectDateRange/ProjectDateRangeForm.php
@@ -56,6 +56,7 @@ class ProjectDateRangeForm extends AbstractType
             'multiple' => false,
             'expanded' => true,
             'choices' => [
+                'label.budgetIndependent' => null,
                 'label.includeNoBudget' => 'none',
                 'label.includeBudgetType_full' => 'full',
                 'label.includeBudgetType_month' => 'month',

--- a/src/Reporting/ProjectDateRange/ProjectDateRangeQuery.php
+++ b/src/Reporting/ProjectDateRange/ProjectDateRangeQuery.php
@@ -26,14 +26,24 @@ final class ProjectDateRangeQuery
      * @var Customer|null
      */
     private $customer;
-
-    private $includeNoWork = true;
-    private $budgetType = 'month';
+    /**
+     * @var bool
+     */
+    private $includeNoWork = false;
+    /**
+     * @var string|null
+     */
+    private $budgetType = null;
 
     public function __construct(\DateTime $month, User $user)
     {
         $this->month = clone $month;
         $this->user = $user;
+    }
+
+    public function isBudgetIndependent(): bool
+    {
+        return $this->budgetType === null;
     }
 
     public function isIncludeNoBudget(): bool

--- a/tests/Controller/Reporting/ProjectDateRangeControllerTest.php
+++ b/tests/Controller/Reporting/ProjectDateRangeControllerTest.php
@@ -51,6 +51,7 @@ class ProjectDateRangeControllerTest extends ControllerBaseTest
         $activities = $this->importFixture($activities);
 
         $timesheets = new TimesheetFixtures();
+        $timesheets->setStartDate(new \DateTime());
         $timesheets->setAmount(50);
         $timesheets->setActivities($activities);
         $timesheets->setUser($this->getUserByRole(User::ROLE_TEAMLEAD));

--- a/tests/Reporting/ProjectDateRange/ProjectDateRangeQueryTest.php
+++ b/tests/Reporting/ProjectDateRange/ProjectDateRangeQueryTest.php
@@ -28,11 +28,12 @@ class ProjectDateRangeQueryTest extends TestCase
         self::assertEquals($date->getTimestamp(), $sut->getMonth()->getTimestamp());
         self::assertSame($user, $sut->getUser());
         self::assertNull($sut->getCustomer());
-        self::assertTrue($sut->isIncludeNoWork());
+        self::assertFalse($sut->isIncludeNoWork());
 
-        self::assertEquals('month', $sut->getBudgetType());
+        self::assertNull($sut->getBudgetType());
         self::assertFalse($sut->isIncludeNoBudget());
-        self::assertTrue($sut->isBudgetTypeMonthly());
+        self::assertFalse($sut->isBudgetTypeMonthly());
+        self::assertTrue($sut->isBudgetIndependent());
     }
 
     public function testSetterGetter()

--- a/translations/messages.de.xlf
+++ b/translations/messages.de.xlf
@@ -1221,6 +1221,10 @@
         <source>label.includeBudgetType_month</source>
         <target>Einträge mit „Monats-Budget“ anzeigen</target>
       </trans-unit>
+      <trans-unit id="Wq.h4adsfsdfnD" resname="label.budgetIndependent">
+        <source>label.budgetIndependent</source>
+        <target>Unabhängig vom „Budget-Typ“ anzeigen</target>
+      </trans-unit>
       <trans-unit id="nVulc7." resname="label.includeBudgetType_full">
         <source>label.includeBudgetType_full</source>
         <target>Einträge mit „Lebenszyklus“-Budget anzeigen</target>

--- a/translations/messages.en.xlf
+++ b/translations/messages.en.xlf
@@ -1221,6 +1221,10 @@
         <source>label.includeBudgetType_month</source>
         <target>Show entries with "monthly" budget</target>
       </trans-unit>
+      <trans-unit id="Wq.h4adsfsdfnD" resname="label.budgetIndependent">
+        <source>label.budgetIndependent</source>
+        <target>Show regardless of "budget-type"</target>
+      </trans-unit>
       <trans-unit id="nVulc7." resname="label.includeBudgetType_full">
         <source>label.includeBudgetType_full</source>
         <target>Show entries with "life cycle" budget</target>


### PR DESCRIPTION
## Description

- allow to show all projects independent from budget type
- do not include projects without booking by default

## Types of changes
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] I verified that my code applies to the guidelines (`composer code-check`)
- [x] I agree that this code is used in Kimai and will be published under the [MIT license](https://github.com/kevinpapst/kimai2/blob/master/LICENSE)
