### PR TITLE
show total hourly rate in detail pages

### DIFF
--- a/templates/embeds/budgets.html.twig
+++ b/templates/embeds/budgets.html.twig
@@ -131,7 +131,7 @@
                             <td class="text-nowrap text-right">{{ stats.internalRate|money(currency) }}</td>
                             <td class="text-nowrap text-right">{{ percentReached|number_format(2) }}%</td>
                         </tr>
-                        {% if timeBudgetVisible and stats.duration > 0%}
+                        {% if not entity.isMonthlyBudget() and timeBudgetVisible and stats.duration > 0 %}
                             {% set realHourlyRate = stats.rateBillable / stats.duration|chart_duration %}
                             <tr>
                                 <td>{{ 'label.hourlyRate'|trans }} ({{ 'label.billable'|trans }} / {{ durationTrans|trans }})</td>

--- a/templates/embeds/budgets.html.twig
+++ b/templates/embeds/budgets.html.twig
@@ -1,4 +1,6 @@
-{% if is_granted('time', entity) %}
+{% set timeBudgetVisible = is_granted('time', entity) %}
+{% set durationTrans = entity.isMonthlyBudget() ? 'stats.durationMonth' : 'stats.durationTotal' %}
+{% if timeBudgetVisible %}
     {% embed '@AdminLTE/Widgets/box-widget.html.twig' %}
         {% import "macros/progressbar.html.twig" as progress %}
         {% import "macros/widgets.html.twig" as widgets %}
@@ -8,7 +10,6 @@
         {% block box_body_class %}no-padding{% endblock %}
         {% block box_attributes %}id="time_budget_box"{% endblock %}
         {% block box_body %}
-            {% set durationTrans = entity.isMonthlyBudget() ? 'stats.durationMonth' : 'stats.durationTotal' %}
             <div class="row">
                 <div class="col-xs-12 col-sm-5">
                     <table class="table table-hover dataTable">
@@ -130,8 +131,16 @@
                             <td class="text-nowrap text-right">{{ stats.internalRate|money(currency) }}</td>
                             <td class="text-nowrap text-right">{{ percentReached|number_format(2) }}%</td>
                         </tr>
-                        {% if entity.budget > 0 %}
+                        {% if timeBudgetVisible and stats.duration > 0%}
+                            {% set realHourlyRate = stats.rateBillable / stats.duration|chart_duration %}
                             <tr>
+                                <td>{{ 'label.hourlyRate'|trans }} ({{ 'label.billable'|trans }} / {{ durationTrans|trans }})</td>
+                                <td class="text-nowrap text-right">{{ realHourlyRate|money(currency) }}</td>
+                                <td class="text-nowrap text-right">-</td>
+                            </tr>
+                        {% endif %}
+                        {% if entity.budget > 0 %}
+                                <tr>
                                 <th colspan="3" class="text-nowrap text-right">
                                     {% if totalPercentReached < 100 %}
                                         {{ 'stats.percentUsedLeft'|trans({'%percent%': totalPercentReached|number_format(2), '%left%': (entity.budget - stats.rateBillable)|money(currency)}) }}


### PR DESCRIPTION
## Description

Adds one more row to the money budget box, with the calculated overall hourly rate (for lifetime budget only):

<img width="1064" alt="Bildschirmfoto 2022-07-26 um 23 35 00" src="https://user-images.githubusercontent.com/533162/181116348-3ef2735f-ebdd-432f-aa0c-88f0ec8e4e2a.png">

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist
- [x] I verified that my code applies to the guidelines (`composer code-check`)
- [x] I agree that this code is used in Kimai and will be published under the [MIT license](https://github.com/kevinpapst/kimai2/blob/master/LICENSE)
