### PR TITLE
disable create-invoice links after click

### DIFF
--- a/templates/invoice/index.html.twig
+++ b/templates/invoice/index.html.twig
@@ -244,9 +244,12 @@
             const overwrites = {'customers[]': link.dataset['customer'], 'template': link.dataset['template']};
             const uri = formPlugin.convertFormDataToQueryString(document.getElementById('{{ formId }}'), overwrites);
 
-            link.href = link.dataset['href'] + '?' + uri;
+            link.classList.toggle('disabled');
+            link.href = 'javascript: void(0)';
 
-            return true;
+            document.location = link.dataset['href'] + '?' + uri;
+
+            return false;
         }
 
         function saveAllInvoices(link)
@@ -254,9 +257,12 @@
             const formPlugin = kimai.getPlugin('form');
             const uri = formPlugin.convertFormDataToQueryString(document.getElementById('{{ formId }}'));
 
-            link.href = '{{ path('invoice') }}?token={{ csrf_token('invoice.create') }}&createInvoice=true&' + uri;
+            link.classList.toggle('disabled');
+            link.href = 'javascript: void(0)';
 
-            return true;
+            document.location = '{{ path('invoice') }}?token={{ csrf_token('invoice.create') }}&createInvoice=true&' + uri;
+
+            return false;
         }
 
         document.addEventListener('kimai.initialized', function() {


### PR DESCRIPTION
## Description

> disable create-invoice links after click to prevent double invoices with history.back()

When creating invoices and then using "browser back", you will still see the entire list of all invoices.
This change will disable the link and make it impossible to click it again after "creating and going back".

Before:
<img width="314" alt="Bildschirmfoto 2022-08-01 um 14 16 43" src="https://user-images.githubusercontent.com/533162/182145804-69faf6fd-0290-4b2b-a761-e7aabacfdf8f.png">

After first invoice:
<img width="323" alt="Bildschirmfoto 2022-08-01 um 14 19 04" src="https://user-images.githubusercontent.com/533162/182146177-6d90eda7-3682-4f1e-b152-c487bb5dce70.png">

After second invoice:
<img width="339" alt="Bildschirmfoto 2022-08-01 um 14 16 00" src="https://user-images.githubusercontent.com/533162/182145688-7f18ed8d-5361-4df1-ad68-7949d7c14163.png">

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] I verified that my code applies to the guidelines (`composer code-check`)
- [ ] I updated the documentation (see [here](https://github.com/kimai/www.kimai.org/tree/master/_documentation))
- [ ] I agree that this code is used in Kimai and will be published under the [MIT license](https://github.com/kevinpapst/kimai2/blob/master/LICENSE)
