### PR TITLE
fixed multiple budget validation checks

### DIFF
--- a/src/Validator/Constraints/TimesheetBudgetUsedValidator.php
+++ b/src/Validator/Constraints/TimesheetBudgetUsedValidator.php
@@ -102,14 +102,13 @@ final class TimesheetBudgetUsedValidator extends ConstraintValidator
             $projectId = (int) $rawData['project'];
             $customerId = (int) $rawData['customer'];
 
-            // if an existing entry was updated, but "date", "duration", "rate" and "billable" were not changed:
-            // do not validate! this could for example happen when export flag is changed OR if "prevent overbooking"
-            // config was recently activated and this is an old entry
+            // if an existing entry was updated, but the relevant fields for budget calculation were not touched: do not validate!
+            // this could for example happen when export flag is changed OR if "prevent overbooking"  config was recently activated and this is an old entry
             if ($duration === $rawData['duration'] &&
                 $rate === $rawData['rate'] &&
                 $timesheet->isBillable() === $rawData['billable'] &&
                 $timesheet->getBegin()->format('Y.m.d') === $rawData['begin']->format('Y.m.d') &&
-                ($timesheet->getProject() === null || $timesheet->getProject()->getId() === $projectId) &&
+                $timesheet->getProject()->getId() === $projectId &&
                 ($timesheet->getActivity() === null || $timesheet->getActivity()->getId() === $activityId)
             ) {
                 return;

--- a/src/Validator/Constraints/TimesheetBudgetUsedValidator.php
+++ b/src/Validator/Constraints/TimesheetBudgetUsedValidator.php
@@ -74,15 +74,15 @@ final class TimesheetBudgetUsedValidator extends ConstraintValidator
             return;
         }
 
-        $duration = $timesheet->getDuration();
-        if (null === $duration || 0 === $duration) {
-            $duration = $timesheet->getEnd()->getTimestamp() - $timesheet->getBegin()->getTimestamp();
-        }
-
         // this validator needs a project to calculate the rates
         if ($timesheet->getProject() === null) {
             return;
         }
+
+        // when changing the date via the calendar and/or the API, the duration will not be reset by the
+        // duration calculator (which runs after validation!) so we manually reset the duration before
+        $timesheet->setDuration(null);
+        $duration = $timesheet->getDuration();
 
         $timeRate = $this->rateService->calculate($timesheet);
         $rate = $timeRate->getRate();

--- a/src/Validator/Constraints/TimesheetBudgetUsedValidator.php
+++ b/src/Validator/Constraints/TimesheetBudgetUsedValidator.php
@@ -98,17 +98,24 @@ final class TimesheetBudgetUsedValidator extends ConstraintValidator
         if ($timesheet->getId() !== null) {
             $rawData = $this->timesheetRepository->getRawData($timesheet);
 
-            // if an existing entry was updated, but "duration", "rate" and "billable" were not changed:
+            $activityId = (int) $rawData['activity'];
+            $projectId = (int) $rawData['project'];
+            $customerId = (int) $rawData['customer'];
+
+            // if an existing entry was updated, but "date", "duration", "rate" and "billable" were not changed:
             // do not validate! this could for example happen when export flag is changed OR if "prevent overbooking"
             // config was recently activated and this is an old entry
-            if ($duration === $rawData['duration'] && $rate === $rawData['rate'] && $timesheet->isBillable() === $rawData['billable'] && $timesheet->getBegin()->format('Y.m.d') === $rawData['begin']->format('Y.m.d')) {
+            if ($duration === $rawData['duration'] &&
+                $rate === $rawData['rate'] &&
+                $timesheet->isBillable() === $rawData['billable'] &&
+                $timesheet->getBegin()->format('Y.m.d') === $rawData['begin']->format('Y.m.d') &&
+                ($timesheet->getProject() === null || $timesheet->getProject()->getId() === $projectId) &&
+                ($timesheet->getActivity() === null || $timesheet->getActivity()->getId() === $activityId)
+            ) {
                 return;
             }
 
             // the duration of an existing entry could be increased or lowered
-            $activityId = (int) $rawData['activity'];
-            $projectId = (int) $rawData['project'];
-            $customerId = (int) $rawData['customer'];
 
             // only subtract the previously logged data in case the record was billable
             // if it wasn't billable, then its values are not included in the statistic models used later on

--- a/tests/Validator/Constraints/TimesheetBudgetUsedValidatorTest.php
+++ b/tests/Validator/Constraints/TimesheetBudgetUsedValidatorTest.php
@@ -411,6 +411,7 @@ class TimesheetBudgetUsedValidatorTest extends ConstraintValidatorTestCase
             $timesheet->method('getRate')->willReturn($rawData['rate']);
             $timesheet->method('getBegin')->willReturn($begin);
             $timesheet->method('getEnd')->willReturn($end);
+            $timesheet->method('getDuration')->willReturn($end->getTimestamp() - $begin->getTimestamp());
             $timesheet->method('getUser')->willReturn(new User());
             $timesheet->method('getProject')->willReturn($project);
             $timesheet->method('getActivity')->willReturn($activity);


### PR DESCRIPTION
## Description

- fix budget check for records with an updated date (changed month) and monthly budgets
- fix budget check for records with changed begin/end date updated via API (mostly calendar entries that were extended via the "drag handler")
- fix budget check for records with an updated project/activity into one with used budget

fixes #3487

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] I verified that my code applies to the guidelines (`composer code-check`)
- [x] I agree that this code is used in Kimai and will be published under the [MIT license](https://github.com/kevinpapst/kimai2/blob/master/LICENSE)
