### PR TITLE
Fixes #3495: Quick entry during grace period

### DIFF
--- a/src/Timesheet/LockdownService.php
+++ b/src/Timesheet/LockdownService.php
@@ -86,9 +86,9 @@ final class LockdownService
         }
 
         // further validate entries inside of the most recent lockdown
-        if ($timesheetStart > $lockdownStart && $timesheetStart < $lockdownEnd) {
+        if ($timesheetStart >= $lockdownStart && $timesheetStart <= $lockdownEnd) {
             // if grace period is still in effect, validation succeeds
-            if ($now < $lockdownGrace) {
+            if ($now <= $lockdownGrace) {
                 return true;
             }
 


### PR DESCRIPTION
During the grace period, new time entries could not be added on the
first day of the lockdown period. This was due to an edge case where the
start time of the timesheet exactly matched the start time of the
lockdown period, and we checked for "greater than" instead of "greater
than or equal to".


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] I verified that my code applies to the guidelines (`composer code-check`)
- [x] I updated the documentation (see [here](https://github.com/kimai/www.kimai.org/tree/master/_documentation))
- [x] I agree that this code is used in Kimai and will be published under the [MIT license](https://github.com/kevinpapst/kimai2/blob/master/LICENSE)
