### PR TITLE
Support custom fonts in PDF via twig templates

### DIFF
--- a/config/packages/twig.yaml
+++ b/config/packages/twig.yaml
@@ -8,5 +8,3 @@ twig:
         # used in templates/emails/layout.html.twig
         '%kernel.project_dir%/assets/css': css
         '%kernel.project_dir%/vendor/kevinpapst/adminlte-bundle/Resources/views': theme
-    globals:
-        projectDirectory: '%kernel.project_dir%'

--- a/config/packages/twig.yaml
+++ b/config/packages/twig.yaml
@@ -8,3 +8,5 @@ twig:
         # used in templates/emails/layout.html.twig
         '%kernel.project_dir%/assets/css': css
         '%kernel.project_dir%/vendor/kevinpapst/adminlte-bundle/Resources/views': theme
+    globals:
+        projectDirectory: '%kernel.project_dir%'

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -57,7 +57,8 @@ services:
             $settings: '%kimai.config%'
 
     App\Utils\MPdfConverter:
-        arguments: ['%kernel.cache_dir%']
+        arguments:
+            $cacheDirectory: '%kernel.cache_dir%'
 
     App\Plugin\PluginManager:
         arguments: [!tagged kimai.plugin]

--- a/src/Export/ExportContext.php
+++ b/src/Export/ExportContext.php
@@ -9,6 +9,9 @@
 
 namespace App\Export;
 
+use Mpdf\Config\ConfigVariables;
+use Mpdf\Config\FontVariables;
+
 /**
  * A simple class that is available in twig renderer context, which can be used to define global renderer options.
  */
@@ -16,7 +19,17 @@ final class ExportContext
 {
     private $options = [];
 
-    public function setOption(string $key, string $value): void
+    public function __construct()
+    {
+        $this->initDefaults();
+    }
+
+    /**
+     * @param string $key
+     * @param string|array $value
+     * @return void
+     */
+    public function setOption(string $key, $value): void
     {
         $this->options[$key] = $value;
     }
@@ -26,12 +39,28 @@ final class ExportContext
         return $this->options;
     }
 
-    public function getOption(string $key): ?string
+    /**
+     * @param string $key
+     * @return array|string|null
+     */
+    public function getOption(string $key)
     {
         if (\array_key_exists($key, $this->options)) {
             return $this->options[$key];
         }
 
         return null;
+    }
+
+    /**
+     * @return void
+     */
+    private function initDefaults(): void
+    {
+        $defaultConfig = (new ConfigVariables())->getDefaults();
+        $defaultFontConfig = (new FontVariables())->getDefaults();
+
+        $this->setOption('fontDir', $defaultConfig['fontDir']);
+        $this->setOption('fontdata', $defaultFontConfig['fontdata']);
     }
 }

--- a/src/Export/ExportContext.php
+++ b/src/Export/ExportContext.php
@@ -9,20 +9,15 @@
 
 namespace App\Export;
 
-use Mpdf\Config\ConfigVariables;
-use Mpdf\Config\FontVariables;
-
 /**
  * A simple class that is available in twig renderer context, which can be used to define global renderer options.
  */
 final class ExportContext
 {
+    /**
+     * @var array
+     */
     private $options = [];
-
-    public function __construct()
-    {
-        $this->initDefaults();
-    }
 
     /**
      * @param string $key
@@ -34,6 +29,9 @@ final class ExportContext
         $this->options[$key] = $value;
     }
 
+    /**
+     * @return array
+     */
     public function getOptions(): array
     {
         return $this->options;
@@ -50,17 +48,5 @@ final class ExportContext
         }
 
         return null;
-    }
-
-    /**
-     * @return void
-     */
-    private function initDefaults(): void
-    {
-        $defaultConfig = (new ConfigVariables())->getDefaults();
-        $defaultFontConfig = (new FontVariables())->getDefaults();
-
-        $this->setOption('fontDir', $defaultConfig['fontDir']);
-        $this->setOption('fontdata', $defaultFontConfig['fontdata']);
     }
 }

--- a/src/Utils/MPdfConverter.php
+++ b/src/Utils/MPdfConverter.php
@@ -18,12 +18,18 @@ use Mpdf\Output\Destination;
 class MPdfConverter implements HtmlToPdfConverter
 {
     /**
+     * @var FileHelper
+     */
+    private $fileHelper;
+
+    /**
      * @var string
      */
     private $cacheDirectory;
 
-    public function __construct(string $cacheDirectory)
+    public function __construct(FileHelper $fileHelper, string $cacheDirectory)
     {
+        $this->fileHelper = $fileHelper;
         $this->cacheDirectory = $cacheDirectory;
     }
 
@@ -33,7 +39,7 @@ class MPdfConverter implements HtmlToPdfConverter
         $fonts = new FontVariables();
         $allowed = [
             'mode', 'format', 'default_font_size', 'default_font', 'margin_left', 'margin_right', 'margin_top',
-            'margin_bottom', 'margin_header', 'margin_footer', 'orientation'
+            'margin_bottom', 'margin_header', 'margin_footer', 'orientation', 'fonts',
         ];
 
         $filtered = array_filter($options, function ($key) use ($allowed, $configs, $fonts) {
@@ -66,8 +72,7 @@ class MPdfConverter implements HtmlToPdfConverter
             ['tempDir' => $this->cacheDirectory, 'exposeVersion' => false]
         );
 
-        $mpdf = new Mpdf($options);
-        $mpdf->creator = Constants::SOFTWARE;
+        $mpdf = $this->initMpdf($options);
 
         // some OS do not follow the PHP default settings
         if ((int) ini_get('pcre.backtrack_limit') < 1000000) {
@@ -96,5 +101,52 @@ class MPdfConverter implements HtmlToPdfConverter
         }
 
         return $mpdf->Output('', Destination::STRING_RETURN);
+    }
+
+    /**
+     * @param array $options
+     * @return Mpdf
+     * @throws \Mpdf\MpdfException
+     * @throws \Exception
+     */
+    private function initMpdf(array $options): Mpdf
+    {
+        $options['fontDir'] = $this->getFontDirectories();
+        $options['fontdata'] = $this->mergeFontData($options);
+
+        $mpdf = new Mpdf($options);
+        $mpdf->creator = Constants::SOFTWARE;
+
+        return $mpdf;
+    }
+
+    /**
+     * @return array
+     * @throws \Exception
+     */
+    private function getFontDirectories(): array
+    {
+        $defaultConfig = (new ConfigVariables())->getDefaults();
+        $fontDirectories = $defaultConfig['fontDir'];
+        $fontDirectories[] = $this->fileHelper->getDataDirectory('fonts');
+
+        return $fontDirectories;
+    }
+
+    /**
+     * @param array $options
+     * @return array
+     */
+    private function mergeFontData(array $options): array
+    {
+        $defaultFontConfig = (new FontVariables())->getDefaults();
+        $fontData = $defaultFontConfig['fontdata'];
+
+        if (array_key_exists('fonts', $options)) {
+            $fontData = array_merge($fontData, $options['fonts']);
+            unset($options['fonts']);
+        }
+
+        return $fontData;
     }
 }

--- a/src/Utils/MPdfConverter.php
+++ b/src/Utils/MPdfConverter.php
@@ -142,9 +142,8 @@ class MPdfConverter implements HtmlToPdfConverter
         $defaultFontConfig = (new FontVariables())->getDefaults();
         $fontData = $defaultFontConfig['fontdata'];
 
-        if (array_key_exists('fonts', $options)) {
+        if (\array_key_exists('fonts', $options)) {
             $fontData = array_merge($fontData, $options['fonts']);
-            unset($options['fonts']);
         }
 
         return $fontData;

--- a/tests/Export/Renderer/PdfRendererTest.php
+++ b/tests/Export/Renderer/PdfRendererTest.php
@@ -11,6 +11,7 @@ namespace App\Tests\Export\Renderer;
 
 use App\Export\Renderer\PDFRenderer;
 use App\Project\ProjectStatisticService;
+use App\Tests\Mocks\FileHelperFactory;
 use App\Utils\HtmlToPdfConverter;
 use App\Utils\MPdfConverter;
 use Symfony\Component\HttpFoundation\Request;
@@ -49,7 +50,7 @@ class PdfRendererTest extends AbstractRendererTest
         $twig = $kernel->getContainer()->get('twig');
         $stack = $kernel->getContainer()->get('request_stack');
         $cacheDir = $kernel->getContainer()->getParameter('kernel.cache_dir');
-        $converter = new MPdfConverter($cacheDir);
+        $converter = new MPdfConverter((new FileHelperFactory($this))->create(), $cacheDir);
         $request = new Request();
         $request->setLocale('en');
         $stack->push($request);

--- a/tests/Export/Timesheet/PdfRendererTest.php
+++ b/tests/Export/Timesheet/PdfRendererTest.php
@@ -11,6 +11,7 @@ namespace App\Tests\Export\Timesheet;
 
 use App\Export\Timesheet\PDFRenderer;
 use App\Project\ProjectStatisticService;
+use App\Tests\Mocks\FileHelperFactory;
 use App\Utils\HtmlToPdfConverter;
 use App\Utils\MPdfConverter;
 use Symfony\Component\HttpFoundation\Request;
@@ -42,7 +43,7 @@ class PdfRendererTest extends AbstractRendererTest
         $twig = $kernel->getContainer()->get('twig');
         $stack = $kernel->getContainer()->get('request_stack');
         $cacheDir = $kernel->getContainer()->getParameter('kernel.cache_dir');
-        $converter = new MPdfConverter($cacheDir);
+        $converter = new MPdfConverter((new FileHelperFactory($this))->create(), $cacheDir);
         $request = new Request();
         $request->setLocale('en');
         $stack->push($request);

--- a/tests/Invoice/Renderer/PdfRendererTest.php
+++ b/tests/Invoice/Renderer/PdfRendererTest.php
@@ -10,6 +10,7 @@
 namespace App\Tests\Invoice\Renderer;
 
 use App\Invoice\Renderer\PdfRenderer;
+use App\Tests\Mocks\FileHelperFactory;
 use App\Utils\MPdfConverter;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\HttpFoundation\Request;
@@ -56,7 +57,7 @@ class PdfRendererTest extends KernelTestCase
         $loader = $twig->getLoader();
         $loader->addPath(__DIR__ . '/../templates/', 'invoice');
 
-        $sut = new PdfRenderer($twig, new MPdfConverter($cacheDir));
+        $sut = new PdfRenderer($twig, new MPdfConverter((new FileHelperFactory($this))->create(), $cacheDir));
         $model = $this->getInvoiceModel();
         $document = $this->getInvoiceDocument('default.pdf.twig', true);
 

--- a/tests/Mocks/FileHelperFactory.php
+++ b/tests/Mocks/FileHelperFactory.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Kimai time-tracking app.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Tests\Mocks;
+
+use App\Utils\FileHelper;
+
+class FileHelperFactory extends AbstractMockFactory
+{
+    public function create(): FileHelper
+    {
+        $data = realpath(__DIR__ . '/../../var/data/');
+
+        return new FileHelper($data);
+    }
+}

--- a/tests/Utils/MPdfConverterTest.php
+++ b/tests/Utils/MPdfConverterTest.php
@@ -9,6 +9,7 @@
 
 namespace App\Tests\Utils;
 
+use App\Tests\Mocks\FileHelperFactory;
 use App\Utils\MPdfConverter;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 
@@ -28,7 +29,7 @@ class MPdfConverterTest extends KernelTestCase
         $kernel = self::bootKernel();
         $cacheDir = $kernel->getContainer()->getParameter('kernel.cache_dir');
 
-        $sut = new MPdfConverter($cacheDir);
+        $sut = new MPdfConverter((new FileHelperFactory($this))->create(), $cacheDir);
         $result = $sut->convertToPdf('<h1>Test</h1>');
         // Yeah, thats not a real test, I know ;-)
         $this->assertNotEmpty($result);


### PR DESCRIPTION
## Description
This PR adds a possibility to add custom fonts to pdfs directly via twig template. Based on discussion #3367.
With these small changes it is possible to set custom font directories and new fonts via `pdfContext` object directly in the twig template.
Example code:
```twig
{%- set fontDir = pdfContext.setOption('fontDir', pdfContext.getOption('fontDir')|merge([projectDirectory ~ '/var/pdf-fonts/'])) -%}
{%- set fontData = pdfContext.setOption('fontdata', pdfContext.getOption('fontdata')|merge({
    'exo2': {
        'R': 'Exo2-Regular.ttf',
        'B': 'Exo2-Bold.ttf',
        'I': 'Exo2-Italic.ttf',
        'BI': 'Exo2-BoldItalic.ttf'
    }
})) -%}
```

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] I verified that my code applies to the guidelines (`composer code-check`)
- [ ] I updated the documentation (see [here](https://github.com/kimai/www.kimai.org/tree/master/_documentation))
- [x] I agree that this code is used in Kimai and will be published under the [MIT license](https://github.com/kevinpapst/kimai2/blob/master/LICENSE)
