### PR TITLE
Project API and globalActivities flag

### DIFF
--- a/src/Entity/Project.php
+++ b/src/Entity/Project.php
@@ -257,6 +257,9 @@ class Project implements EntityWithMetaFields, EntityWithBudget
      *
      * @var bool
      *
+     * @Serializer\Expose()
+     * @Serializer\Groups({"Default"})
+     *
      * @ORM\Column(name="global_activities", type="boolean", nullable=false, options={"default": true})
      * @Assert\NotNull()
      */

--- a/src/Form/API/ProjectApiEditForm.php
+++ b/src/Form/API/ProjectApiEditForm.php
@@ -10,6 +10,7 @@
 namespace App\Form\API;
 
 use App\Form\ProjectEditForm;
+use App\Form\Type\APITrueFalseType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -23,6 +24,11 @@ class ProjectApiEditForm extends ProjectEditForm
         parent::buildForm($builder, $options);
 
         $builder->remove('metaFields');
+        $builder->remove('globalActivities');
+        $builder->add('globalActivities', APITrueFalseType::class, [
+            'label' => 'label.globalActivities',
+            'empty_data' => '1',
+        ]);
     }
 
     /**

--- a/src/Form/Type/APITrueFalseType.php
+++ b/src/Form/Type/APITrueFalseType.php
@@ -18,6 +18,7 @@ class APITrueFalseType extends AbstractType
     public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
+            'false_values' => [0, '0', false],
             'required' => false,
         ]);
     }

--- a/src/Form/Type/APITrueFalseType.php
+++ b/src/Form/Type/APITrueFalseType.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the Kimai time-tracking app.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Form\Type;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class APITrueFalseType extends AbstractType
+{
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'required' => false,
+        ]);
+    }
+
+    public function getParent(): string
+    {
+        return CheckboxType::class;
+    }
+}

--- a/tests/API/APIControllerBaseTest.php
+++ b/tests/API/APIControllerBaseTest.php
@@ -433,6 +433,7 @@ abstract class APIControllerBaseTest extends ControllerBaseTest
                     'billable' => 'bool',
                     'color' => '@string',
                     'customer' => 'int',
+                    'globalActivities' => 'bool',
                     'comment' => '@string',
                 ];
 
@@ -445,6 +446,7 @@ abstract class APIControllerBaseTest extends ControllerBaseTest
                     'billable' => 'bool',
                     'color' => '@string',
                     'customer' => ['result' => 'object', 'type' => 'Customer'],
+                    'globalActivities' => 'bool',
                     'comment' => '@string',
                 ];
 
@@ -461,6 +463,7 @@ abstract class APIControllerBaseTest extends ControllerBaseTest
                     'parentTitle' => 'string',
                     'start' => '@datetime',
                     'end' => '@datetime',
+                    'globalActivities' => 'bool',
                     'teams' => ['result' => 'array', 'type' => 'Team'],
                     'comment' => '@string',
                 ];
@@ -478,6 +481,7 @@ abstract class APIControllerBaseTest extends ControllerBaseTest
                     'parentTitle' => 'string',
                     'start' => '@datetime',
                     'end' => '@datetime',
+                    'globalActivities' => 'bool',
                     'teams' => ['result' => 'array', 'type' => 'Team'],
                     'comment' => '@string',
                     'budget' => 'float',

--- a/tests/API/ProjectControllerTest.php
+++ b/tests/API/ProjectControllerTest.php
@@ -298,10 +298,49 @@ class ProjectControllerTest extends APIControllerBaseTest
         $this->assertIsArray($result);
         self::assertApiResponseTypeStructure('ProjectEntity', $result);
         $this->assertNotEmpty($result['id']);
+        self::assertTrue($result['globalActivities']);
         self::assertEquals('2018-02-08T13:02:54+0000', $result['orderDate']);
         self::assertEquals('2019-02-01T19:32:17+0000', $result['start']);
         self::assertEquals('2020-02-08T21:11:42+0000', $result['end']);
         self::assertEquals('1234567890/WXYZ/SUBPROJECT/1234/CONTRACT/EMPLOYEE1', $result['orderNumber']);
+    }
+
+    public function testPostActionWithOtherFields()
+    {
+        $client = $this->getClientForAuthenticatedUser(User::ROLE_ADMIN);
+        $data = [
+            'name' => 'foo',
+            'customer' => 1,
+            'globalActivities' => 0,
+        ];
+        $this->request($client, '/api/projects', 'POST', [], json_encode($data));
+        $this->assertTrue($client->getResponse()->isSuccessful());
+
+        $result = json_decode($client->getResponse()->getContent(), true);
+        $this->assertIsArray($result);
+        self::assertApiResponseTypeStructure('ProjectEntity', $result);
+        $this->assertNotEmpty($result['id']);
+        self::assertEquals('foo', $result['name']);
+        self::assertFalse($result['globalActivities']);
+    }
+
+    public function testPostActionWithOtherFields2()
+    {
+        $client = $this->getClientForAuthenticatedUser(User::ROLE_ADMIN);
+        $data = [
+            'name' => 'foo',
+            'customer' => 1,
+            'globalActivities' => 1,
+        ];
+        $this->request($client, '/api/projects', 'POST', [], json_encode($data));
+        $this->assertTrue($client->getResponse()->isSuccessful());
+
+        $result = json_decode($client->getResponse()->getContent(), true);
+        $this->assertIsArray($result);
+        self::assertApiResponseTypeStructure('ProjectEntity', $result);
+        $this->assertNotEmpty($result['id']);
+        self::assertEquals('foo', $result['name']);
+        self::assertTrue($result['globalActivities']);
     }
 
     public function testPostActionWithLeastFields()

--- a/tests/API/ProjectControllerTest.php
+++ b/tests/API/ProjectControllerTest.php
@@ -311,7 +311,7 @@ class ProjectControllerTest extends APIControllerBaseTest
         $data = [
             'name' => 'foo',
             'customer' => 1,
-            'globalActivities' => 0,
+            'globalActivities' => '0',
         ];
         $this->request($client, '/api/projects', 'POST', [], json_encode($data));
         $this->assertTrue($client->getResponse()->isSuccessful());
@@ -330,7 +330,7 @@ class ProjectControllerTest extends APIControllerBaseTest
         $data = [
             'name' => 'foo',
             'customer' => 1,
-            'globalActivities' => 1,
+            'globalActivities' => '1',
         ];
         $this->request($client, '/api/projects', 'POST', [], json_encode($data));
         $this->assertTrue($client->getResponse()->isSuccessful());


### PR DESCRIPTION
## Description

- expose `globalActivities` setting in project entity
- fix `globalActivities` being true by default if created via API

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist
- [x] I verified that my code applies to the guidelines (`composer code-check`)
- [ ] I updated the documentation (see [here](https://github.com/kimai/www.kimai.org/tree/master/_documentation))
- [x] I agree that this code is used in Kimai and will be published under the [MIT license](https://github.com/kevinpapst/kimai2/blob/master/LICENSE)
