### PR TITLE
do not show potential invoices with a negative total

### DIFF
--- a/src/Invoice/Calculator/AbstractCalculator.php
+++ b/src/Invoice/Calculator/AbstractCalculator.php
@@ -48,7 +48,7 @@ abstract class AbstractCalculator
      */
     public function getSubtotal(): float
     {
-        $amount = 0;
+        $amount = 0.00;
         foreach ($this->model->getEntries() as $entry) {
             $amount += $entry->getRate();
         }

--- a/src/Invoice/ServiceInvoice.php
+++ b/src/Invoice/ServiceInvoice.php
@@ -590,6 +590,10 @@ final class ServiceInvoice
             $model->addEntries($settings['entries']);
             $this->prepareModelQueryDates($model);
 
+            if ($model->getCalculator()->getTotal() < 0.0) {
+                continue;
+            }
+
             $models[] = $model;
         }
 


### PR DESCRIPTION
## Description

There are no negative invoices and so Kimai should not allow to create those.

This allows to handle credits in the future.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] I verified that my code applies to the guidelines (`composer code-check`)
- [ ] I updated the documentation (see [here](https://github.com/kimai/www.kimai.org/tree/master/_documentation))
- [x] I agree that this code is used in Kimai and will be published under the [MIT license](https://github.com/kevinpapst/kimai2/blob/master/LICENSE)
