### PR TITLE
fix one-minute rounding bug in quick-entries and more

### DIFF
--- a/src/Controller/QuickEntryController.php
+++ b/src/Controller/QuickEntryController.php
@@ -118,7 +118,10 @@ class QuickEntryController extends AbstractController
             ];
         }
 
-        $beginTime = $factory->createDateTime($this->configuration->getTimesheetDefaultBeginTime())->format('H:i:s');
+        $defaultBegin = $factory->createDateTime($this->configuration->getTimesheetDefaultBeginTime());
+        $defaultHour = (int) $defaultBegin->format('H');
+        $defaultMinute = (int) $defaultBegin->format('i');
+        $defaultBegin->setTime($defaultHour, $defaultMinute, 0, 0);
 
         // fill all rows and columns to make sure we do not have missing records
         /** @var QuickEntryModel[] $models */
@@ -132,7 +135,7 @@ class QuickEntryController extends AbstractController
                     $tmp->setProject($row['project']);
                     $tmp->setActivity($row['activity']);
                     $tmp->setBegin(clone $day['day']);
-                    $tmp->getBegin()->modify($beginTime);
+                    $tmp->getBegin()->setTime($defaultHour, $defaultMinute, 0, 0);
                     $model->addTimesheet($tmp);
                 } else {
                     $model->addTimesheet($day['entry']);
@@ -147,7 +150,7 @@ class QuickEntryController extends AbstractController
             $tmp = new Timesheet();
             $tmp->setUser($user);
             $tmp->setBegin(clone $day['day']);
-            $tmp->getBegin()->modify($beginTime);
+            $tmp->getBegin()->setTime($defaultHour, $defaultMinute, 0, 0);
             $empty->addTimesheet($tmp);
         }
 
@@ -161,7 +164,7 @@ class QuickEntryController extends AbstractController
                     $tmp = new Timesheet();
                     $tmp->setUser($user);
                     $tmp->setBegin(clone $day['day']);
-                    $tmp->getBegin()->modify($beginTime);
+                    $tmp->getBegin()->setTime($defaultHour, $defaultMinute, 0, 0);
                     $model->addTimesheet($tmp);
                 }
 

--- a/src/Controller/QuickEntryController.php
+++ b/src/Controller/QuickEntryController.php
@@ -207,26 +207,26 @@ class QuickEntryController extends AbstractController
                 }
             }
 
-            if ($this->isGranted('delete_own_timesheet') && \count($deleteTimesheets) > 0) {
-                try {
+            try {
+                $saved = false;
+                if (\count($deleteTimesheets) > 0 && $this->isGranted('delete_own_timesheet')) {
                     $this->timesheetService->deleteMultipleTimesheets($deleteTimesheets);
-
-                    return $this->redirectToRoute('quick_entry', ['begin' => $begin->format('Y-m-d')]);
-                } catch (\Exception $ex) {
-                    $this->flashError('action.delete.error');
-                    $this->logException($ex);
+                    $saved = true;
                 }
-            }
 
-            if (\count($saveTimesheets) > 0) {
-                try {
+                if (\count($saveTimesheets) > 0) {
                     $this->timesheetService->updateMultipleTimesheets($saveTimesheets);
+                    $saved = true;
+                }
+
+                if ($saved) {
+                    $this->flashSuccess('action.update.success');
 
                     return $this->redirectToRoute('quick_entry', ['begin' => $begin->format('Y-m-d')]);
-                } catch (\Exception $ex) {
-                    $this->flashError('action.update.error');
-                    $this->logException($ex);
                 }
+            } catch (\Exception $ex) {
+                $this->flashError('action.update.error');
+                $this->logException($ex);
             }
         }
 

--- a/src/Form/Type/QuickEntryTimesheetType.php
+++ b/src/Form/Type/QuickEntryTimesheetType.php
@@ -81,7 +81,7 @@ class QuickEntryTimesheetType extends AbstractType
                 try {
                     if (null !== $duration) {
                         $end = clone $data->getBegin();
-                        $end->modify('+ ' . $duration . ' seconds');
+                        $end->modify('+ ' . abs($duration) . ' seconds');
                         $data->setEnd($end);
                     } else {
                         $data->setDuration(null);


### PR DESCRIPTION
## Description

- fix one-minute rounding bug for quick entries form
- prevent issues with negative durations (always convert to positive value)
- allow to delete and create/update timesheets in one go (previously no entries were saved if one was deleted)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist
- [x] I verified that my code applies to the guidelines (`composer code-check`)
- [x] I agree that this code is used in Kimai and will be published under the [MIT license](https://github.com/kevinpapst/kimai2/blob/master/LICENSE)
