### PR TITLE
Naive implementation of non-accesskey hotkeys

### DIFF
--- a/assets/js/KimaiLoader.js
+++ b/assets/js/KimaiLoader.js
@@ -40,6 +40,7 @@ import KimaiTeamForm from "./forms/KimaiTeamForm";
 import KimaiCopyDataForm from "./forms/KimaiCopyDataForm";
 import KimaiDateNowForm from "./forms/KimaiDateNowForm";
 import KimaiNotification from "./plugins/KimaiNotification";
+import KimaiHotkeys from "./plugins/KimaiHotkeys";
 
 export default class KimaiLoader {
 
@@ -71,6 +72,7 @@ export default class KimaiLoader {
         kimai.registerPlugin(new KimaiCopyDataForm());
         kimai.registerPlugin(new KimaiDateNowForm());
         kimai.registerPlugin(new KimaiForm());
+        kimai.registerPlugin(new KimaiHotkeys());
 
         // SPECIAL FEATURES
         kimai.registerPlugin(new KimaiConfirmationLink('confirmation-link'));

--- a/assets/js/plugins/KimaiHotkeys.js
+++ b/assets/js/plugins/KimaiHotkeys.js
@@ -1,0 +1,41 @@
+import KimaiPlugin from "../KimaiPlugin";
+
+export default class KimaiHotkeys extends KimaiPlugin {
+    getId() {
+        return 'hotkeys';
+    }
+
+    init() {
+        // https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent
+        // https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key
+
+        const selector = `[data-hotkey="ctrl+Enter"]`
+        const matches = ev => ev.ctrlKey && ev.key === 'Enter'
+
+        window.addEventListener('keyup', (ev) => {
+            if (matches(ev)) {
+                const elements = [...document.querySelectorAll(selector)].filter(element => isVisible(element))
+
+                if (elements.length > 1) {
+                    console.warn(`KimaiHotkeys: More than one visible element matches ${selector}. No action triggered.`)
+                }
+
+                if (elements.length === 1) {
+                    ev.stopPropagation();
+                    ev.preventDefault();
+
+                    elements[0].click();
+                }
+            }
+        })
+    }
+}
+
+// adopted from Bootstrap 5.1.1, MIT
+function isVisible (element) {
+    if (!element || element.getClientRects().length === 0) {
+        return false;
+    }
+
+    return getComputedStyle(element).getPropertyValue('visibility') === 'visible';
+}

--- a/templates/default/_form_modal.html.twig
+++ b/templates/default/_form_modal.html.twig
@@ -25,7 +25,7 @@
             <div class="modal-footer">
                 {% block modal_footer %}
                     {% block submit_button %}
-                        <button type="submit" class="btn btn-primary pull-left modal-form-save" data-loading-text="{{ (submit_button|default('action.save'))|trans }}…" id="{{ block('modal_id') }}_save">{{ (submit_button|default('action.save'))|trans }}</button>
+                        <button type="submit" class="btn btn-primary pull-left modal-form-save" data-loading-text="{{ (submit_button|default('action.save'))|trans }}…" id="{{ block('modal_id') }}_save" data-hotkey="ctrl+Enter">{{ (submit_button|default('action.save'))|trans }}</button>
                     {% endblock %}
                     <button type="button" class="btn btn-cancel" data-bs-dismiss="modal">{{ 'action.close'|trans }}</button>
                 {% endblock %}


### PR DESCRIPTION
Submit form modals on ctrl+enter.
Keyup events are checked against preset criteria. If criteria are met and exactly one visible element matches the provided selector a click event is fired on that element.

https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent
https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key

close #3572