### PR TITLE
fix several rendering issues in markdown

### DIFF
--- a/src/Twig/Runtime/MarkdownExtension.php
+++ b/src/Twig/Runtime/MarkdownExtension.php
@@ -63,7 +63,7 @@ final class MarkdownExtension implements RuntimeExtensionInterface
         if ($this->isMarkdownEnabled()) {
             $content = $this->markdown->toHtml($content);
         } elseif ($fullLength) {
-            $content = '<p>' . nl2br($content) . '</p>';
+            $content = '<p>' . nl2br(htmlspecialchars($content)) . '</p>';
         }
 
         return $content;
@@ -115,7 +115,7 @@ final class MarkdownExtension implements RuntimeExtensionInterface
             return $this->markdown->toHtml($content);
         }
 
-        return nl2br($content);
+        return nl2br(htmlspecialchars($content));
     }
 
     /**

--- a/src/Twig/RuntimeExtensions.php
+++ b/src/Twig/RuntimeExtensions.php
@@ -45,8 +45,8 @@ class RuntimeExtensions extends AbstractExtension
     {
         return [
             new TwigFilter('md2html', [MarkdownExtension::class, 'markdownToHtml'], ['pre_escape' => 'html', 'is_safe' => ['html']]),
-            new TwigFilter('desc2html', [MarkdownExtension::class, 'timesheetContent'], ['pre_escape' => 'html', 'is_safe' => ['html']]),
-            new TwigFilter('comment2html', [MarkdownExtension::class, 'commentContent'], ['pre_escape' => 'html', 'is_safe' => ['html']]),
+            new TwigFilter('desc2html', [MarkdownExtension::class, 'timesheetContent'], ['is_safe' => ['html']]),
+            new TwigFilter('comment2html', [MarkdownExtension::class, 'commentContent'], ['is_safe' => ['html']]),
             new TwigFilter('comment1line', [MarkdownExtension::class, 'commentOneLiner'], ['pre_escape' => 'html', 'is_safe' => ['html']]),
             new TwigFilter('colorize', [ThemeExtension::class, 'colorize']),
         ];

--- a/src/Utils/ParsedownExtension.php
+++ b/src/Utils/ParsedownExtension.php
@@ -18,7 +18,7 @@ class ParsedownExtension extends \Parsedown
 
     /**
      * Overwritten to prevent # to show up as headings for two reasons:
-     * - Hashes are often used to cross link issues in other systems
+     * - Hashes are often used to cross-link issues in other systems
      * - Headings should not occur in time record listings
      */
     protected $BlockTypes = [
@@ -145,5 +145,18 @@ class ParsedownExtension extends \Parsedown
         $this->ids[$text] = '';
 
         return $text;
+    }
+
+    protected function blockTable($Line, array $Block = null)
+    {
+        $Block = parent::blockTable($Line, $Block);
+
+        if (\is_null($Block)) {
+            return;
+        }
+
+        $Block['element']['attributes']['class'] = 'table';
+
+        return $Block;
     }
 }

--- a/tests/Twig/RuntimeExtensionsTest.php
+++ b/tests/Twig/RuntimeExtensionsTest.php
@@ -80,12 +80,10 @@ class RuntimeExtensionsTest extends TestCase
                     $found_md2html = true;
                     break;
                 case 'desc2html':
-                    self::assertEquals('html', $filters[1]->getPreEscape());
                     self::assertEquals(['html'], $filters[1]->getSafe(new Node()));
                     $found_desc2html = true;
                     break;
                 case 'comment2html':
-                    self::assertEquals('html', $filters[2]->getPreEscape());
                     self::assertEquals(['html'], $filters[2]->getSafe(new Node()));
                     $found_comment2html = true;
                     break;


### PR DESCRIPTION
- fix double escaping of html entities: `&quot;` instead of "
- fix table is missing css class "table"
- fix quotes are not rendered

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] I verified that my code applies to the guidelines (`composer code-check`)
- [ ] I updated the documentation (see [here](https://github.com/kimai/www.kimai.org/tree/master/_documentation))
- [x] I agree that this code is used in Kimai and will be published under the [MIT license](https://github.com/kevinpapst/kimai2/blob/master/LICENSE)
