### PR TITLE
added permission check on project rates

### DIFF
--- a/src/Voter/EntityMultiRoleVoter.php
+++ b/src/Voter/EntityMultiRoleVoter.php
@@ -20,7 +20,7 @@ use Symfony\Component\Security\Core\Authorization\Voter\Voter;
 final class EntityMultiRoleVoter extends Voter
 {
     /**
-     * support rules based on the given activity
+     * support rules based on the given activity/project/customer
      */
     private const ALLOWED_ATTRIBUTES = [
         'budget_money',

--- a/templates/reporting/project_daterange.html.twig
+++ b/templates/reporting/project_daterange.html.twig
@@ -5,6 +5,7 @@
 
 {% set showMoneyBudget = is_granted('budget_money', 'project') %}
 {% set showTimeBudget = is_granted('budget_time', 'project') %}
+{% set viewRevenue = is_granted('view_rate_other_timesheet') %}
 
 {% set columns = {
     'name':          {'class': 'alwaysVisible'},
@@ -21,7 +22,13 @@
 {% endif %}
 {% set columns = columns|merge({
     'duration':      {'class': 'text-center hw-min', 'title': 'stats.durationMonth'|trans, 'columnClass': 'w-min'},
-    'rate':          {'class': 'text-center hw-min', 'title': 'stats.amountMonth'|trans, 'columnClass': 'w-min'},
+}) %}
+{% if viewRevenue %}
+    {% set columns = columns|merge({
+        'rate':          {'class': 'text-center hw-min', 'title': 'stats.amountMonth'|trans, 'columnClass': 'w-min'},
+    }) %}
+{% endif %}
+{% set columns = columns|merge({
     'billable':      {'class': 'text-center hw-min', 'columnClass': 'w-min'},
     'actions':       {'class': 'actions alwaysVisible'},
 }) %}


### PR DESCRIPTION
## Description

fixing visibility on the project earned rates, visible to everyone previously.
afterwards only visible to users with `view_rate_other_timesheet` permission, as in other reports as well.

see https://github.com/kevinpapst/kimai2/discussions/3609 opened by @stevenrenaud

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] I verified that my code applies to the guidelines (`composer code-check`)
- [x] I agree that this code is used in Kimai and will be published under the [MIT license](https://github.com/kevinpapst/kimai2/blob/master/LICENSE)
