### PR TITLE
added project + customer setting for calendar entry titles

### DIFF
--- a/src/Form/Type/CalendarTitlePatternType.php
+++ b/src/Form/Type/CalendarTitlePatternType.php
@@ -27,6 +27,7 @@ class CalendarTitlePatternType extends AbstractType
     public const PATTERN_ACTIVITY_DESCRIPTION = self::PATTERN_ACTIVITY . self::SPACER . self::PATTERN_DESCRIPTION;
     public const PATTERN_PROJECT_DESCRIPTION = self::PATTERN_PROJECT . self::SPACER . self::PATTERN_DESCRIPTION;
     public const PATTERN_CUSTOMER_DESCRIPTION = self::PATTERN_CUSTOMER . self::SPACER . self::PATTERN_DESCRIPTION;
+    public const PATTERN_PROJECT_CUSTOMER = self::PATTERN_PROJECT . self::SPACER . self::PATTERN_CUSTOMER;
 
     private $translator;
 
@@ -52,6 +53,7 @@ class CalendarTitlePatternType extends AbstractType
                 $activity . self::SPACER . $description => CalendarTitlePatternType::PATTERN_ACTIVITY_DESCRIPTION,
                 $project . self::SPACER . $description => CalendarTitlePatternType::PATTERN_PROJECT_DESCRIPTION,
                 $customer . self::SPACER . $description => CalendarTitlePatternType::PATTERN_CUSTOMER_DESCRIPTION,
+                $project . self::SPACER . $customer => CalendarTitlePatternType::PATTERN_PROJECT_CUSTOMER,
             ]
         ]);
     }

--- a/templates/calendar/user.html.twig
+++ b/templates/calendar/user.html.twig
@@ -148,6 +148,8 @@
                 title = apiItem.project.name + description;
             {% elseif config.entryTitlePattern == constant('\\App\\Form\\Type\\CalendarTitlePatternType::PATTERN_CUSTOMER_DESCRIPTION') %}
                 title = apiItem.project.customer.name + description;
+            {% elseif config.entryTitlePattern == constant('\\App\\Form\\Type\\CalendarTitlePatternType::PATTERN_PROJECT_CUSTOMER') %}
+                title = apiItem.project.name + apiItem.project.customer.name;
             {% endif %}
 
             if (title === '' || title === null) {


### PR DESCRIPTION
## Description

Allowing "project name" + "customer name" as title for calendar entries

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] I verified that my code applies to the guidelines (`composer code-check`)
- [ ] I updated the documentation (see [here](https://github.com/kimai/www.kimai.org/tree/master/_documentation))
- [x] I agree that this code is used in Kimai and will be published under the [MIT license](https://github.com/kevinpapst/kimai2/blob/master/LICENSE)
