### PR TITLE
fix project end-start dates in quick-entry form

### DIFF
--- a/src/Form/QuickEntryForm.php
+++ b/src/Form/QuickEntryForm.php
@@ -63,13 +63,6 @@ class QuickEntryForm extends AbstractType
             }
         ));
 
-        $startDate = new \DateTime();
-        if ($builder->getData() !== null) {
-            /** @var QuickEntryWeek $data */
-            $data = $builder->getData();
-            $startDate = $data->getDate();
-        }
-
         $builder->add('date', WeekPickerType::class, [
             'model_timezone' => $options['timezone'],
             'view_timezone' => $options['timezone'],
@@ -83,7 +76,8 @@ class QuickEntryForm extends AbstractType
             'entry_options' => [
                 'label' => false,
                 'duration_minutes' => $this->configuration->getTimesheetIncrementDuration(),
-                'start_date' => $startDate,
+                'start_date' => $options['start_date'],
+                'end_date' => $options['end_date'],
                 'empty_data' => function (FormInterface $form) use ($options) {
                     return clone $options['prototype_data'];
                 },
@@ -103,13 +97,21 @@ class QuickEntryForm extends AbstractType
      */
     public function configureOptions(OptionsResolver $resolver)
     {
+        $start = new \DateTime();
+        $start->setTime(0, 0, 0);
+
+        $end = clone $start;
+        $end->add(new \DateInterval('P1W'));
+        $end->setTime(23, 59, 59);
+
         $resolver->setDefaults([
             'csrf_protection' => true,
             'csrf_field_name' => '_token',
             'csrf_token_id' => 'timesheet_quick_edit',
             'data_class' => QuickEntryWeek::class,
             'timezone' => date_default_timezone_get(),
-            'start_date' => new \DateTime(),
+            'start_date' => $start,
+            'end_date' => $end,
             'prototype_data' => null,
         ]);
     }

--- a/src/Form/Type/QuickEntryWeekType.php
+++ b/src/Form/Type/QuickEntryWeekType.php
@@ -24,10 +24,7 @@ use Symfony\Component\Validator\Constraints\Valid;
 
 class QuickEntryWeekType extends AbstractType
 {
-    /**
-     * {@inheritdoc}
-     */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $projectOptions = [
             'label' => false,
@@ -35,7 +32,9 @@ class QuickEntryWeekType extends AbstractType
             'join_customer' => true,
             'query_builder_for_user' => true,
             'placeholder' => '',
-            'activity_enabled' => true
+            'activity_enabled' => true,
+            'project_date_start' => $options['start_date'],
+            'project_date_end' => $options['end_date'],
         ];
 
         $builder->add('project', ProjectType::class, $projectOptions);
@@ -47,13 +46,6 @@ class QuickEntryWeekType extends AbstractType
                 return;
             }
 
-            $begin = clone $data->getFirstEntry()->getBegin();
-            $begin->setTime(0, 0, 0);
-            $projectOptions['project_date_start'] = $begin;
-
-            $end = clone $data->getLatestEntry()->getBegin();
-            $end->setTime(23, 59, 59);
-            $projectOptions['project_date_end'] = $begin;
             $projectOptions['projects'] = [$data->getProject()];
 
             $event->getForm()->add('project', ProjectType::class, $projectOptions);
@@ -177,10 +169,7 @@ class QuickEntryWeekType extends AbstractType
         );
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'data_class' => QuickEntryModel::class,
@@ -188,6 +177,7 @@ class QuickEntryWeekType extends AbstractType
             'duration_minutes' => null,
             'duration_hours' => 10,
             'start_date' => new DateTime(),
+            'end_date' => new DateTime(),
             'prototype_data' => null,
         ]);
     }

--- a/src/Model/QuickEntryModel.php
+++ b/src/Model/QuickEntryModel.php
@@ -42,14 +42,6 @@ class QuickEntryModel
 
     public function isPrototype(): bool
     {
-        if ($this->hasExistingTimesheet()) {
-            return false;
-        }
-
-        if ($this->hasNewTimesheet()) {
-            return false;
-        }
-
         return $this->prototype;
     }
 

--- a/src/Model/QuickEntryModel.php
+++ b/src/Model/QuickEntryModel.php
@@ -22,6 +22,7 @@ class QuickEntryModel
     private $user;
     private $project;
     private $activity;
+    private $prototype = false;
     /**
      * @var Timesheet[]
      */
@@ -34,6 +35,11 @@ class QuickEntryModel
         $this->activity = $activity;
     }
 
+    public function markAsPrototype(): void
+    {
+        $this->prototype = true;
+    }
+
     public function isPrototype(): bool
     {
         if ($this->hasExistingTimesheet()) {
@@ -44,7 +50,7 @@ class QuickEntryModel
             return false;
         }
 
-        return $this->getUser() === null && $this->getProject() === null && $this->getActivity() === null;
+        return $this->prototype;
     }
 
     public function getUser(): ?User

--- a/tests/Model/QuickEntryModelTest.php
+++ b/tests/Model/QuickEntryModelTest.php
@@ -24,7 +24,7 @@ class QuickEntryModelTest extends TestCase
     public function testEmptyModel()
     {
         $sut = new QuickEntryModel();
-        self::assertTrue($sut->isPrototype());
+        self::assertFalse($sut->isPrototype());
         self::assertNull($sut->getProject());
         self::assertNull($sut->getActivity());
         self::assertNull($sut->getUser());
@@ -105,7 +105,6 @@ class QuickEntryModelTest extends TestCase
     {
         $sut = new QuickEntryModel();
 
-        self::assertTrue($sut->isPrototype());
         self::assertFalse($sut->hasExistingTimesheet());
         $mock = $this->createMock(Timesheet::class);
         $mock->method('getId')->willReturn(1);
@@ -125,5 +124,19 @@ class QuickEntryModelTest extends TestCase
         self::assertSame($project, $sut->getProject());
         self::assertSame($activity, $sut->getActivity());
         self::assertSame($user, $sut->getUser());
+    }
+
+    public function testPrototype()
+    {
+        $sut = new QuickEntryModel();
+        $sut->markAsPrototype();
+        self::assertTrue($sut->isPrototype());
+
+        $sut = new QuickEntryModel();
+        $sut->markAsPrototype();
+        $mock = $this->createMock(Timesheet::class);
+        $mock->method('getId')->willReturn(1);
+        $sut->addTimesheet($mock);
+        self::assertTrue($sut->isPrototype());
     }
 }

--- a/tests/Model/QuickEntryWeekTest.php
+++ b/tests/Model/QuickEntryWeekTest.php
@@ -21,9 +21,8 @@ class QuickEntryWeekTest extends TestCase
     public function testModel()
     {
         $date = new \DateTime();
-        $rows = [];
 
-        $sut = new QuickEntryWeek($date, $rows);
+        $sut = new QuickEntryWeek($date);
         self::assertSame($date, $sut->getDate());
         self::assertEquals([], $sut->getRows());
 


### PR DESCRIPTION
## Description

- improve sort by project name
- improve prototype detection
- fix project start and end date was ignored

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] I verified that my code applies to the guidelines (`composer code-check`)
- [ ] I updated the documentation (see [here](https://github.com/kimai/www.kimai.org/tree/master/_documentation))
- [x] I agree that this code is used in Kimai and will be published under the [MIT license](https://github.com/kevinpapst/kimai2/blob/master/LICENSE)
