### PR TITLE
Add accessibility attributes to sortable table headers.

### DIFF
--- a/templates/macros/datatables.html.twig
+++ b/templates/macros/datatables.html.twig
@@ -74,7 +74,11 @@
                             {% if title != 'actions' and not headerOptions.orderBy is same as(false) %}
                                 {% if orderBy == headerOptions.orderBy %}
                                     {% set headerClass = headerClass ~ ' sortable sorting_' ~ (order) %}
-                                    {% set ariaSort = order ~ 'ending' %}
+                                    {% if order == 'asc' %}
+                                        {% set ariaSort = 'ascending' %}
+                                    {% else %}
+                                        {% set ariaSort = 'descending' %}
+                                    {% endif %}
                                 {% else %}
                                     {% set headerClass = headerClass ~ ' sortable sorting' %}
                                 {% endif %}

--- a/templates/macros/datatables.html.twig
+++ b/templates/macros/datatables.html.twig
@@ -89,7 +89,7 @@
                             {% elseif title is not empty and title != 'actions' %}
                                 {% set headerTitle = (translationPrefix ~ title)|trans({}, translationDomain) %}
                             {% endif %}
-                            <th data-field="{{ title }}" {% if not headerOptions.orderBy is same as(false) %}data-order="{{ headerOptions.orderBy }}" role="button" {% endif %}{% if ariaSort %}aria-sort="{{ ariaSort }}" {% endif %}class="{{ headerClass }}">
+                            <th data-field="{{ title }}" {% if not headerOptions.orderBy is same as(false) %}data-order="{{ headerOptions.orderBy }}" role="button" {% endif %}{% if ariaSort is defined %}aria-sort="{{ ariaSort }}" {% endif %}class="{{ headerClass }}">
                                 {% if headerOptions.html_before is defined %}
                                     {{ headerOptions.html_before|raw }}
                                 {% endif %}

--- a/templates/macros/datatables.html.twig
+++ b/templates/macros/datatables.html.twig
@@ -74,6 +74,7 @@
                             {% if title != 'actions' and not headerOptions.orderBy is same as(false) %}
                                 {% if orderBy == headerOptions.orderBy %}
                                     {% set headerClass = headerClass ~ ' sortable sorting_' ~ (order) %}
+                                    {% set ariaSort = order ~ 'ending' %}
                                 {% else %}
                                     {% set headerClass = headerClass ~ ' sortable sorting' %}
                                 {% endif %}
@@ -84,7 +85,7 @@
                             {% elseif title is not empty and title != 'actions' %}
                                 {% set headerTitle = (translationPrefix ~ title)|trans({}, translationDomain) %}
                             {% endif %}
-                            <th data-field="{{ title }}" {% if not headerOptions.orderBy is same as(false) %}data-order="{{ headerOptions.orderBy }}" {% endif %}class="{{ headerClass }}">
+                            <th data-field="{{ title }}" {% if not headerOptions.orderBy is same as(false) %}data-order="{{ headerOptions.orderBy }}" role="button" {% endif %}{% if ariaSort %}aria-sort="{{ ariaSort }}" {% endif %}class="{{ headerClass }}">
                                 {% if headerOptions.html_before is defined %}
                                     {{ headerOptions.html_before|raw }}
                                 {% endif %}


### PR DESCRIPTION
Fixes #3646

## Description
Implements the necessary `ARIA` and `role` accessibility attributes to make it possible to read and control table sorting with accessibility software.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] I verified that my code applies to the guidelines (`composer code-check`)
- [ ] I updated the documentation (see [here](https://github.com/kimai/www.kimai.org/tree/master/_documentation))
- [x] I agree that this code is used in Kimai and will be published under the [MIT license](https://github.com/kevinpapst/kimai2/blob/master/LICENSE)
