### PR TITLE
Release 1.30 - last release before 2.0

### DIFF
--- a/config/packages/prod/monolog.yaml
+++ b/config/packages/prod/monolog.yaml
@@ -4,9 +4,7 @@ monolog:
             type: fingers_crossed
             action_level: error
             handler: nested
-            excluded_404s:
-                # regex: exclude all 404 errors from the logs
-                - ^/
+            excluded_http_codes: [403, 404]
         nested:
             type: stream
             level: info

--- a/src/Command/KimaiImporterCommand.php
+++ b/src/Command/KimaiImporterCommand.php
@@ -942,7 +942,7 @@ final class KimaiImporterCommand extends Command
                 $user->addPreference($newPref);
             }
 
-            // set default values if they were not set in the the user preferences
+            // set default values if they were not set in the user preferences
             $defaults = ['language' => $language, 'timezone' => $timezone];
             foreach ($defaults as $key => $default) {
                 if (null === $user->getPreferenceValue($key)) {

--- a/src/Constants.php
+++ b/src/Constants.php
@@ -17,11 +17,11 @@ class Constants
     /**
      * The current release version
      */
-    public const VERSION = '1.29.1';
+    public const VERSION = '1.30.0';
     /**
      * The current release: major * 10000 + minor * 100 + patch
      */
-    public const VERSION_ID = 12901;
+    public const VERSION_ID = 13000;
     /**
      * The current release status, either "stable" or "dev"
      */

--- a/src/Controller/HomepageController.php
+++ b/src/Controller/HomepageController.php
@@ -32,7 +32,7 @@ class HomepageController extends AbstractController
     {
         /** @var User $user */
         $user = $this->getUser();
-        $userRoute = $user->getPreferenceValue('login.initial_view', InitialViewType::DEFAULT_VIEW);
+        $userRoute = $user->getPreferenceValue('login.initial_view', InitialViewType::DEFAULT_VIEW, false);
         $userLanguage = $user->getLanguage();
         $requestLanguage = $request->getLocale();
 

--- a/src/Controller/ProfileController.php
+++ b/src/Controller/ProfileController.php
@@ -262,7 +262,7 @@ final class ProfileController extends AbstractController
                 // switch locale ONLY if updated profile is the current user
                 $locale = $request->getLocale();
                 if ($this->getUser()->getId() === $profile->getId()) {
-                    $locale = $profile->getPreferenceValue('language', $locale);
+                    $locale = $profile->getPreferenceValue('language', $locale, false);
                 }
 
                 return $this->redirectToRoute('user_profile_preferences', [

--- a/src/Controller/ReportingController.php
+++ b/src/Controller/ReportingController.php
@@ -32,7 +32,7 @@ final class ReportingController extends AbstractController
         $user = $this->getUser();
         $route = null;
 
-        $defaultReport = $user->getPreferenceValue('reporting.initial_view', ReportingService::DEFAULT_VIEW);
+        $defaultReport = $user->getPreferenceValue('reporting.initial_view', ReportingService::DEFAULT_VIEW, false);
         $allReports = $reportingService->getAvailableReports($user);
 
         foreach ($allReports as $report) {
@@ -43,7 +43,7 @@ final class ReportingController extends AbstractController
         }
 
         // fallback, if the configured report could not be found
-        // eg. when it was deleted or replaced by an enhanced version with a new id
+        // e.g. when it was deleted or replaced by an enhanced version with a new id
         if ($route === null && \count($allReports) > 0) {
             $report = $allReports[array_keys($allReports)[0]];
             $route = $report->getRoute();

--- a/src/Controller/TimesheetAbstractController.php
+++ b/src/Controller/TimesheetAbstractController.php
@@ -535,7 +535,7 @@ abstract class TimesheetAbstractController extends AbstractController
 
     protected function includeSummary(): bool
     {
-        return (bool) $this->getUser()->getPreferenceValue('timesheet.daily_stats', false);
+        return (bool) $this->getUser()->getPreferenceValue('timesheet.daily_stats', false, false);
     }
 
     protected function includeUserInForms(string $formName): bool

--- a/src/Controller/TimesheetTeamController.php
+++ b/src/Controller/TimesheetTeamController.php
@@ -116,7 +116,7 @@ class TimesheetTeamController extends TimesheetAbstractController
                 $tags = [];
                 /** @var Tag $tag */
                 foreach ($entry->getTags() as $tag) {
-                    $tag->removeTimesheet($entry);
+                    $entry->addTag($tag);
                     $tags[] = $tag;
                 }
 

--- a/src/DataFixtures/TimesheetFixtures.php
+++ b/src/DataFixtures/TimesheetFixtures.php
@@ -210,7 +210,7 @@ class TimesheetFixtures extends Fixture implements FixtureGroupInterface
     {
         $start = $this->getRandomFirstDay();
         $start = $start->modify('- ' . (rand(1, 86400)) . ' seconds');
-        $start->setTimezone(new \DateTimeZone($user->getPreferenceValue(UserPreference::TIMEZONE, date_default_timezone_get())));
+        $start->setTimezone(new \DateTimeZone($user->getTimezone()));
 
         $entry = new Timesheet();
         $entry

--- a/src/Entity/Timesheet.php
+++ b/src/Entity/Timesheet.php
@@ -545,7 +545,6 @@ class Timesheet implements EntityWithMetaFields, ExportItemInterface
             return $this;
         }
         $this->tags->add($tag);
-        $tag->addTimesheet($this);
 
         return $this;
     }
@@ -559,7 +558,6 @@ class Timesheet implements EntityWithMetaFields, ExportItemInterface
             return;
         }
         $this->tags->removeElement($tag);
-        $tag->removeTimesheet($this);
     }
 
     /**

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -481,17 +481,17 @@ class User implements UserInterface, EquatableInterface, \Serializable
 
     public function is24Hour(): bool
     {
-        return (bool) $this->getPreferenceValue(UserPreference::HOUR_24, true);
+        return (bool) $this->getPreferenceValue(UserPreference::HOUR_24, true, false);
     }
 
     public function getLocale(): string
     {
-        return $this->getPreferenceValue(UserPreference::LOCALE, User::DEFAULT_LANGUAGE);
+        return $this->getPreferenceValue(UserPreference::LOCALE, User::DEFAULT_LANGUAGE, false);
     }
 
     public function getTimezone(): string
     {
-        return $this->getPreferenceValue(UserPreference::TIMEZONE, date_default_timezone_get());
+        return $this->getPreferenceValue(UserPreference::TIMEZONE, date_default_timezone_get(), false);
     }
 
     public function getLanguage(): string
@@ -514,17 +514,17 @@ class User implements UserInterface, EquatableInterface, \Serializable
 
     public function getFirstDayOfWeek(): string
     {
-        return $this->getPreferenceValue(UserPreference::FIRST_WEEKDAY, User::DEFAULT_FIRST_WEEKDAY);
+        return $this->getPreferenceValue(UserPreference::FIRST_WEEKDAY, User::DEFAULT_FIRST_WEEKDAY, false);
     }
 
     public function isSmallLayout(): bool
     {
-        return $this->getPreferenceValue('theme.layout', 'fixed') === 'boxed';
+        return $this->getPreferenceValue('theme.layout', 'fixed', false) === 'boxed';
     }
 
     public function isExportDecimal(): bool
     {
-        return (bool) $this->getPreferenceValue('timesheet.export_decimal', false);
+        return (bool) $this->getPreferenceValue('timesheet.export_decimal', false, false);
     }
 
     public function setTimezone(?string $timezone)
@@ -538,16 +538,19 @@ class User implements UserInterface, EquatableInterface, \Serializable
     /**
      * @param string $name
      * @param mixed $default
+     * @param bool $allowNull
      * @return bool|int|string|null
      */
-    public function getPreferenceValue(string $name, $default = null)
+    public function getPreferenceValue(string $name, $default = null, bool $allowNull = true)
     {
         $preference = $this->getPreference($name);
         if (null === $preference) {
             return $default;
         }
 
-        return $preference->getValue();
+        $value = $preference->getValue();
+
+        return $allowNull ? $value : ($value ?? $default);
     }
 
     /**

--- a/src/Timesheet/RateService.php
+++ b/src/Timesheet/RateService.php
@@ -65,7 +65,7 @@ final class RateService implements RateServiceInterface
 
         if (null !== $fixedRate) {
             if (null === $fixedInternalRate) {
-                $fixedInternalRate = (float) $record->getUser()->getPreferenceValue(UserPreference::INTERNAL_RATE, $fixedRate);
+                $fixedInternalRate = (float) $record->getUser()->getPreferenceValue(UserPreference::INTERNAL_RATE, $fixedRate, false);
             }
 
             return new Rate($fixedRate, $fixedInternalRate, null, $fixedRate);
@@ -73,16 +73,11 @@ final class RateService implements RateServiceInterface
 
         // user preferences => fallback if nothing else was configured
         if (null === $hourlyRate) {
-            $hourlyRate = (float) $record->getUser()->getPreferenceValue(UserPreference::HOURLY_RATE, 0.00);
+            $hourlyRate = (float) $record->getUser()->getPreferenceValue(UserPreference::HOURLY_RATE, 0.00, false);
         }
 
         if (null === $internalRate) {
-            $internalRate = $record->getUser()->getPreferenceValue(UserPreference::INTERNAL_RATE, 0.00);
-            if (null === $internalRate) {
-                $internalRate = $hourlyRate;
-            } else {
-                $internalRate = (float) $internalRate;
-            }
+            $internalRate = (float) $record->getUser()->getPreferenceValue(UserPreference::INTERNAL_RATE, $hourlyRate, false);
         }
 
         $factor = 1.00;

--- a/tests/API/TimesheetControllerTest.php
+++ b/tests/API/TimesheetControllerTest.php
@@ -312,7 +312,6 @@ class TimesheetControllerTest extends APIControllerBaseTest
         $timesheet = new Timesheet();
         $timesheet
             ->setHourlyRate(137.21)
-            ->setInternalRate(64.96)
             ->setBegin($startDate)
             ->setEnd($endDate)
             ->setExported(true)
@@ -348,11 +347,11 @@ class TimesheetControllerTest extends APIControllerBaseTest
             'metaFields' => [],
             'hourlyRate' => 137.21,
             'rate' => 1772.2958,
-            'internalRate' => 0.0,
+            'internalRate' => 1772.2958,
         ];
 
         foreach ($expected as $key => $value) {
-            self::assertEquals($value, $result[$key]);
+            self::assertEquals($value, $result[$key], sprintf('Field %s has invalid value', $key));
         }
     }
 

--- a/tests/Entity/TagTest.php
+++ b/tests/Entity/TagTest.php
@@ -10,7 +10,6 @@
 namespace App\Tests\Entity;
 
 use App\Entity\Tag;
-use App\Entity\Timesheet;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -39,21 +38,5 @@ class TagTest extends TestCase
 
         $sut->setColor('#fffccc');
         $this->assertEquals('#fffccc', $sut->getColor());
-    }
-
-    public function testWithTimesheet()
-    {
-        $sut = new Tag();
-        $timesheet = new Timesheet();
-
-        $this->assertEmpty($timesheet->getTags());
-
-        $sut->setName('bar');
-        $sut->addTimesheet($timesheet);
-
-        $this->assertSame($sut, $timesheet->getTags()[0]);
-
-        $sut->removeTimesheet($timesheet);
-        $this->assertEmpty($timesheet->getTags());
     }
 }


### PR DESCRIPTION
## Description

The release 1.30 is very likely the last one in the 1.x series. Targeted for end of the year.

After this one a feature freeze will take place: fully concentrating on bringing #2902 to life in Q1 2023.

### Changes

- exclude all 403 and 404 from logs
- prevent mandatory user preferences turning null
- cleanup bi-directional tag handling between timesheets and tags, causing issues for new tags

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] I verified that my code applies to the guidelines (`composer code-check`)
- [ ] I updated the documentation (see [here](https://github.com/kimai/www.kimai.org/tree/master/_documentation))
- [x] I agree that this code is used in Kimai and will be published under the [MIT license](https://github.com/kevinpapst/kimai2/blob/master/LICENSE)
