### PR TITLE
Users API: fix non-admins can't search for all users

### DIFF
--- a/src/API/UserController.php
+++ b/src/API/UserController.php
@@ -95,7 +95,6 @@ final class UserController extends BaseApiController
     public function cgetAction(ParamFetcherInterface $paramFetcher): Response
     {
         $query = new UserQuery();
-        $query->setCurrentUser($this->getUser());
 
         if (null !== ($visible = $paramFetcher->get('visible'))) {
             $query->setVisibility($visible);


### PR DESCRIPTION
## Description
I noticed that if a non-admin user with permission `view_users` calls the API path `/api/users`, it will only return an array with one object: the user themselves.
Deleting fixes it as far as I can see.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] I verified that my code applies to the guidelines (`composer code-check`)
- [ ] I updated the documentation (see [here](https://github.com/kimai/www.kimai.org/tree/master/_documentation))
- [x] I agree that this code is used in Kimai and will be published under the [MIT license](https://github.com/kevinpapst/kimai2/blob/master/LICENSE)
