### PR TITLE
do not traverse into invoice template subdirectories

### DIFF
--- a/src/Repository/InvoiceDocumentRepository.php
+++ b/src/Repository/InvoiceDocumentRepository.php
@@ -161,7 +161,7 @@ final class InvoiceDocumentRepository
                 continue;
             }
 
-            $finder = Finder::create()->ignoreDotFiles(true)->files()->in($searchDir)->name('*.*');
+            $finder = Finder::create()->ignoreDotFiles(true)->files()->in($searchDir)->depth(0)->name('*.*');
             foreach ($finder->getIterator() as $file) {
                 $doc = new InvoiceDocument($file);
                 // the first found invoice document wins


### PR DESCRIPTION
## Description

do not traverse into invoice template subdirectories

Fixes https://github.com/kimai/invoice-templates/issues/5

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] I verified that my code applies to the guidelines (`composer code-check`)
- [ ] I updated the documentation (see [here](https://github.com/kimai/www.kimai.org/tree/master/_documentation))
- [x] I agree that this code is used in Kimai (see [license](https://github.com/kimai/kimai/blob/main/LICENSE))
