### PR TITLE
Release 1.30.3

### DIFF
--- a/src/Constants.php
+++ b/src/Constants.php
@@ -17,11 +17,11 @@ class Constants
     /**
      * The current release version
      */
-    public const VERSION = '1.30.2';
+    public const VERSION = '1.30.3';
     /**
      * The current release: major * 10000 + minor * 100 + patch
      */
-    public const VERSION_ID = 13002;
+    public const VERSION_ID = 13003;
     /**
      * The current release status, either "stable" or "dev"
      */

--- a/src/Controller/TimesheetAbstractController.php
+++ b/src/Controller/TimesheetAbstractController.php
@@ -148,14 +148,13 @@ abstract class TimesheetAbstractController extends AbstractController
 
     protected function create(Request $request, string $renderTemplate): Response
     {
-        $entry = $this->service->createNewTimesheet($this->getUser());
+        $entry = $this->service->createNewTimesheet($this->getUser(), $request);
 
         $preForm = $this->createFormForGetRequest(TimesheetPreCreateForm::class, $entry, [
             'include_user' => $this->includeUserInForms('create'),
         ]);
         $preForm->submit($request->query->all(), false);
 
-        $this->service->prepareNewTimesheet($entry, $request);
         $createForm = $this->getCreateForm($entry);
         $createForm->handleRequest($request);
 

--- a/src/Form/TimesheetPreCreateForm.php
+++ b/src/Form/TimesheetPreCreateForm.php
@@ -10,6 +10,7 @@
 namespace App\Form;
 
 use App\Form\Type\DescriptionType;
+use App\Form\Type\MetaFieldsCollectionType;
 use App\Form\Type\TagsInputType;
 use App\Form\Type\UserType;
 use Symfony\Component\Form\AbstractType;
@@ -29,6 +30,7 @@ class TimesheetPreCreateForm extends AbstractType
         $this->addActivity($builder, null, null, ['required' => false]);
         $builder->add('description', DescriptionType::class, ['required' => false]);
         $builder->add('tags', TagsInputType::class, ['required' => false]);
+        $builder->add('metaFields', MetaFieldsCollectionType::class);
         if ($options['include_user']) {
             $builder->add('user', UserType::class, ['required' => false]);
         }

--- a/templates/calendar/user.html.twig
+++ b/templates/calendar/user.html.twig
@@ -149,7 +149,7 @@
             {% elseif config.entryTitlePattern == constant('\\App\\Form\\Type\\CalendarTitlePatternType::PATTERN_CUSTOMER_DESCRIPTION') %}
                 title = apiItem.project.customer.name + description;
             {% elseif config.entryTitlePattern == constant('\\App\\Form\\Type\\CalendarTitlePatternType::PATTERN_PROJECT_CUSTOMER') %}
-                title = apiItem.project.name + apiItem.project.customer.name;
+                title = apiItem.project.name + '{{ constant('\\App\\Form\\Type\\CalendarTitlePatternType::SPACER') }}' + apiItem.project.customer.name;
             {% endif %}
 
             if (title === '' || title === null) {


### PR DESCRIPTION
## Description

- fix calendar title for project - customer
- allow to pre-fill timesheet metafields via URL `&metaFields[foo][value]=234`

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] I verified that my code applies to the guidelines (`composer code-check`)
- [ ] I updated the documentation (see [here](https://github.com/kimai/www.kimai.org/tree/master/_documentation))
- [x] I agree that this code is used in Kimai (see [license](https://github.com/kimai/kimai/blob/main/LICENSE))
