### PR TITLE
1.30.10 - fix invoice number handling for null fields

### DIFF
--- a/src/Constants.php
+++ b/src/Constants.php
@@ -17,11 +17,11 @@ class Constants
     /**
      * The current release version
      */
-    public const VERSION = '1.30.9';
+    public const VERSION = '1.30.10';
     /**
      * The current release: major * 10000 + minor * 100 + patch
      */
-    public const VERSION_ID = 13009;
+    public const VERSION_ID = 13010;
     /**
      * The current release status, either "stable" or "dev"
      */

--- a/src/Invoice/NumberGenerator/ConfigurableNumberGenerator.php
+++ b/src/Invoice/NumberGenerator/ConfigurableNumberGenerator.php
@@ -217,11 +217,17 @@ final class ConfigurableNumberGenerator implements NumberGeneratorInterface
                 break;
 
             case 'cname':
-                $partialResult = $this->model->getCustomer() !== null ? $this->model->getCustomer()->getName() : '';
+                $partialResult = $this->model->getCustomer() !== null ? $this->model->getCustomer()->getName() : null;
+                if ($partialResult === null) {
+                    throw new \InvalidArgumentException('Customer has no name, replacer {cname} failed evaluation.');
+                }
                 break;
 
             case 'cnumber':
-                $partialResult = $this->model->getCustomer() !== null ? $this->model->getCustomer()->getNumber() : '';
+                $partialResult = $this->model->getCustomer() !== null ? $this->model->getCustomer()->getNumber() : null;
+                if ($partialResult === null) {
+                    throw new \InvalidArgumentException('Customer has no number, replacer {cnumber} failed evaluation.');
+                }
                 break;
 
             default:

--- a/tests/Invoice/NumberGenerator/ConfigurableNumberGeneratorTest.php
+++ b/tests/Invoice/NumberGenerator/ConfigurableNumberGeneratorTest.php
@@ -166,6 +166,38 @@ class ConfigurableNumberGeneratorTest extends TestCase
         $this->assertEquals('default', $sut->getId());
     }
 
+    public function getMissingFieldTestData()
+    {
+        return [
+            ['{Y}/{cnumber}_{ccy,3}', 'Customer has no number, replacer {cnumber} failed evaluation.'],
+            ['{Y}/{cname}_{ccy,3}', 'Customer has no name, replacer {cname} failed evaluation.'],
+        ];
+    }
+
+    /**
+     * @dataProvider getMissingFieldTestData
+     */
+    public function testCustomerHasMissingField(string $format, string $message)
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage($message);
+
+        $user = $this->createMock(User::class);
+        $user->method('getId')->willReturn(13);
+        $user->method('getAccountNumber')->willReturn('0815');
+
+        $customer = new Customer();
+
+        $sut = $this->getSut($format);
+        $model = (new InvoiceModelFactoryFactory($this))->create()->createModel(new DebugFormatter());
+        $model->setInvoiceDate(new \DateTime());
+        $model->setCustomer($customer);
+        $model->setUser($user);
+        $sut->setModel($model);
+
+        $sut->getInvoiceNumber();
+    }
+
     public function getInvalidTestData()
     {
         $invoiceDate = new \DateTime();


### PR DESCRIPTION
## Description

Adds a clear error message, if invoice number configuration contains `{cnumber}` or `{cname}` and these fields are null.

Fixes #3861 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] I verified that my code applies to the guidelines (`composer code-check`)
- [x] I agree that this code is used in Kimai (see [license](https://github.com/kimai/kimai/blob/main/LICENSE))
