### PR TITLE
Improve inline stats

### DIFF
--- a/src/Repository/Result/TimesheetResult.php
+++ b/src/Repository/Result/TimesheetResult.php
@@ -35,16 +35,22 @@ final class TimesheetResult
     public function getStatistic(): TimesheetResultStatistic
     {
         if ($this->statisticCache === null) {
+            $withDuration = $this->query->countFilter() > 0;
             $qb = clone $this->queryBuilder;
             $qb
                 ->resetDQLPart('select')
                 ->resetDQLPart('orderBy')
                 ->select('COUNT(t.id) as counter')
-                ->addSelect('COALESCE(SUM(t.duration), 0) as duration');
+            ;
+
+            if ($withDuration) {
+                $qb->addSelect('COALESCE(SUM(t.duration), 0) as duration');
+            }
 
             $result = $qb->getQuery()->getArrayResult()[0];
+            $duration = $withDuration ? $result['duration'] : 0;
 
-            $this->statisticCache = new TimesheetResultStatistic($result['counter'], $result['duration']);
+            $this->statisticCache = new TimesheetResultStatistic($result['counter'], $duration);
         }
 
         return $this->statisticCache;

--- a/templates/export/index.html.twig
+++ b/templates/export/index.html.twig
@@ -41,7 +41,9 @@
 
 {% block status %}
     {% from "macros/status.html.twig" import status_duration, status_money %}
-    {{ status_duration(totalDuration|duration) }}
+    {% if totalDuration > 0 %}
+        {{ status_duration(totalDuration|duration) }}
+    {% endif %}
     {% for totalCurrency, totalRate in totalRates %}
         {{ status_money(totalRate|money(totalCurrency)) }}
     {% endfor %}

--- a/templates/invoice/index.html.twig
+++ b/templates/invoice/index.html.twig
@@ -36,7 +36,9 @@
 
 {% block status %}
     {% from "macros/status.html.twig" import status_duration, status_money %}
-    {{ status_duration(totalDuration|duration) }}
+    {% if totalDuration > 0 %}
+        {{ status_duration(totalDuration|duration) }}
+    {% endif %}
     {% for totalCurrency, totalRate in totalRates %}
         {{ status_money(totalRate|money(totalCurrency)) }}
     {% endfor %}

--- a/templates/timesheet/index.html.twig
+++ b/templates/timesheet/index.html.twig
@@ -59,8 +59,10 @@
 {% endblock %}
 
 {% block status %}
-    {% from "macros/status.html.twig" import status_duration %}
-    {{ status_duration(stats.duration|duration) }}
+    {% if stats.duration > 0 %}
+        {% from "macros/status.html.twig" import status_duration %}
+        {{ status_duration(stats.duration|duration) }}
+    {% endif %}
 {% endblock %}
 
 {% block datatable_row_attr %}


### PR DESCRIPTION
## Description

- deactivate timesheet stats if no filter was chosen (otherwise a full table scan would be triggered for each listing display)
- hide duration stats are hidden if duration = 0 on invoice / export / timesheet listing

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] I verified that my code applies to the guidelines (`composer code-check`)
- [x] I agree that this code is used in Kimai (see [license](https://github.com/kimai/kimai/blob/main/LICENSE))
