### PR TITLE
Natural sorting of language dropdown display values

### DIFF
--- a/src/Form/Type/LanguageType.php
+++ b/src/Form/Type/LanguageType.php
@@ -29,11 +29,13 @@ final class LanguageType extends AbstractType
         $choices = [];
         foreach ($this->localeService->getAllLocales() as $key) {
             $name = ucfirst(Locales::getName($key, $key));
-            $choices[$name] = $key;
+            $choices[$key] = $name;
         }
 
+        natcasesort($choices);
+
         $resolver->setDefaults([
-            'choices' => $choices,
+            'choices' => array_flip($choices),
             'label' => 'language',
             'choice_translation_domain' => false,
         ]);

--- a/tests/Form/Type/LanguageTypeTest.php
+++ b/tests/Form/Type/LanguageTypeTest.php
@@ -1,0 +1,72 @@
+<?php
+
+/*
+ * This file is part of the Kimai time-tracking app.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Tests\Form\Type;
+
+use App\Configuration\LocaleService;
+use App\Form\Type\LanguageType;
+use Symfony\Component\Form\FormExtensionInterface;
+use Symfony\Component\Form\PreloadedExtension;
+use Symfony\Component\Form\Test\TypeTestCase;
+
+class LanguageTypeTest extends TypeTestCase
+{
+    public function testNaturalSortOfLanguageDisplayNames(): void
+    {
+        $form = $this->factory->create(LanguageType::class);
+
+        $options = $form->getConfig()->getOptions();
+
+        $this->assertArrayHasKey('choices', $options);
+        $this->assertIsArray($options['choices']);
+
+        $choices = array_values($options['choices']);
+
+        $this->assertEquals(
+            expected: ['de', 'de_CH', 'de_AT', 'en'],
+            actual: $choices,
+            message: 'Natural order of language names is not correct'
+        );
+    }
+
+    /**
+     * @return iterable<FormExtensionInterface>
+     */
+    protected function getExtensions(): iterable
+    {
+        $languageSettings = [
+            'de' => [
+                'date' => 'dd.MM.yy',
+                'time' => 'HH:mm',
+                'rtl' => false,
+            ],
+            'de_AT' => [
+                'date' => 'dd.MM.yy',
+                'time' => 'HH:mm',
+                'rtl' => false,
+            ],
+            'de_CH' => [
+                'date' => 'dd.MM.yy',
+                'time' => 'HH:mm',
+                'rtl' => false,
+            ],
+            'en' => [
+                'date' => 'M/d/yy',
+                'time' => 'h:mm a',
+                'rtl' => false,
+            ]
+        ];
+
+        return array_merge(parent::getExtensions(), [
+            new PreloadedExtension([
+                new LanguageType(new LocaleService($languageSettings))
+            ], [])
+        ]);
+    }
+}


### PR DESCRIPTION
## Description
As mentioned in #3767 displayed names of the languages in the LanguageType dropdown are not sorted naturally.

This has some considerations that I skipped, also detailing about the reasoning:

- Differences in sorting due to the active locale, like DIN 5007-1 (o,ö are equal and should come before p), DIN 5007-1 variant 2, EN 13710 can not be considered, as PHP lacks an implementation for this. Currently natsort (or an UTF-8 codepoint approach) lacks the distinction between `Deutsch (Schweiz)` and `Deutsch (Österreich)` and sort it wrong (Österreich being behind Schweiz).
- Testing is fiddly with the `LocaleService` depending on both configuration and `\Locale` so I had to mock a specfic structure in the test.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] I verified that my code applies to the guidelines (`composer code-check`)
- [ ] I updated the documentation (see [here](https://github.com/kimai/www.kimai.org/tree/master/_documentation))
- [x] I agree that this code is used in Kimai (see [license](https://github.com/kimai/kimai/blob/main/LICENSE))