### PR TITLE
show available github release only if newer version exists

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1067,11 +1067,6 @@ parameters:
             path: src/Controller/DoctorController.php
 
         -
-            message: "#^Method App\\\\Controller\\\\DoctorController\\:\\:getNextUpdateVersion\\(\\) return type has no value type specified in iterable type array\\.$#"
-            count: 1
-            path: src/Controller/DoctorController.php
-
-        -
             message: "#^Method App\\\\Controller\\\\DoctorController\\:\\:getPhpInfo\\(\\) return type has no value type specified in iterable type array\\.$#"
             count: 1
             path: src/Controller/DoctorController.php
@@ -6523,11 +6518,6 @@ parameters:
 
         -
             message: "#^Cannot access property \\$zipball_url on mixed\\.$#"
-            count: 1
-            path: src/Utils/ReleaseVersion.php
-
-        -
-            message: "#^Method App\\\\Utils\\\\ReleaseVersion\\:\\:getLatestReleaseFromGithub\\(\\) return type has no value type specified in iterable type array\\.$#"
             count: 1
             path: src/Utils/ReleaseVersion.php
 

--- a/src/Controller/DoctorController.php
+++ b/src/Controller/DoctorController.php
@@ -9,6 +9,7 @@
 
 namespace App\Controller;
 
+use App\Constants;
 use App\Utils\FileHelper;
 use App\Utils\PageSetup;
 use App\Utils\ReleaseVersion;
@@ -87,6 +88,13 @@ final class DoctorController extends AbstractController
         $page = new PageSetup('Doctor');
         $page->setHelp('doctor.html');
 
+        $latestRelease = $this->getNextUpdateVersion();
+        if (is_array($latestRelease) && array_key_exists('version', $latestRelease)) {
+            if (version_compare(Constants::VERSION, $latestRelease['version']) >= 0) {
+                $latestRelease = null;
+            }
+        }
+
         return $this->render('doctor/index.html.twig', [
             'page_setup' => $page,
             'modules' => get_loaded_extensions(),
@@ -100,7 +108,7 @@ final class DoctorController extends AbstractController
             'logLines' => $logLines,
             'logSize' => $this->getLogSize(),
             'composer' => $this->getComposerPackages(),
-            'release' => $this->getNextUpdateVersion()
+            'release' => $latestRelease
         ]);
     }
 

--- a/src/Controller/DoctorController.php
+++ b/src/Controller/DoctorController.php
@@ -89,7 +89,7 @@ final class DoctorController extends AbstractController
         $page->setHelp('doctor.html');
 
         $latestRelease = $this->getNextUpdateVersion();
-        if (is_array($latestRelease) && array_key_exists('version', $latestRelease)) {
+        if (\is_array($latestRelease) && \array_key_exists('version', $latestRelease)) {
             if (version_compare(Constants::VERSION, $latestRelease['version']) >= 0) {
                 $latestRelease = null;
             }

--- a/src/Controller/DoctorController.php
+++ b/src/Controller/DoctorController.php
@@ -90,7 +90,7 @@ final class DoctorController extends AbstractController
 
         $latestRelease = $this->getNextUpdateVersion();
         if (\is_array($latestRelease) && \array_key_exists('version', $latestRelease)) {
-            if (version_compare(Constants::VERSION, $latestRelease['version']) >= 0) {
+            if (version_compare(Constants::VERSION, (string) $latestRelease['version']) >= 0) {
                 $latestRelease = null;
             }
         }
@@ -117,6 +117,7 @@ final class DoctorController extends AbstractController
      */
     private function getComposerPackages(): array
     {
+        /** @var array<string, string> $versions */
         $versions = [];
 
         if (class_exists(InstalledVersions::class)) {
@@ -321,6 +322,9 @@ final class DoctorController extends AbstractController
         return $phpInfo;
     }
 
+    /**
+     * @return array{'version': string, 'date': \DateTimeInterface, 'url': string, 'download': string, 'content': string}|null
+     */
     private function getNextUpdateVersion(): ?array
     {
         return $this->cache->get('kimai.update_release', function (ItemInterface $item) {

--- a/src/Utils/ReleaseVersion.php
+++ b/src/Utils/ReleaseVersion.php
@@ -22,6 +22,8 @@ final class ReleaseVersion
      * Get all releases from GitHub.
      *
      * @throws \Exception
+     * @return array|null
+     * @return array<string, array{'version': string, 'date': \DateTimeInterface, 'url': string, 'download': string, 'content': string}>
      * @return array
      */
     private function getReleasesFromGithub(): array
@@ -93,7 +95,7 @@ final class ReleaseVersion
      * - content (string, release notes)
      *
      * @param bool $compatible
-     * @return array|null
+     * @return array{'version': string, 'date': \DateTimeInterface, 'url': string, 'download': string, 'content': string}|null
      * @throws \Exception
      */
     public function getLatestReleaseFromGithub(bool $compatible): ?array

--- a/templates/doctor/index.html.twig
+++ b/templates/doctor/index.html.twig
@@ -9,7 +9,7 @@
 {% block main %}
 
     {% if release is not null and release is iterable %}
-        {% embed '@theme/embeds/card.html.twig' with release %}
+        {% embed '@theme/embeds/card.html.twig' with {'release': release, boxtype: 'warning'} %}
             {% block box_title %}Kimai {{ release.version }} available (released on {{ release.date|date_short }}){% endblock %}
             {% block box_body %}
                 {{ release.content|md2html }}

--- a/tests/Controller/DoctorControllerTest.php
+++ b/tests/Controller/DoctorControllerTest.php
@@ -32,7 +32,7 @@ class DoctorControllerTest extends ControllerBaseTest
         $this->assertAccessIsGranted($client, '/doctor');
 
         $result = $client->getCrawler()->filter('.content .card-header');
-        $counter = count($result);
+        $counter = \count($result);
         // this can contain a warning box, that a new release is available
         self::assertTrue($counter === 6 || $counter === 5);
     }

--- a/tests/Controller/DoctorControllerTest.php
+++ b/tests/Controller/DoctorControllerTest.php
@@ -32,7 +32,9 @@ class DoctorControllerTest extends ControllerBaseTest
         $this->assertAccessIsGranted($client, '/doctor');
 
         $result = $client->getCrawler()->filter('.content .card-header');
-        self::assertCount(5, $result);
+        $counter = count($result);
+        // this can contain a warning box, that a new release is available
+        self::assertTrue($counter === 6 || $counter === 5);
     }
 
     public function testFlushLogWithInvalidCsrf()


### PR DESCRIPTION
## Description

- doctor: show available github release only if newer version exists

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] I verified that my code applies to the guidelines (`composer code-check`)
- [ ] I updated the documentation (see [here](https://github.com/kimai/www.kimai.org/tree/master/_documentation))
- [x] I agree that this code is used in Kimai (see [license](https://github.com/kimai/kimai/blob/main/LICENSE))
