### PR TITLE
allow to remove date from non-required field

### DIFF
--- a/templates/form/blocks.html.twig
+++ b/templates/form/blocks.html.twig
@@ -127,6 +127,13 @@
             <a href="#" data-form-widget="date-now" data-format="{{ jsFormat }}" data-target="{{ id }}">{{ icon('calendar') }}</a>
         </div>
         {{- block('form_widget_simple') -}}
+        {% if not required %}
+        <span class="input-group-text">
+            <a href="#" class="link-secondary fs-5" onclick="document.getElementById('{{ id }}').value = ''">
+                {{ icon('cancel') }}
+            </a>
+        </span>
+        {% endif %}
     </div>
 {%- endblock date_widget %}
 


### PR DESCRIPTION
## Description

Form "date" fields, which have an optional date attached, could not be emptied.
The Litepicker always added the date from the previous value back into the field upon closing it.
There was no way to empty the field by keyboard or mouse.
Now you can click the small X icon at the end of the field

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] I verified that my code applies to the guidelines (`composer code-check`)
- [ ] I updated the documentation (see [here](https://github.com/kimai/www.kimai.org/tree/master/_documentation))
- [x] I agree that this code is used in Kimai (see [license](https://github.com/kimai/kimai/blob/main/LICENSE))
