### PR TITLE
[TASK] Use one letter as minimum for name

### DIFF
--- a/src/Entity/Activity.php
+++ b/src/Entity/Activity.php
@@ -54,7 +54,7 @@ class Activity implements EntityWithMetaFields, EntityWithBudget
      */
     #[ORM\Column(name: 'name', type: 'string', length: 150, nullable: false)]
     #[Assert\NotBlank]
-    #[Assert\Length(min: 3, max: 150)]
+    #[Assert\Length(min: 1, max: 150)]
     #[Serializer\Expose]
     #[Serializer\Groups(['Default'])]
     #[Exporter\Expose(label: 'name')]

--- a/src/Entity/Customer.php
+++ b/src/Entity/Customer.php
@@ -41,7 +41,7 @@ class Customer implements EntityWithMetaFields, EntityWithBudget
     private ?int $id = null;
     #[ORM\Column(name: 'name', type: 'string', length: 150, nullable: false)]
     #[Assert\NotBlank]
-    #[Assert\Length(min: 3, max: 150)]
+    #[Assert\Length(min: 1, max: 150)]
     #[Serializer\Expose]
     #[Serializer\Groups(['Default'])]
     #[Exporter\Expose(label: 'name')]

--- a/src/Entity/Project.php
+++ b/src/Entity/Project.php
@@ -59,7 +59,7 @@ class Project implements EntityWithMetaFields, EntityWithBudget
      */
     #[ORM\Column(name: 'name', type: 'string', length: 150, nullable: false)]
     #[Assert\NotNull]
-    #[Assert\Length(min: 3, max: 150)]
+    #[Assert\Length(min: 1, max: 150)]
     #[Serializer\Expose]
     #[Serializer\Groups(['Default'])]
     #[Exporter\Expose(label: 'name')]

--- a/src/Entity/Team.php
+++ b/src/Entity/Team.php
@@ -38,7 +38,7 @@ class Team
      */
     #[ORM\Column(name: 'name', type: 'string', length: 100, nullable: false)]
     #[Assert\NotBlank]
-    #[Assert\Length(min: 2, max: 100)]
+    #[Assert\Length(min: 1, max: 100)]
     #[Serializer\Expose]
     #[Serializer\Groups(['Default'])]
     private ?string $name = null;

--- a/tests/API/TeamControllerTest.php
+++ b/tests/API/TeamControllerTest.php
@@ -206,7 +206,7 @@ class TeamControllerTest extends APIControllerBaseTest
         $result = json_decode($client->getResponse()->getContent(), true);
 
         $data = [
-            'name' => '1',
+            'name' => '',
             'members' => [
                 ['user' => 9999, 'teamlead' => 1],
             ],


### PR DESCRIPTION
## Description
A time tracking system should not force me to have at least 3 letters for a project, activity or customer name if the system can handle it without breaking. This is especially important if you are importing data from other systems as there can be project names which are just 2 letters long (which is the case for me)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] I verified that my code applies to the guidelines (`composer code-check`)
- [ ] I updated the documentation (see [here](https://github.com/kimai/www.kimai.org/tree/master/_documentation))
- [x] I agree that this code is used in Kimai (see [license](https://github.com/kimai/kimai/blob/main/LICENSE))
