### PR TITLE
Weekly hours: warn on validation error - closes #4233

### DIFF
--- a/src/Controller/QuickEntryController.php
+++ b/src/Controller/QuickEntryController.php
@@ -181,7 +181,13 @@ final class QuickEntryController extends AbstractController
 
         $form->handleRequest($request);
 
-        if ($form->isSubmitted() && $form->isValid()) {
+        if ($form->isSubmitted()) {
+
+            if(!$form->isValid()){
+                $this->flashError('action.update.error', $form->getErrors());
+                return $this->redirectToRoute('quick_entry', ['begin' => $begin->format('Y-m-d')]);
+            }
+
             /** @var QuickEntryWeek $data */
             $data = $form->getData();
 


### PR DESCRIPTION
## Description
Adding an error message popup when quick entry form is not valid. This is preventing silent save failure.

## Types of changes
- UX improvement - fixes #4233

## Checklist
- [X] I verified that my code applies to the guidelines (`composer code-check`)
- [X] I updated the documentation (see [here](https://github.com/kimai/www.kimai.org/tree/master/_documentation))
- [X] I agree that this code is used in Kimai (see [license](https://github.com/kimai/kimai/blob/main/LICENSE))
