### PR TITLE
feat: pass kimai_version to repository-dispatch and add input for manual trigger

### DIFF
--- a/.github/workflows/website.yaml
+++ b/.github/workflows/website.yaml
@@ -3,8 +3,8 @@ on:
   workflow_dispatch:
     inputs:
       kimai_version:
-          description: 'The Kimai version to update the website for'
-          required: true
+        description: 'The Kimai version to update the website for'
+        required: true
   release:
     types: [released]
 

--- a/.github/workflows/website.yaml
+++ b/.github/workflows/website.yaml
@@ -2,9 +2,9 @@ name: 'Website update'
 on:
   workflow_dispatch:
     inputs:
-        kimai_version:
-            description: 'The Kimai version to update the website for'
-            required: true
+      kimai_version:
+          description: 'The Kimai version to update the website for'
+          required: true
   release:
     types: [released]
 

--- a/.github/workflows/website.yaml
+++ b/.github/workflows/website.yaml
@@ -1,6 +1,10 @@
 name: 'Website update'
 on:
   workflow_dispatch:
+    inputs:
+        kimai_version:
+            description: 'The Kimai version to update the website for'
+            required: true
   release:
     types: [released]
 
@@ -9,9 +13,23 @@ jobs:
     name: Trigger version update for website
     runs-on: ubuntu-latest
     steps:
+      - name: "Determine Version"
+        run: |
+          input="${{ github.event.inputs.kimai_version }}"
+
+          # Determine between manual trigger and release event
+          if [ -z "$input" ]; then
+              echo "No input provided, using release tag"
+              echo "kimai_version=${{ github.event.release.tag_name }}" >> $GITHUB_ENV
+          else
+              echo "Using input provided: $input"
+              echo "kimai_version=$input" >> $GITHUB_ENV
+          fi
+
       - name: Emit repository_dispatch
         uses: peter-evans/repository-dispatch@v2
         with:
           token: ${{ secrets.WEBSITE_ACCESS_TOKEN }}
           repository: kimai/www.kimai.org
           event-type: kimai_release
+          client_payload: '{"kimai_version": "$kimai_version"}'


### PR DESCRIPTION
## Description
This PR works together with https://github.com/kimai/www.kimai.org/pull/287 to establish a system to automatically update the kimai_version on the website.

The changes are some smaller improvements to the `website.yaml` action to...

1. Add an input to the manual trigger to avoid sending empty version numbers to the website repository
2. Add a small script to differentiate between automatic and manual runs and set the correct version
3. Send the determined `kimai_version` in the `client_payload` to the website repository to be in control of what happens there.

NOTE: It's a bit hard for me to test those changes, but I've merged the code to the `main` branch of my fork, so we can at least see the interface for the manual run: https://github.com/cngJo/kimai/actions/workflows/website.yaml

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] I verified that my code applies to the guidelines (`composer code-check`)
- [ ] I updated the documentation (see [here](https://github.com/kimai/www.kimai.org/tree/master/_documentation))
- [x] I agree that this code is used in Kimai (see [license](https://github.com/kimai/kimai/blob/main/LICENSE))
