### PR TITLE
Fix: Change client_payload to client-payload in website.yaml

### DIFF
--- a/.github/workflows/website.yaml
+++ b/.github/workflows/website.yaml
@@ -32,4 +32,4 @@ jobs:
           token: ${{ secrets.WEBSITE_ACCESS_TOKEN }}
           repository: kimai/www.kimai.org
           event-type: kimai_release
-          client_payload: '{"kimai_version": "$kimai_version"}'
+          client-payload: '{"kimai_version": "$kimai_version"}'


### PR DESCRIPTION
## Description
Fixes a small typo in the `website.yaml` workflow to ensure the `client-payload` is properly passed to the `workflow_dispatch`.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] I verified that my code applies to the guidelines (`composer code-check`)
- [ ] I updated the documentation (see [here](https://github.com/kimai/www.kimai.org/tree/master/_documentation))
- [x] I agree that this code is used in Kimai (see [license](https://github.com/kimai/kimai/blob/main/LICENSE))
