### PR TITLE
Change isWeekend() check to isWorkingDay() and fallback to Saturday/Sunday as weekend

### DIFF
--- a/src/Twig/LocaleFormatExtensions.php
+++ b/src/Twig/LocaleFormatExtensions.php
@@ -118,6 +118,7 @@ final class LocaleFormatExtensions extends AbstractExtension implements LocaleAw
 
         return $this->locale;
     }
+
     public function isWeekend(\DateTimeInterface|string|null $dateTime): bool
     {
         if (!$dateTime instanceof \DateTimeInterface) {
@@ -126,7 +127,7 @@ final class LocaleFormatExtensions extends AbstractExtension implements LocaleAw
 
         $day = (int) $dateTime->format('N');
 
-        if (!array_key_exists($day, $this->dayCache)) {
+        if (!\array_key_exists($day, $this->dayCache)) {
             $isWeekend = ($day === 6 || $day === 7);
 
             /** @var User|null $user */

--- a/src/Twig/LocaleFormatExtensions.php
+++ b/src/Twig/LocaleFormatExtensions.php
@@ -124,20 +124,6 @@ final class LocaleFormatExtensions extends AbstractExtension implements LocaleAw
 
         $day = (int) $dateTime->format('w');
 
-        if ($this->fdowSunday === null) {
-            /** @var User|null $user */
-            $user = $this->security->getUser();
-            if ($user !== null) {
-                $this->fdowSunday = $user->isFirstDayOfWeekSunday();
-            } else {
-                $this->fdowSunday = false;
-            }
-        }
-
-        if ($this->fdowSunday) {
-            return ($day === 5 || $day === 6);
-        }
-
         return ($day === 0 || $day === 6);
     }
 

--- a/src/Twig/LocaleFormatExtensions.php
+++ b/src/Twig/LocaleFormatExtensions.php
@@ -17,7 +17,6 @@ use App\Utils\FormFormatConverter;
 use App\Utils\JavascriptFormatConverter;
 use App\Utils\LocaleFormatter;
 use DateTime;
-use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Contracts\Translation\LocaleAwareInterface;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFilter;
@@ -26,11 +25,10 @@ use Twig\TwigTest;
 
 final class LocaleFormatExtensions extends AbstractExtension implements LocaleAwareInterface
 {
-    private ?bool $fdowSunday = null;
     private ?LocaleFormatter $formatter = null;
     private ?string $locale = null;
 
-    public function __construct(private LocaleService $localeService, private Security $security)
+    public function __construct(private LocaleService $localeService)
     {
     }
 

--- a/src/Twig/LocaleFormatExtensions.php
+++ b/src/Twig/LocaleFormatExtensions.php
@@ -17,6 +17,7 @@ use App\Utils\FormFormatConverter;
 use App\Utils\JavascriptFormatConverter;
 use App\Utils\LocaleFormatter;
 use DateTime;
+use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Contracts\Translation\LocaleAwareInterface;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFilter;

--- a/src/Twig/LocaleFormatExtensions.php
+++ b/src/Twig/LocaleFormatExtensions.php
@@ -26,10 +26,6 @@ use Twig\TwigTest;
 
 final class LocaleFormatExtensions extends AbstractExtension implements LocaleAwareInterface
 {
-    /**
-     * @var array<int, bool>
-     */
-    private array $dayCache = [];
     private ?LocaleFormatter $formatter = null;
     private ?string $locale = null;
 
@@ -127,19 +123,13 @@ final class LocaleFormatExtensions extends AbstractExtension implements LocaleAw
 
         $day = (int) $dateTime->format('N');
 
-        if (!\array_key_exists($day, $this->dayCache)) {
-            $isWeekend = ($day === 6 || $day === 7);
-
-            /** @var User|null $tmp */
-            $tmp = $user ?? $this->security->getUser();
-            if ($tmp !== null && $tmp->hasWorkHourConfiguration()) {
-                $isWeekend = !$tmp->isWorkDay($dateTime);
-            }
-
-            $this->dayCache[$day] = $isWeekend;
+        /** @var User|null $tmp */
+        $tmp = $user ?? $this->security->getUser();
+        if ($tmp !== null && $tmp->hasWorkHourConfiguration()) {
+            return !$tmp->isWorkDay($dateTime);
         }
 
-        return $this->dayCache[$day];
+        return ($day === 6 || $day === 7);
     }
 
     public function dateShort(\DateTimeInterface|string|null $date): string

--- a/src/Twig/LocaleFormatExtensions.php
+++ b/src/Twig/LocaleFormatExtensions.php
@@ -119,7 +119,7 @@ final class LocaleFormatExtensions extends AbstractExtension implements LocaleAw
         return $this->locale;
     }
 
-    public function isWeekend(\DateTimeInterface|string|null $dateTime): bool
+    public function isWeekend(\DateTimeInterface|string|null $dateTime, ?User $user = null): bool
     {
         if (!$dateTime instanceof \DateTimeInterface) {
             return false;
@@ -130,10 +130,10 @@ final class LocaleFormatExtensions extends AbstractExtension implements LocaleAw
         if (!\array_key_exists($day, $this->dayCache)) {
             $isWeekend = ($day === 6 || $day === 7);
 
-            /** @var User|null $user */
-            $user = $this->security->getUser();
-            if ($user !== null && $user->hasWorkHourConfiguration()) {
-                $isWeekend = !$user->isWorkDay($dateTime);
+            /** @var User|null $tmp */
+            $tmp = $user ?? $this->security->getUser();
+            if ($tmp !== null && $tmp->hasWorkHourConfiguration()) {
+                $isWeekend = !$tmp->isWorkDay($dateTime);
             }
 
             $this->dayCache[$day] = $isWeekend;

--- a/src/Twig/LocaleFormatExtensions.php
+++ b/src/Twig/LocaleFormatExtensions.php
@@ -117,7 +117,6 @@ final class LocaleFormatExtensions extends AbstractExtension implements LocaleAw
 
         return $this->locale;
     }
-    
     public function isWeekend(\DateTimeInterface|string|null $dateTime): bool
     {
         if (!$dateTime instanceof \DateTimeInterface) {

--- a/templates/contract/status.html.twig
+++ b/templates/contract/status.html.twig
@@ -213,7 +213,7 @@
                             {% set dayCount = 0 %}
                             {% for day in month.days %}
                                 {% set class = 'text-end contractDay text-nowrap' %}
-                                {% if day.day is weekend %}
+                                {% if day.day is weekend(user) %}
                                     {% set class = class ~ ' weekend' %}
                                 {% endif %}
                                 {% if day.workingTime.expectedTime > 0 and day.workingTime.actualTime == 0 and now > day.day %}

--- a/templates/reporting/report_by_user.html.twig
+++ b/templates/reporting/report_by_user.html.twig
@@ -3,18 +3,18 @@
 {% block report_content %}
     {% embed 'reporting/report_by_user_data.html.twig' %}
         {% block period_name %}
-            <th class="text-center text-nowrap{% if column is weekend %} weekend{% endif %}{% if column is today %} today{% endif %}">
+            <th class="text-center text-nowrap{% if column is weekend(user) %} weekend{% endif %}{% if column is today %} today{% endif %}">
                 {{ column|date_weekday }}
             </th>
         {% endblock %}
         {% block column_classes_project -%}
-            {% if column.date is weekend %} weekend{% endif %}{% if column.date is today %} today{% endif %}
+            {% if column.date is weekend(user) %} weekend{% endif %}{% if column.date is today %} today{% endif %}
         {%- endblock %}
         {% block column_classes_activity -%}
-            {% if column.date is weekend %} weekend{% endif %}{% if column.date is today %} today{% endif %}
+            {% if column.date is weekend(user) %} weekend{% endif %}{% if column.date is today %} today{% endif %}
         {%- endblock %}
         {% block column_classes_total -%}
-            {% if column is weekend %} weekend{% endif %}
+            {% if column is weekend(user) %} weekend{% endif %}
         {%- endblock %}
     {% endembed %}
 {% endblock %}

--- a/templates/reporting/report_user_list.html.twig
+++ b/templates/reporting/report_user_list.html.twig
@@ -3,7 +3,7 @@
 {% block report_content %}
     {% embed 'reporting/user_list_period_data.html.twig' with {stats: stats, dataType: dataType, period_attribute: period_attribute, subReportRoute: subReportRoute, subReportDate: subReportDate, decimal: decimal} only %}
         {% block period_name %}
-            <th class="text-center text-nowrap{% if column is weekend %} weekend{% endif %}{% if column is today %} today{% endif %}">
+            <th class="text-center text-nowrap{% if column is today %} today{% endif %}">
                 {{ column|date_weekday }}
             </th>
         {% endblock %}
@@ -25,6 +25,6 @@
         {% block duration %}
             {{ period.totalDuration|duration(decimal) }}
         {% endblock %}
-        {% block period_cell_class %}{% if period.date is weekend %} weekend{% endif %}{% if period.date is today %} today{% endif %}{% endblock %}
+        {% block period_cell_class %}{% if period.date is weekend(userPeriod.user) %} weekend{% endif %}{% if period.date is today %} today{% endif %}{% endblock %}
     {% endembed %}
 {% endblock %}


### PR DESCRIPTION
## Description
`format('w')` always returns `0` for Sunday and `6` for Saturday. The user configuration will not affect the result.

NOTE: I did not check the side-effects where "isWeekend()" is used elsewhere.

fixes #4260

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] I verified that my code applies to the guidelines (`composer code-check`)
    - I edited the code removal from Github editor. I have no PHP dev environment.
- [X] I updated the documentation (see [here](https://github.com/kimai/www.kimai.org/tree/master/_documentation))
- [X] I agree that this code is used in Kimai (see [license](https://github.com/kimai/kimai/blob/main/LICENSE))
