### PR TITLE
Fix locale definitions starting with AM/PM

### DIFF
--- a/config/locales.php
+++ b/config/locales.php
@@ -199,7 +199,7 @@
   ],
   'en_CH' => 
   [
-    'date' => 'dd/MM/y',
+    'date' => 'dd.MM.y',
     'time' => 'HH:mm',
     'rtl' => false,
   ],
@@ -457,7 +457,7 @@
   ],
   'en_MV' => 
   [
-    'date' => 'M/d/yy',
+    'date' => 'd-M-yy',
     'time' => 'HH:mm',
     'rtl' => false,
   ],
@@ -1316,19 +1316,19 @@
   'ko' => 
   [
     'date' => 'yy. M. d.',
-    'time' => 'a h:mm',
+    'time' => 'h:mm a',
     'rtl' => false,
   ],
   'ko_KP' => 
   [
     'date' => 'yy. M. d.',
-    'time' => 'a h:mm',
+    'time' => 'h:mm a',
     'rtl' => false,
   ],
   'ko_KR' => 
   [
     'date' => 'yy. M. d.',
-    'time' => 'a h:mm',
+    'time' => 'h:mm a',
     'rtl' => false,
   ],
   'nb_NO' => 
@@ -1589,6 +1589,12 @@
     'time' => 'HH:mm',
     'rtl' => false,
   ],
+  'uk' => 
+  [
+    'date' => 'dd.MM.yy',
+    'time' => 'HH:mm',
+    'rtl' => false,
+  ],
   'vi' => 
   [
     'date' => 'dd/MM/y',
@@ -1605,6 +1611,12 @@
   [
     'date' => 'y/M/d',
     'time' => 'HH:mm',
+    'rtl' => false,
+  ],
+  'zh_Hant' => 
+  [
+    'date' => 'y/M/d',
+    'time' => 'Bh:mm',
     'rtl' => false,
   ],
 ];

--- a/src/Command/RegenerateLocalesCommand.php
+++ b/src/Command/RegenerateLocalesCommand.php
@@ -106,7 +106,7 @@ final class RegenerateLocalesCommand extends Command
             if (str_contains($settings['time'], 'a ')) {
                 $settings['time'] = str_replace('a ', '', $settings['time']) . ' a';
             }
-            $settings['time'] = str_replace(' ', ' ', $settings['time']);
+            $settings['time'] = str_replace("\u{202f}", ' ', $settings['time']);
 
             // make sure that sub-locales of a RTL language are also flagged as RTL
             $rtlLocale = $locale;

--- a/src/Command/RegenerateLocalesCommand.php
+++ b/src/Command/RegenerateLocalesCommand.php
@@ -98,11 +98,12 @@ final class RegenerateLocalesCommand extends Command
             $shortDate = new \IntlDateFormatter($locale, \IntlDateFormatter::SHORT, \IntlDateFormatter::NONE);
             $shortTime = new \IntlDateFormatter($locale, \IntlDateFormatter::NONE, \IntlDateFormatter::SHORT);
 
-            // special case when time pattern starts with A / a => this will lead to an error
-            // \DateTimeImmutable::getLastErrors() => Meridian can only come after an hour has been found
             $settings['date'] = $shortDate->getPattern();
             $settings['time'] = $shortTime->getPattern();
 
+            // see https://github.com/kimai/kimai/issues/4402 - Korean time format failed parsing
+            // special case when time pattern starts with A / a => this will lead to an error
+            // \DateTimeImmutable::getLastErrors() => Meridian can only come after an hour has been found
             if (str_contains($settings['time'], 'a ')) {
                 $settings['time'] = str_replace('a ', '', $settings['time']) . ' a';
             }

--- a/src/Command/RegenerateLocalesCommand.php
+++ b/src/Command/RegenerateLocalesCommand.php
@@ -98,8 +98,15 @@ final class RegenerateLocalesCommand extends Command
             $shortDate = new \IntlDateFormatter($locale, \IntlDateFormatter::SHORT, \IntlDateFormatter::NONE);
             $shortTime = new \IntlDateFormatter($locale, \IntlDateFormatter::NONE, \IntlDateFormatter::SHORT);
 
+            // special case when time pattern starts with A / a => this will lead to an error
+            // \DateTimeImmutable::getLastErrors() => Meridian can only come after an hour has been found
             $settings['date'] = $shortDate->getPattern();
             $settings['time'] = $shortTime->getPattern();
+
+            if (str_contains($settings['time'], 'a ')) {
+                $settings['time'] = str_replace('a ', '', $settings['time']) . ' a';
+            }
+            $settings['time'] = str_replace(' ', ' ', $settings['time']);
 
             // make sure that sub-locales of a RTL language are also flagged as RTL
             $rtlLocale = $locale;


### PR DESCRIPTION
## Description

Locales that usually start with AM/PM cannot be supported, because PHP fails parsing times that start with these identifiers. The identifier always need to be appended. 
So instead of `PM 1:23` it needs to be `1:23 PM`.
This might be a disturbance for users of these locales (currently Korean is the only affected locale) but it is still better than not working (which is currently the case).

Also regenerate some locale and added `uk` and `zh_Hant`

This fixes #4402

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] I verified that my code applies to the guidelines (`composer code-check`)
- [x] I agree that this code is used in Kimai (see [license](https://github.com/kimai/kimai/blob/main/LICENSE))
