### PR TITLE
Add emoji to terminal output at end of startup

### DIFF
--- a/.docker/service.sh
+++ b/.docker/service.sh
@@ -48,11 +48,13 @@ function runServer() {
   /opt/kimai/bin/console kimai:reload --env="$APP_ENV"
   chown -R $USER_ID:$GROUP_ID /opt/kimai/var
   if [ -e /use_apache ]; then
+    echo "🏁 Running 🪶 apache server"
     exec /usr/sbin/apache2 -D FOREGROUND
   elif [ -e /use_fpm ]; then
+    echo "🏁 Running 🐘 php-fpm server"
     exec php-fpm
   else
-    echo "Error, unknown server type"
+    echo "⚠️ Error, unknown server type"
   fi
 }
 


### PR DESCRIPTION
## Description
When I run in a container, the output at docker log is very cold, to give a best feedback to sysadmin/developers and be more happy, I added emojis signalizing the step of end of startup

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] I verified that my code applies to the guidelines (`composer code-check`)
- [x] I updated the documentation (see [here](https://github.com/kimai/www.kimai.org/tree/master/_documentation))
- [x] I agree that this code is used in Kimai (see [license](https://github.com/kimai/kimai/blob/main/LICENSE))
