### PR TITLE
sort invoice items by date before passing to template

### DIFF
--- a/src/Invoice/Calculator/AbstractCalculator.php
+++ b/src/Invoice/Calculator/AbstractCalculator.php
@@ -21,6 +21,10 @@ abstract class AbstractCalculator
      */
     abstract public function getEntries(): array;
 
+    /**
+     * @param array<InvoiceItem> $items
+     * @return array<InvoiceItem>
+     */
     protected function sortEntries(array $items): array
     {
         usort($items, function (InvoiceItem $item1, InvoiceItem $item2) {

--- a/src/Invoice/Calculator/AbstractCalculator.php
+++ b/src/Invoice/Calculator/AbstractCalculator.php
@@ -21,6 +21,15 @@ abstract class AbstractCalculator
      */
     abstract public function getEntries(): array;
 
+    protected function sortEntries(array $items): array
+    {
+        usort($items, function (InvoiceItem $item1, InvoiceItem $item2) {
+            return $item1->getBegin() <=> $item2->getBegin();
+        });
+
+        return $items;
+    }
+
     abstract public function getId(): string;
 
     public function setModel(InvoiceModel $model): void

--- a/src/Invoice/Calculator/AbstractSumInvoiceCalculator.php
+++ b/src/Invoice/Calculator/AbstractSumInvoiceCalculator.php
@@ -77,7 +77,7 @@ abstract class AbstractSumInvoiceCalculator extends AbstractMergedCalculator imp
             $this->mergeSumInvoiceItem($invoiceItem, $entry);
         }
 
-        return array_values($invoiceItems);
+        return $this->sortEntries(array_values($invoiceItems));
     }
 
     /**

--- a/src/Invoice/Calculator/DefaultCalculator.php
+++ b/src/Invoice/Calculator/DefaultCalculator.php
@@ -39,7 +39,7 @@ final class DefaultCalculator extends AbstractMergedCalculator implements Calcul
             $entries[] = $item;
         }
 
-        return $entries;
+        return $this->sortEntries($entries);
     }
 
     public function getId(): string

--- a/tests/Invoice/Calculator/ActivityInvoiceCalculatorTest.php
+++ b/tests/Invoice/Calculator/ActivityInvoiceCalculatorTest.php
@@ -54,7 +54,7 @@ class ActivityInvoiceCalculatorTest extends AbstractCalculatorTest
 
         $timesheet = new Timesheet();
         $timesheet
-            ->setBegin(new \DateTime())
+            ->setBegin(new \DateTime('2018-11-29'))
             ->setEnd(new \DateTime())
             ->setDuration(3600)
             ->setRate(293.27)
@@ -74,7 +74,7 @@ class ActivityInvoiceCalculatorTest extends AbstractCalculatorTest
 
         $timesheet3 = new Timesheet();
         $timesheet3
-            ->setBegin(new \DateTime())
+            ->setBegin(new \DateTime('2018-11-28'))
             ->setEnd(new \DateTime())
             ->setDuration(1800)
             ->setRate(111.11)
@@ -84,7 +84,7 @@ class ActivityInvoiceCalculatorTest extends AbstractCalculatorTest
 
         $timesheet4 = new Timesheet();
         $timesheet4
-            ->setBegin(new \DateTime())
+            ->setBegin(new \DateTime('2018-11-28'))
             ->setEnd(new \DateTime())
             ->setDuration(400)
             ->setRate(1947.99)
@@ -94,7 +94,7 @@ class ActivityInvoiceCalculatorTest extends AbstractCalculatorTest
 
         $timesheet5 = new Timesheet();
         $timesheet5
-            ->setBegin(new \DateTime())
+            ->setBegin(new \DateTime('2018-11-29'))
             ->setEnd(new \DateTime())
             ->setDuration(400)
             ->setRate(84)
@@ -114,7 +114,7 @@ class ActivityInvoiceCalculatorTest extends AbstractCalculatorTest
         $timesheet7 = new Timesheet();
         $timesheet7
             ->setBegin(new \DateTime())
-            ->setEnd(new \DateTime())
+            ->setEnd(new \DateTime('2018-11-18'))
             ->setDuration(0)
             ->setRate(0)
             ->setUser(new User())

--- a/tests/Invoice/Calculator/ActivityInvoiceCalculatorTest.php
+++ b/tests/Invoice/Calculator/ActivityInvoiceCalculatorTest.php
@@ -36,6 +36,7 @@ class ActivityInvoiceCalculatorTest extends AbstractCalculatorTest
 
     public function testWithMultipleEntries(): void
     {
+        $date = new \DateTime();
         $customer = new Customer('foo');
         $template = new InvoiceTemplate();
         $template->setVat(19);
@@ -64,7 +65,7 @@ class ActivityInvoiceCalculatorTest extends AbstractCalculatorTest
 
         $timesheet2 = new Timesheet();
         $timesheet2
-            ->setBegin(new \DateTime())
+            ->setBegin(clone $date)
             ->setEnd(new \DateTime())
             ->setDuration(400)
             ->setRate(84.75)
@@ -104,7 +105,7 @@ class ActivityInvoiceCalculatorTest extends AbstractCalculatorTest
 
         $timesheet6 = new Timesheet();
         $timesheet6
-            ->setBegin(new \DateTime())
+            ->setBegin(clone $date)
             ->setEnd(new \DateTime())
             ->setDuration(0)
             ->setRate(0)
@@ -113,7 +114,7 @@ class ActivityInvoiceCalculatorTest extends AbstractCalculatorTest
 
         $timesheet7 = new Timesheet();
         $timesheet7
-            ->setBegin(new \DateTime())
+            ->setBegin(clone $date)
             ->setEnd(new \DateTime('2018-11-18'))
             ->setDuration(0)
             ->setRate(0)
@@ -123,7 +124,7 @@ class ActivityInvoiceCalculatorTest extends AbstractCalculatorTest
 
         $timesheet8 = new Timesheet();
         $timesheet8
-            ->setBegin(new \DateTime())
+            ->setBegin(clone $date)
             ->setEnd(new \DateTime())
             ->setDuration(0)
             ->setRate(0)
@@ -150,6 +151,11 @@ class ActivityInvoiceCalculatorTest extends AbstractCalculatorTest
 
         $entries = $sut->getEntries();
         self::assertCount(4, $entries);
+        $this->assertEquals('2018-11-28', $entries[0]->getBegin()?->format('Y-m-d'));
+        $this->assertEquals('2018-11-28', $entries[1]->getBegin()?->format('Y-m-d'));
+        $this->assertEquals('2018-11-29', $entries[2]->getBegin()?->format('Y-m-d'));
+        $this->assertEquals($date->format('Y-m-d'), $entries[3]->getBegin()?->format('Y-m-d'));
+
         $this->assertEquals(404.38, $entries[0]->getRate());
         $this->assertEquals(2032.74, $entries[1]->getRate());
         $this->assertEquals(84, $entries[2]->getRate());

--- a/tests/Invoice/Calculator/ActivityUserInvoiceCalculatorTest.php
+++ b/tests/Invoice/Calculator/ActivityUserInvoiceCalculatorTest.php
@@ -36,6 +36,7 @@ class ActivityUserInvoiceCalculatorTest extends AbstractCalculatorTest
 
     public function testWithMultipleEntries(): void
     {
+        $date = new \DateTime();
         $customer = new Customer('foo');
         $template = new InvoiceTemplate();
         $template->setVat(19);
@@ -67,7 +68,7 @@ class ActivityUserInvoiceCalculatorTest extends AbstractCalculatorTest
 
         $timesheet2 = new Timesheet();
         $timesheet2
-            ->setBegin(new \DateTime())
+            ->setBegin(new \DateTime('2018-11-18'))
             ->setEnd(new \DateTime())
             ->setDuration(400)
             ->setRate(84.75)
@@ -77,7 +78,7 @@ class ActivityUserInvoiceCalculatorTest extends AbstractCalculatorTest
 
         $timesheet3 = new Timesheet();
         $timesheet3
-            ->setBegin(new \DateTime())
+            ->setBegin(clone $date)
             ->setEnd(new \DateTime())
             ->setDuration(1800)
             ->setRate(111.11)
@@ -87,7 +88,7 @@ class ActivityUserInvoiceCalculatorTest extends AbstractCalculatorTest
 
         $timesheet4 = new Timesheet();
         $timesheet4
-            ->setBegin(new \DateTime())
+            ->setBegin(new \DateTime('2018-11-29'))
             ->setEnd(new \DateTime())
             ->setDuration(400)
             ->setRate(1947.99)
@@ -97,7 +98,7 @@ class ActivityUserInvoiceCalculatorTest extends AbstractCalculatorTest
 
         $timesheet5 = new Timesheet();
         $timesheet5
-            ->setBegin(new \DateTime())
+            ->setBegin(new \DateTime('2018-11-18'))
             ->setEnd(new \DateTime())
             ->setDuration(400)
             ->setRate(84)
@@ -107,7 +108,7 @@ class ActivityUserInvoiceCalculatorTest extends AbstractCalculatorTest
 
         $timesheet5a = new Timesheet();
         $timesheet5a
-            ->setBegin(new \DateTime())
+            ->setBegin(new \DateTime('2018-11-08'))
             ->setEnd(new \DateTime())
             ->setDuration(400)
             ->setRate(84)
@@ -117,7 +118,7 @@ class ActivityUserInvoiceCalculatorTest extends AbstractCalculatorTest
 
         $timesheet6 = new Timesheet();
         $timesheet6
-            ->setBegin(new \DateTime())
+            ->setBegin(clone $date)
             ->setEnd(new \DateTime())
             ->setDuration(0)
             ->setRate(0)
@@ -126,7 +127,7 @@ class ActivityUserInvoiceCalculatorTest extends AbstractCalculatorTest
 
         $timesheet7 = new Timesheet();
         $timesheet7
-            ->setBegin(new \DateTime())
+            ->setBegin(clone $date)
             ->setEnd(new \DateTime())
             ->setDuration(0)
             ->setRate(0)
@@ -136,7 +137,7 @@ class ActivityUserInvoiceCalculatorTest extends AbstractCalculatorTest
 
         $timesheet8 = new Timesheet();
         $timesheet8
-            ->setBegin(new \DateTime())
+            ->setBegin(clone $date)
             ->setEnd(new \DateTime())
             ->setDuration(0)
             ->setRate(0)
@@ -163,12 +164,19 @@ class ActivityUserInvoiceCalculatorTest extends AbstractCalculatorTest
 
         $entries = $sut->getEntries();
         self::assertCount(6, $entries);
-        $this->assertEquals(404.38, $entries[0]->getRate());
+        $this->assertEquals('2018-11-08', $entries[0]->getBegin()->format('Y-m-d'));
+        $this->assertEquals('2018-11-18', $entries[1]->getBegin()->format('Y-m-d'));
+        $this->assertEquals('2018-11-18', $entries[2]->getBegin()->format('Y-m-d'));
+        $this->assertEquals($date->format('Y-m-d'), $entries[3]->getBegin()->format('Y-m-d'));
+        $this->assertEquals($date->format('Y-m-d'), $entries[4]->getBegin()->format('Y-m-d'));
+        $this->assertEquals($date->format('Y-m-d'), $entries[5]->getBegin()->format('Y-m-d'));
+
+        $this->assertEquals(404.38, $entries[5]->getRate());
         $this->assertEquals(2032.74, $entries[1]->getRate());
         $this->assertEquals(84.0, $entries[2]->getRate());
-        $this->assertEquals(84.0, $entries[3]->getRate());
+        $this->assertEquals(84.0, $entries[0]->getRate());
         $this->assertEquals(0, $entries[4]->getRate());
-        $this->assertEquals(0, $entries[5]->getRate());
+        $this->assertEquals(0, $entries[3]->getRate());
     }
 
     public function testDescriptionByActivity(): void

--- a/tests/Invoice/Calculator/ActivityUserInvoiceCalculatorTest.php
+++ b/tests/Invoice/Calculator/ActivityUserInvoiceCalculatorTest.php
@@ -164,12 +164,12 @@ class ActivityUserInvoiceCalculatorTest extends AbstractCalculatorTest
 
         $entries = $sut->getEntries();
         self::assertCount(6, $entries);
-        $this->assertEquals('2018-11-08', $entries[0]->getBegin()->format('Y-m-d'));
-        $this->assertEquals('2018-11-18', $entries[1]->getBegin()->format('Y-m-d'));
-        $this->assertEquals('2018-11-18', $entries[2]->getBegin()->format('Y-m-d'));
-        $this->assertEquals($date->format('Y-m-d'), $entries[3]->getBegin()->format('Y-m-d'));
-        $this->assertEquals($date->format('Y-m-d'), $entries[4]->getBegin()->format('Y-m-d'));
-        $this->assertEquals($date->format('Y-m-d'), $entries[5]->getBegin()->format('Y-m-d'));
+        $this->assertEquals('2018-11-08', $entries[0]->getBegin()?->format('Y-m-d'));
+        $this->assertEquals('2018-11-18', $entries[1]->getBegin()?->format('Y-m-d'));
+        $this->assertEquals('2018-11-18', $entries[2]->getBegin()?->format('Y-m-d'));
+        $this->assertEquals($date->format('Y-m-d'), $entries[3]->getBegin()?->format('Y-m-d'));
+        $this->assertEquals($date->format('Y-m-d'), $entries[4]->getBegin()?->format('Y-m-d'));
+        $this->assertEquals($date->format('Y-m-d'), $entries[5]->getBegin()?->format('Y-m-d'));
 
         $this->assertEquals(404.38, $entries[5]->getRate());
         $this->assertEquals(2032.74, $entries[1]->getRate());

--- a/tests/Invoice/Calculator/DateInvoiceCalculatorTest.php
+++ b/tests/Invoice/Calculator/DateInvoiceCalculatorTest.php
@@ -124,9 +124,9 @@ class DateInvoiceCalculatorTest extends AbstractCalculatorTest
 
         $entries = $sut->getEntries();
         self::assertCount(3, $entries);
-        $this->assertEquals('2018-11-28', $entries[0]->getBegin()->format('Y-m-d'));
-        $this->assertEquals('2018-11-29', $entries[1]->getBegin()->format('Y-m-d'));
-        $this->assertEquals($date->format('Y-m-d'), $entries[2]->getBegin()->format('Y-m-d'));
+        $this->assertEquals('2018-11-28', $entries[0]->getBegin()?->format('Y-m-d'));
+        $this->assertEquals('2018-11-29', $entries[1]->getBegin()?->format('Y-m-d'));
+        $this->assertEquals($date->format('Y-m-d'), $entries[2]->getBegin()?->format('Y-m-d'));
         $this->assertEquals(378.02, $entries[1]->getRate());
         $this->assertEquals(195.11, $entries[0]->getRate());
         $this->assertEquals(1947.99, $entries[2]->getRate());

--- a/tests/Invoice/Calculator/DateInvoiceCalculatorTest.php
+++ b/tests/Invoice/Calculator/DateInvoiceCalculatorTest.php
@@ -37,6 +37,7 @@ class DateInvoiceCalculatorTest extends AbstractCalculatorTest
 
     public function testWithMultipleEntries(): void
     {
+        $date = new DateTime();
         $customer = new Customer('foo');
         $template = new InvoiceTemplate();
         $template->setVat(19);
@@ -85,7 +86,7 @@ class DateInvoiceCalculatorTest extends AbstractCalculatorTest
 
         $timesheet4 = new Timesheet();
         $timesheet4
-            ->setBegin(new DateTime())
+            ->setBegin($date)
             ->setEnd(new DateTime('2018-11-28'))
             ->setDuration(400)
             ->setRate(1947.99)
@@ -123,8 +124,11 @@ class DateInvoiceCalculatorTest extends AbstractCalculatorTest
 
         $entries = $sut->getEntries();
         self::assertCount(3, $entries);
-        $this->assertEquals(378.02, $entries[0]->getRate());
-        $this->assertEquals(195.11, $entries[1]->getRate());
+        $this->assertEquals('2018-11-28', $entries[0]->getBegin()->format('Y-m-d'));
+        $this->assertEquals('2018-11-29', $entries[1]->getBegin()->format('Y-m-d'));
+        $this->assertEquals($date->format('Y-m-d'), $entries[2]->getBegin()->format('Y-m-d'));
+        $this->assertEquals(378.02, $entries[1]->getRate());
+        $this->assertEquals(195.11, $entries[0]->getRate());
         $this->assertEquals(1947.99, $entries[2]->getRate());
         self::assertEquals(2521.12, $entries[0]->getRate() + $entries[1]->getRate() + $entries[2]->getRate());
     }

--- a/tests/Invoice/Calculator/DateUserInvoiceCalculatorTest.php
+++ b/tests/Invoice/Calculator/DateUserInvoiceCalculatorTest.php
@@ -126,11 +126,10 @@ class DateUserInvoiceCalculatorTest extends AbstractCalculatorTest
 
         $entries = $sut->getEntries();
         self::assertCount(4, $entries);
-        $this->assertEquals(378.02, $entries[0]->getRate());
-        $this->assertEquals(111.11, $entries[1]->getRate());
-        $this->assertEquals(1947.99, $entries[2]->getRate());
-        $this->assertEquals(84, $entries[3]->getRate());
-        self::assertEquals(2521.12, $entries[0]->getRate() + $entries[1]->getRate() + $entries[2]->getRate() + $entries[3]->getRate());
+        $this->assertEquals(378.02, $entries[2]->getRate());
+        $this->assertEquals(111.11, $entries[0]->getRate());
+        $this->assertEquals(1947.99, $entries[3]->getRate());
+        $this->assertEquals(84, $entries[1]->getRate());
     }
 
     public function testDescriptionByTimesheet(): void

--- a/tests/Invoice/Calculator/DefaultCalculatorTest.php
+++ b/tests/Invoice/Calculator/DefaultCalculatorTest.php
@@ -49,7 +49,7 @@ class DefaultCalculatorTest extends AbstractCalculatorTest
 
         $timesheet2 = new Timesheet();
         $timesheet2->setDescription('foo 2');
-        $timesheet2->setBegin(clone $date);
+        $timesheet2->setBegin(new \DateTime('2018-11-18'));
         $timesheet2->setDuration(400);
         $timesheet2->setRate(84);
         $timesheet2->setActivity(new Activity());

--- a/tests/Invoice/Calculator/PriceInvoiceCalculatorTest.php
+++ b/tests/Invoice/Calculator/PriceInvoiceCalculatorTest.php
@@ -88,8 +88,8 @@ class PriceInvoiceCalculatorTest extends AbstractCalculatorTest
 
         $timesheet4 = new Timesheet();
         $timesheet4
-            ->setBegin(new DateTime())
-            ->setEnd(new DateTime('2018-11-28'))
+            ->setBegin(new DateTime('2018-11-28'))
+            ->setEnd(new DateTime())
             ->setDuration(400)
             ->setHourlyRate(0)
             ->setRate(1947.99)
@@ -127,10 +127,16 @@ class PriceInvoiceCalculatorTest extends AbstractCalculatorTest
 
         $entries = $sut->getEntries();
         self::assertCount(4, $entries);
-        $this->assertEquals(378.02, $entries[0]->getRate());
-        $this->assertEquals(111.11, $entries[1]->getRate());
-        $this->assertEquals(1947.99, $entries[2]->getRate());
-        $this->assertEquals(84, $entries[3]->getRate());
+
+        $this->assertEquals('2018-11-28', $entries[0]->getBegin()->format('Y-m-d'));
+        $this->assertEquals('2018-11-28', $entries[1]->getBegin()->format('Y-m-d'));
+        $this->assertEquals('2018-11-28', $entries[2]->getBegin()->format('Y-m-d'));
+        $this->assertEquals('2018-11-29', $entries[3]->getBegin()->format('Y-m-d'));
+
+        $this->assertEquals(378.02, $entries[3]->getRate());
+        $this->assertEquals(111.11, $entries[0]->getRate());
+        $this->assertEquals(1947.99, $entries[1]->getRate());
+        $this->assertEquals(84, $entries[2]->getRate());
     }
 
     public function testDescriptionByTimesheet(): void

--- a/tests/Invoice/Calculator/PriceInvoiceCalculatorTest.php
+++ b/tests/Invoice/Calculator/PriceInvoiceCalculatorTest.php
@@ -128,10 +128,10 @@ class PriceInvoiceCalculatorTest extends AbstractCalculatorTest
         $entries = $sut->getEntries();
         self::assertCount(4, $entries);
 
-        $this->assertEquals('2018-11-28', $entries[0]->getBegin()->format('Y-m-d'));
-        $this->assertEquals('2018-11-28', $entries[1]->getBegin()->format('Y-m-d'));
-        $this->assertEquals('2018-11-28', $entries[2]->getBegin()->format('Y-m-d'));
-        $this->assertEquals('2018-11-29', $entries[3]->getBegin()->format('Y-m-d'));
+        $this->assertEquals('2018-11-28', $entries[0]->getBegin()?->format('Y-m-d'));
+        $this->assertEquals('2018-11-28', $entries[1]->getBegin()?->format('Y-m-d'));
+        $this->assertEquals('2018-11-28', $entries[2]->getBegin()?->format('Y-m-d'));
+        $this->assertEquals('2018-11-29', $entries[3]->getBegin()?->format('Y-m-d'));
 
         $this->assertEquals(378.02, $entries[3]->getRate());
         $this->assertEquals(111.11, $entries[0]->getRate());

--- a/tests/Invoice/Calculator/ProjectInvoiceCalculatorTest.php
+++ b/tests/Invoice/Calculator/ProjectInvoiceCalculatorTest.php
@@ -55,7 +55,7 @@ class ProjectInvoiceCalculatorTest extends AbstractCalculatorTest
 
         $timesheet = new Timesheet();
         $timesheet
-            ->setBegin(new DateTime())
+            ->setBegin(new DateTime('2018-11-29'))
             ->setEnd(new DateTime())
             ->setDuration(3600)
             ->setRate(293.27)
@@ -65,7 +65,7 @@ class ProjectInvoiceCalculatorTest extends AbstractCalculatorTest
 
         $timesheet2 = new Timesheet();
         $timesheet2
-            ->setBegin(new DateTime())
+            ->setBegin(new DateTime('2018-11-28'))
             ->setEnd(new DateTime())
             ->setDuration(400)
             ->setRate(84.75)
@@ -75,7 +75,7 @@ class ProjectInvoiceCalculatorTest extends AbstractCalculatorTest
 
         $timesheet3 = new Timesheet();
         $timesheet3
-            ->setBegin(new DateTime())
+            ->setBegin(new DateTime('2018-11-29'))
             ->setEnd(new DateTime())
             ->setDuration(1800)
             ->setRate(111.11)
@@ -85,7 +85,7 @@ class ProjectInvoiceCalculatorTest extends AbstractCalculatorTest
 
         $timesheet4 = new Timesheet();
         $timesheet4
-            ->setBegin(new DateTime())
+            ->setBegin(new DateTime('2018-11-08'))
             ->setEnd(new DateTime())
             ->setDuration(400)
             ->setRate(1947.99)
@@ -95,7 +95,7 @@ class ProjectInvoiceCalculatorTest extends AbstractCalculatorTest
 
         $timesheet5 = new Timesheet();
         $timesheet5
-            ->setBegin(new DateTime())
+            ->setBegin(new DateTime('2018-11-28'))
             ->setEnd(new DateTime())
             ->setDuration(400)
             ->setRate(84)
@@ -123,9 +123,14 @@ class ProjectInvoiceCalculatorTest extends AbstractCalculatorTest
 
         $entries = $sut->getEntries();
         self::assertCount(3, $entries);
-        $this->assertEquals(404.38, $entries[0]->getRate());
-        $this->assertEquals(2032.74, $entries[1]->getRate());
-        $this->assertEquals(84, $entries[2]->getRate());
+
+        $this->assertEquals('2018-11-08', $entries[0]->getBegin()->format('Y-m-d'));
+        $this->assertEquals('2018-11-28', $entries[1]->getBegin()->format('Y-m-d'));
+        $this->assertEquals('2018-11-29', $entries[2]->getBegin()->format('Y-m-d'));
+
+        $this->assertEquals(404.38, $entries[2]->getRate());
+        $this->assertEquals(2032.74, $entries[0]->getRate());
+        $this->assertEquals(84, $entries[1]->getRate());
         self::assertEquals(2521.12, $entries[0]->getRate() + $entries[1]->getRate() + $entries[2]->getRate());
     }
 

--- a/tests/Invoice/Calculator/ProjectInvoiceCalculatorTest.php
+++ b/tests/Invoice/Calculator/ProjectInvoiceCalculatorTest.php
@@ -124,9 +124,9 @@ class ProjectInvoiceCalculatorTest extends AbstractCalculatorTest
         $entries = $sut->getEntries();
         self::assertCount(3, $entries);
 
-        $this->assertEquals('2018-11-08', $entries[0]->getBegin()->format('Y-m-d'));
-        $this->assertEquals('2018-11-28', $entries[1]->getBegin()->format('Y-m-d'));
-        $this->assertEquals('2018-11-29', $entries[2]->getBegin()->format('Y-m-d'));
+        $this->assertEquals('2018-11-08', $entries[0]->getBegin()?->format('Y-m-d'));
+        $this->assertEquals('2018-11-28', $entries[1]->getBegin()?->format('Y-m-d'));
+        $this->assertEquals('2018-11-29', $entries[2]->getBegin()?->format('Y-m-d'));
 
         $this->assertEquals(404.38, $entries[2]->getRate());
         $this->assertEquals(2032.74, $entries[0]->getRate());

--- a/tests/Invoice/Calculator/ProjectUserInvoiceCalculatorTest.php
+++ b/tests/Invoice/Calculator/ProjectUserInvoiceCalculatorTest.php
@@ -58,7 +58,7 @@ class ProjectUserInvoiceCalculatorTest extends AbstractCalculatorTest
 
         $timesheet = new Timesheet();
         $timesheet
-            ->setBegin(new DateTime())
+            ->setBegin(new DateTime('2018-11-29'))
             ->setEnd(new DateTime())
             ->setDuration(3600)
             ->setRate(293.27)
@@ -68,7 +68,7 @@ class ProjectUserInvoiceCalculatorTest extends AbstractCalculatorTest
 
         $timesheet2 = new Timesheet();
         $timesheet2
-            ->setBegin(new DateTime())
+            ->setBegin(new DateTime('2018-11-28'))
             ->setEnd(new DateTime())
             ->setDuration(400)
             ->setRate(84.75)
@@ -78,7 +78,7 @@ class ProjectUserInvoiceCalculatorTest extends AbstractCalculatorTest
 
         $timesheet3 = new Timesheet();
         $timesheet3
-            ->setBegin(new DateTime())
+            ->setBegin(new DateTime('2018-11-29'))
             ->setEnd(new DateTime())
             ->setDuration(1800)
             ->setRate(111.11)
@@ -88,7 +88,7 @@ class ProjectUserInvoiceCalculatorTest extends AbstractCalculatorTest
 
         $timesheet4 = new Timesheet();
         $timesheet4
-            ->setBegin(new DateTime())
+            ->setBegin(new DateTime('2018-11-08'))
             ->setEnd(new DateTime())
             ->setDuration(400)
             ->setRate(1947.99)
@@ -98,7 +98,7 @@ class ProjectUserInvoiceCalculatorTest extends AbstractCalculatorTest
 
         $timesheet5 = new Timesheet();
         $timesheet5
-            ->setBegin(new DateTime())
+            ->setBegin(new DateTime('2018-11-28'))
             ->setEnd(new DateTime())
             ->setDuration(400)
             ->setRate(84)
@@ -126,10 +126,14 @@ class ProjectUserInvoiceCalculatorTest extends AbstractCalculatorTest
 
         $entries = $sut->getEntries();
         self::assertCount(3, $entries);
-        $this->assertEquals(404.38, $entries[0]->getRate());
-        $this->assertEquals(2032.74, $entries[1]->getRate());
-        $this->assertEquals(84, $entries[2]->getRate());
-        self::assertEquals(2521.12, $entries[0]->getRate() + $entries[1]->getRate() + $entries[2]->getRate());
+
+        $this->assertEquals('2018-11-08', $entries[0]->getBegin()->format('Y-m-d'));
+        $this->assertEquals('2018-11-28', $entries[1]->getBegin()->format('Y-m-d'));
+        $this->assertEquals('2018-11-29', $entries[2]->getBegin()->format('Y-m-d'));
+
+        $this->assertEquals(404.38, $entries[2]->getRate());
+        $this->assertEquals(2032.74, $entries[0]->getRate());
+        $this->assertEquals(84, $entries[1]->getRate());
     }
 
     public function testDescriptionByProject(): void

--- a/tests/Invoice/Calculator/ProjectUserInvoiceCalculatorTest.php
+++ b/tests/Invoice/Calculator/ProjectUserInvoiceCalculatorTest.php
@@ -127,9 +127,9 @@ class ProjectUserInvoiceCalculatorTest extends AbstractCalculatorTest
         $entries = $sut->getEntries();
         self::assertCount(3, $entries);
 
-        $this->assertEquals('2018-11-08', $entries[0]->getBegin()->format('Y-m-d'));
-        $this->assertEquals('2018-11-28', $entries[1]->getBegin()->format('Y-m-d'));
-        $this->assertEquals('2018-11-29', $entries[2]->getBegin()->format('Y-m-d'));
+        $this->assertEquals('2018-11-08', $entries[0]->getBegin()?->format('Y-m-d'));
+        $this->assertEquals('2018-11-28', $entries[1]->getBegin()?->format('Y-m-d'));
+        $this->assertEquals('2018-11-29', $entries[2]->getBegin()?->format('Y-m-d'));
 
         $this->assertEquals(404.38, $entries[2]->getRate());
         $this->assertEquals(2032.74, $entries[0]->getRate());

--- a/tests/Invoice/Calculator/ShortInvoiceCalculatorTest.php
+++ b/tests/Invoice/Calculator/ShortInvoiceCalculatorTest.php
@@ -56,7 +56,7 @@ class ShortInvoiceCalculatorTest extends AbstractCalculatorTest
             ->setUser(new User())
             ->setActivity($activity)
             ->setProject($project)
-            ->setBegin(new \DateTime())
+            ->setBegin(new \DateTime('2018-11-29'))
             ->setEnd(new \DateTime())
             ->addTag((new Tag())->setName('foo'))
             ->addTag((new Tag())->setName('bar'))
@@ -70,7 +70,7 @@ class ShortInvoiceCalculatorTest extends AbstractCalculatorTest
             ->setUser(new User())
             ->setActivity($activity)
             ->setProject($project)
-            ->setBegin(new \DateTime())
+            ->setBegin(new \DateTime('2018-11-28'))
             ->setEnd(new \DateTime())
             ->addTag((new Tag())->setName('bar1'))
         ;
@@ -83,7 +83,7 @@ class ShortInvoiceCalculatorTest extends AbstractCalculatorTest
             ->setUser(new User())
             ->setActivity($activity)
             ->setProject($project)
-            ->setBegin(new \DateTime())
+            ->setBegin(new \DateTime('2018-11-29'))
             ->setEnd(new \DateTime())
         ;
 
@@ -106,8 +106,11 @@ class ShortInvoiceCalculatorTest extends AbstractCalculatorTest
         $this->assertEquals(5800, $sut->getTimeWorked());
         $this->assertEquals(1, \count($sut->getEntries()));
 
-        /** @var InvoiceItem $result */
-        $result = $sut->getEntries()[0];
+        $entries = $sut->getEntries();
+        self::assertCount(1, $entries);
+        $result = $entries[0];
+
+        $this->assertEquals('2018-11-28', $result->getBegin()->format('Y-m-d'));
         $this->assertEquals('activity description', $result->getDescription());
         $this->assertEquals(293.27, $result->getHourlyRate());
         $this->assertNull($result->getFixedRate());

--- a/tests/Invoice/Calculator/ShortInvoiceCalculatorTest.php
+++ b/tests/Invoice/Calculator/ShortInvoiceCalculatorTest.php
@@ -110,7 +110,7 @@ class ShortInvoiceCalculatorTest extends AbstractCalculatorTest
         self::assertCount(1, $entries);
         $result = $entries[0];
 
-        $this->assertEquals('2018-11-28', $result->getBegin()->format('Y-m-d'));
+        $this->assertEquals('2018-11-28', $result->getBegin()?->format('Y-m-d'));
         $this->assertEquals('activity description', $result->getDescription());
         $this->assertEquals(293.27, $result->getHourlyRate());
         $this->assertNull($result->getFixedRate());

--- a/tests/Invoice/Calculator/UserInvoiceCalculatorTest.php
+++ b/tests/Invoice/Calculator/UserInvoiceCalculatorTest.php
@@ -53,7 +53,7 @@ class UserInvoiceCalculatorTest extends AbstractCalculatorTest
 
         $timesheet = new Timesheet();
         $timesheet
-            ->setBegin(new \DateTime())
+            ->setBegin(new \DateTime('2018-11-29'))
             ->setEnd(new \DateTime())
             ->setDuration(3600)
             ->setRate(293.27)
@@ -63,7 +63,7 @@ class UserInvoiceCalculatorTest extends AbstractCalculatorTest
 
         $timesheet2 = new Timesheet();
         $timesheet2
-            ->setBegin(new \DateTime())
+            ->setBegin(new \DateTime('2018-11-28'))
             ->setEnd(new \DateTime())
             ->setDuration(400)
             ->setRate(84.75)
@@ -73,7 +73,7 @@ class UserInvoiceCalculatorTest extends AbstractCalculatorTest
 
         $timesheet3 = new Timesheet();
         $timesheet3
-            ->setBegin(new \DateTime())
+            ->setBegin(new \DateTime('2018-11-08'))
             ->setEnd(new \DateTime())
             ->setDuration(1800)
             ->setRate(111.11)
@@ -83,7 +83,7 @@ class UserInvoiceCalculatorTest extends AbstractCalculatorTest
 
         $timesheet4 = new Timesheet();
         $timesheet4
-            ->setBegin(new \DateTime())
+            ->setBegin(new \DateTime('2018-11-28'))
             ->setEnd(new \DateTime())
             ->setDuration(400)
             ->setRate(1947.99)

--- a/tests/Invoice/Calculator/WeeklyInvoiceCalculatorTest.php
+++ b/tests/Invoice/Calculator/WeeklyInvoiceCalculatorTest.php
@@ -126,9 +126,8 @@ class WeeklyInvoiceCalculatorTest extends AbstractCalculatorTest
 
         $entries = $sut->getEntries();
         self::assertCount(2, $entries);
-        $this->assertEquals(378.02, $entries[0]->getRate());
-        $this->assertEquals(2143.1, $entries[1]->getRate());
-        self::assertEquals(2521.12, $entries[0]->getRate() + $entries[1]->getRate());
+        $this->assertEquals(378.02, $entries[1]->getRate());
+        $this->assertEquals(2143.1, $entries[0]->getRate());
     }
 
     public function testDescriptionByTimesheet(): void


### PR DESCRIPTION
## Description

prevent that items from different repositories show up after another instead of being sorted within the daterange of all items

example:
expenses were sorted by date as well, but they followed after all timesheets.
with this change, the expenses will be sorted as line items within all entries, so they do not show up at the end anymore.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] I verified that my code applies to the guidelines (`composer code-check`)
- [ ] I updated the documentation (see [here](https://github.com/kimai/www.kimai.org/tree/master/_documentation))
- [x] I agree that this code is used in Kimai (see [license](https://github.com/kimai/kimai/blob/main/LICENSE))
