### PR TITLE
Docker: set a proper database URL including full version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -238,7 +238,7 @@ COPY --from=php-ext-redis /usr/local/etc/php/conf.d/docker-php-ext-redis.ini /us
 COPY --from=php-ext-redis /usr/local/lib/php/extensions/no-debug-non-zts-20220829/redis.so /usr/local/lib/php/extensions/no-debug-non-zts-20220829/redis.so
 COPY --from=php-ext-opcache /usr/local/etc/php/conf.d/docker-php-ext-opcache.ini  /usr/local/etc/php/conf.d/docker-php-ext-opcache.ini
 
-ENV DATABASE_URL=sqlite:///%kernel.project_dir%/var/data/kimai.sqlite
+ENV DATABASE_URL="mysql://kimai:kimai@127.0.0.1:3306/kimai?charset=utf8mb4&serverVersion=5.7.40"
 ENV APP_SECRET=change_this_to_something_unique
 # The default container name for nginx is nginx
 ENV TRUSTED_PROXIES=nginx,localhost,127.0.0.1


### PR DESCRIPTION
## Description

There are currently errors during "Test lite" in the docker builds:
https://github.com/kimai/kimai/actions/runs/7241462128

```
In ExceptionConverter.php line 101:
                                                                               
  An exception occurred in the driver: SQLSTATE[HY000] [200] No such file or  directory                                                                   
```

I assume that Doctrine changed behavior and now tries to query that none existing sqlite file.

The new database URL is a fully functioning URI, which hopefully prevents doctrine from querying the database server upon startup for the "full server version".

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] I verified that my code applies to the guidelines (`composer code-check`)
- [x] I agree that this code is used in Kimai (see [license](https://github.com/kimai/kimai/blob/main/LICENSE))
