### PR TITLE
[BUGFIX] Fix wrong default protocol for homepage

### DIFF
--- a/src/Form/CustomerEditForm.php
+++ b/src/Form/CustomerEditForm.php
@@ -103,6 +103,7 @@ class CustomerEditForm extends AbstractType
                 'label' => 'homepage',
                 'required' => false,
                 'block_prefix' => 'homepage',
+                'default_protocol' => 'https',
             ])
             ->add('timezone', TimezoneType::class, [
                 'label' => 'timezone',

--- a/templates/form/blocks.html.twig
+++ b/templates/form/blocks.html.twig
@@ -394,9 +394,9 @@
 {# customer homepage, search for "homepage" block_prefix #}
 {% block homepage_widget -%}
     <div class="input-group input-group-flat">
-        <span class="input-group-text">
-            https://
-        </span>
+        {% if '://' not in value  %}
+            <span class="input-group-text">https://</span>
+        {% endif %}
         {{ block('url_widget') }}
     </div>
 {%- endblock homepage_widget %}


### PR DESCRIPTION
Resolves: #4513

## Description
The label specifies that when entering a homepage, it will be prefixed with https which does not happen. Instead it will be prefixed with http.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] I verified that my code applies to the guidelines (`composer code-check`)
- [ ] I updated the documentation (see [here](https://github.com/kimai/www.kimai.org/tree/master/_documentation))
- [x] I agree that this code is used in Kimai (see [license](https://github.com/kimai/kimai/blob/main/LICENSE))
