### PR TITLE
Hotfix to re-enable PHP/Kimai test

### DIFF
--- a/.docker/test-lite.sh
+++ b/.docker/test-lite.sh
@@ -1,7 +1,7 @@
 #!/bin/sh -e
 
 if [ -z "$DATABASE_URL" ]; then
-  export DATABASE_URL="mysql://kimai:kimai@127.0.0.1:3306/kimai?charset=utf8mb4&serverVersion=5.7.40"
+  DATABASE_URL="mysql://kimai:kimai@127.0.0.1:3306/kimai?charset=utf8mb4&serverVersion=5.7.40"
 fi
 
 /opt/kimai/bin/console kimai:version

--- a/.docker/test-lite.sh
+++ b/.docker/test-lite.sh
@@ -1,13 +1,14 @@
 #!/bin/sh -e
 
-# Test PHP/Kimai
-# This does not work currently, as a real database is required
-# see https://github.com/kimai/kimai/issues/4503
-#/opt/kimai/bin/console kimai:version
-#if [ $? != 0 ]; then
-#  echo "PHP/Kimai not responding"
-#  exit 1
-#fi
+if [ -z "$DATABASE_URL" ]; then
+  export DATABASE_URL="mysql://kimai:kimai@127.0.0.1:3306/kimai?charset=utf8mb4&serverVersion=5.7.40"
+fi
+
+/opt/kimai/bin/console kimai:version
+if [ $? != 0 ]; then
+  echo "PHP/Kimai not responding"
+  exit 1
+fi
 
 # Test FPM CGI
 if [ -f /use_fpm ]; then


### PR DESCRIPTION
## Description
This hotfix reenable /opt/kimai/bin/console kimai:version during CI/CD, closing issue #4503 and takes in consideration https://github.com/kimai/kimai/pull/4504/commits/48d86d41b284396e6fff277aad81305b28d39c4e. It should be analyzed if DATABASE_URL defined in the Dockerfile is still mandatory.

A later PR may fix this issue in a more complete way (for example spinning up a real mysql database), but in the meantime it permits to execute the kimai:version test.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] I verified that my code applies to the guidelines (`composer code-check`)
- [ ] I updated the documentation (see [here](https://github.com/kimai/www.kimai.org/tree/master/_documentation))
- [x] I agree that this code is used in Kimai (see [license](https://github.com/kimai/kimai/blob/main/LICENSE))
