### PR TITLE
allow to edit username

### DIFF
--- a/src/Controller/ProfileController.php
+++ b/src/Controller/ProfileController.php
@@ -309,15 +309,18 @@ final class ProfileController extends AbstractController
 
     private function createEditForm(User $user): FormInterface
     {
+        $currentUser = $this->getUser();
+
         return $this->createForm(
             UserEditType::class,
             $user,
             [
                 'action' => $this->generateUrl('user_profile_edit', ['username' => $user->getUserIdentifier()]),
                 'method' => 'POST',
-                'include_active_flag' => ($user->getId() !== $this->getUser()->getId()),
+                'include_active_flag' => $user !== $currentUser,
                 'include_preferences' => true,
                 'include_supervisor' => $this->isGranted('supervisor', $user),
+                'include_username' => $currentUser->isSuperAdmin() && $currentUser !== $user,
                 'include_password_reset' => $this->isGranted('password', $user),
             ]
         );

--- a/src/Form/UserEditType.php
+++ b/src/Form/UserEditType.php
@@ -42,6 +42,14 @@ class UserEditType extends AbstractType
             $user = $options['data'];
         }
 
+        if ($options['include_username']) {
+            $builder->add('username', TextType::class, [
+                'label' => 'user_identifier',
+                'help' => 'user_identifier.help',
+                'required' => true,
+            ]);
+        }
+
         $builder->add('alias', TextType::class, [
             'label' => 'alias',
             'required' => false,
@@ -117,6 +125,7 @@ class UserEditType extends AbstractType
             'include_active_flag' => true,
             'include_preferences' => true,
             'include_supervisor' => true,
+            'include_username' => false,
             'include_password_reset' => true,
         ]);
     }

--- a/templates/user/layout.html.twig
+++ b/templates/user/layout.html.twig
@@ -15,7 +15,7 @@
                             <div class="col-auto" data-toggle="tooltip" title="{{ 'id'|trans }}: {{ user.id }}">
                                 {{ widgets.user_avatar(user, false, 'avatar-lg') }}
                             </div>
-                            <div class="col" style="min-width: 100px">
+                            <div class="col" style="min-width: 100px"{% block user_title_box_attributes %}{% endblock %}>
                                 <h4 class="card-title m-0">{{ widgets.username(user) }}</h4>
                                 {% if user.title is not empty %}
                                 <div class="text-body-secondary">

--- a/templates/user/profile.html.twig
+++ b/templates/user/profile.html.twig
@@ -1,5 +1,11 @@
 {% extends 'user/form.html.twig' %}
 
+{% block user_title_box_attributes %}
+    {% if form.username is defined %}
+        ondblclick="document.getElementById('user_edit_username_hidden').style.display = 'flex'"
+    {% endif %}
+{% endblock %}
+
 {% block form_content %}
 
     {% form_theme form 'form/horizontal.html.twig' %}
@@ -9,6 +15,13 @@
     <fieldset class="form-fieldset form-fieldset-light">
         {{ form_row(form.alias) }}
         {{ form_row(form.email) }}
+        {% if form.username is defined %}
+            {% set styleUsername = 'display:none' %}
+            {% if form.username.vars.errors|length > 0 %}
+                {% set styleUsername = '' %}
+            {% endif %}
+            {{ form_row(form.username, {row_attr: {id: 'user_edit_username_hidden', style: styleUsername}}) }}
+        {% endif %}
     </fieldset>
 
     <fieldset class="form-fieldset form-fieldset-light">

--- a/translations/messages.de.xlf
+++ b/translations/messages.de.xlf
@@ -1693,6 +1693,14 @@
         <source>unpaid_vacation</source>
         <target>Unbezahlter Urlaub</target>
       </trans-unit>
+      <trans-unit id="q59lI2y" resname="user_identifier">
+        <source>user_identifier</source>
+        <target>Benutzer ID</target>
+      </trans-unit>
+      <trans-unit id="uqv2Lrv" resname="user_identifier.help">
+        <source>user_identifier.help</source>
+        <target>Die eindeutige Benutzerkennung wird zur Authentifizierung und bei Exporten verwendet</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/translations/messages.en.xlf
+++ b/translations/messages.en.xlf
@@ -1693,6 +1693,14 @@
         <source>unpaid_vacation</source>
         <target>Unpaid holidays</target>
       </trans-unit>
+      <trans-unit id="q59lI2y" resname="user_identifier">
+        <source>user_identifier</source>
+        <target>User ID</target>
+      </trans-unit>
+      <trans-unit id="uqv2Lrv" resname="user_identifier.help">
+        <source>user_identifier.help</source>
+        <target>The unique user identifier is used for authentication and in exports</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>


### PR DESCRIPTION
## Description

This adds the option to edit the `username`:
- Only available for `ROLE_SUPER_ADMIN`
- A super-admin **cannot** edit his own username, as this would cause conflicts with the security system (e.g. an immediately logout would happen)

The form field is hidden by default.
<img width="680" alt="Bildschirmfoto 2024-01-12 um 22 34 55" src="https://github.com/kimai/kimai/assets/533162/bf6c430c-dc9e-459c-b777-328fd0362ef1">

Upon double clicking the username, the field will be shown:
![image](https://github.com/kimai/kimai/assets/533162/c2b93f30-1a75-4541-aa4b-e4fb2699ba3a)

This is a security measure, as the username should normally not be changed.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] I verified that my code applies to the guidelines (`composer code-check`)
- [ ] I updated the documentation (see [here](https://github.com/kimai/www.kimai.org/tree/master/_documentation))
- [x] I agree that this code is used in Kimai (see [license](https://github.com/kimai/kimai/blob/main/LICENSE))
