### PR TITLE
Make 'pagebreak' optional in pdf layout exporter

### DIFF
--- a/cp.sh
+++ b/cp.sh
@@ -1,0 +1,4 @@
+cp templates/export/renderer/derksen-it-timesheet.pdf.twig \
+   templates/invoice/renderer/derksen-it.pdf.twig \
+   templates/export/pdf-layout.html.twig \
+   /net/192.168.12.120/volume1/docker/kimai/

--- a/templates/export/pdf-layout.html.twig
+++ b/templates/export/pdf-layout.html.twig
@@ -8,6 +8,7 @@
 {% set showCustomerSummary = showCustomerSummary ?? true %}
 {% set showTotalSummary = showTotalSummary ?? true %}
 {% set showDateTimeShort = showDateTimeShort ?? false %}
+{% set showPageBreak = showPageBreak ?? true %}
 {% set now = create_date('now', app.user) %}
 {% set decimal = decimal ?? false %}
 {# this is only triggered, if a user exports from his personal timesheet screen #}
@@ -220,7 +221,9 @@ mpdf-->
         </tbody>
     </table>
 
-    <pagebreak>
+    {% if showPageBreak %}
+        <pagebreak>
+    {% endif %}
 {% endblock %}
 {% block items %}
     {% block items_header %}

--- a/templates/export/renderer/derksen-it-timesheet.pdf.twig
+++ b/templates/export/renderer/derksen-it-timesheet.pdf.twig
@@ -1,0 +1,49 @@
+{% extends 'export/pdf-layout.html.twig' %}
+{% set showRateColumn = false %}
+{% set showRateBudget = false %}
+{% set showTimeBudget = false %}
+{% set showUserColumn = true %}
+{% set showPageBreak = false %}
+{% set showCustomerSummary = false %}
+{% set showTotalSummary = false %}
+{% set decimal = true %}
+{% set showDateTimeShort = true %}
+
+{% block description %}
+        {{ entry.activity.name }}
+{% endblock %}
+
+{% block items_header %}
+<br>
+{% endblock %}
+{% block summary_header %}
+    <h2 style="margin-bottom: 4px; padding-bottom: 0">{% block title %}{{ 'Uren verantwoording'|trans }}{% endblock %}</h2>
+    {% if query is defined %}
+    <p>
+        {{ 'export.period'|trans }}:
+        {{ query.begin|date_short }} - {{ query.end|date_short }}
+    </p>
+    {% endif %}
+{% endblock %}
+
+{% block pdf_footer %}
+<!--mpdf
+<htmlpagefooter name="myfooter">
+<table class="items">
+    <thead>
+    <tr>
+        <th>{{ 'Datum' }}</th>
+        <th>{{ 'Naam en handtekening' }}</th>
+    </tr>
+    </thead>
+    <tr>
+        <td>
+<div style="height:100px;font-size:100px;">&nbsp;</div>
+        </td>
+        <td><br></td>
+    </tr>
+</table>
+</htmlpagefooter>
+<sethtmlpagefooter name="myfooter" value="on" />
+mpdf-->
+{% endblock %}

--- a/templates/invoice/renderer/derksen-it.pdf.twig
+++ b/templates/invoice/renderer/derksen-it.pdf.twig
@@ -1,0 +1,157 @@
+<!DOCTYPE html>
+<html lang="{{ invoice['invoice.language'] }}">
+<head>
+    <meta charset="utf-8">
+    <title>{% block title %}{{ invoice['invoice.number'] }}-{{ invoice['customer.company']|default(invoice['customer.name'])|u.snake }}{% endblock %}</title>
+    <style>
+        {{ encore_entry_css_source('invoice-pdf')|raw }}
+    </style>
+</head>
+<body>
+<!--mpdf
+<htmlpageheader name="header">
+    <table class="header">
+        <tr>
+            <td class="title">
+                {{ invoice['template.title'] }}
+            </td>
+            <td class="date text-right">
+                {{ 'date'|trans }}: {{ invoice['invoice.date'] }}
+            </td>
+        </tr>
+    </table>
+</htmlpageheader>
+<sethtmlpageheader name="header" page="ALL" value="on" show-this-page="1" />
+<htmlpagefooter name="footer">
+    <table class="footer">
+        <tr>
+            <td>
+                <strong>{{ 'contact'|trans }}</strong>:
+                {{ invoice['template.contact']|nl2str(' – ') }}
+                <br>
+                <strong>{{ 'invoice_bank_account'|trans }}</strong>:
+                {{ invoice['template.payment_details']|nl2str(' – ') }}
+            </td>
+            <td align="right">
+                {{ 'export.page_of'|trans({'%page%': '{PAGENO}', '%pages%': '{nb}'}) }}
+            </td>
+        </tr>
+    </table>
+</htmlpagefooter>
+<sethtmlpagefooter page="ALL" value="on" name="footer" show-this-page="1" />
+mpdf-->
+    <table class="addresses">
+        <tr>
+            <td style="width:60%">
+                {{ 'invoice.to'|trans }}
+                <br>
+                <strong>{{ invoice['customer.company']|default(invoice['customer.name']) }}</strong>
+                <br>
+                {{ invoice['customer.address']|nl2br }}
+                {% if invoice['customer.vat_id'] is not empty %}
+                    <br>
+                    {{ 'vat_id'|trans }}: {{ invoice['customer.vat_id'] }}
+                {% endif %}
+            </td>
+            <td>
+                {{ 'invoice.from'|trans }}
+                <br>
+                <strong>{{ invoice['template.company'] }}</strong>
+                <br>
+                {{ invoice['template.address']|trim|nl2br }}
+                {% if invoice['template.vat_id'] is not empty %}
+                    <br>
+                    {{ 'vat_id'|trans }}:
+                    {{ invoice['template.vat_id'] }}
+                {% endif %}
+            </td>
+        </tr>
+    </table>
+
+    <p>
+        {{ 'invoice.number'|trans }}:
+        {{ invoice['invoice.number'] }}
+
+        <br>
+        {{ 'invoice.due_days'|trans }}:
+        {{ invoice['invoice.due_date'] }}
+
+        {% if invoice['customer.number'] is not empty %}
+            <br>
+            {{ 'number'|trans }}:
+            {{ invoice['customer.number'] }}
+        {% endif %}
+
+        {% if invoice['query.project.order_number'] is defined and invoice['query.project.order_number'] is not empty %}
+            <br>
+            {{ 'orderNumber'|trans }}:
+            {{ invoice['query.project.order_number'] }}
+        {% endif %}
+    </p>
+
+    {% if invoice['customer.invoice_text'] is not empty%}
+        <p>{{ invoice['customer.invoice_text']|md2html }}</p>
+    {% endif %}
+
+    <table class="items">
+        <thead>
+            <tr>
+                <th style="width:60%"><strong>{{ 'description'|trans }}</strong></th>
+                <th class="text-right"><strong>{{ 'unit_price'|trans }}</strong></th>
+                <th class="text-right"><strong>{{ 'amount'|trans }}</strong></th>
+                <th class="last text-right"><strong>{{ 'total_rate'|trans }}</strong></th>
+            </tr>
+        </thead>
+        <tbody>
+        {% for invoiceLineItem in entries %}
+            <!-- CONTENT_PART -->
+            <tr>
+                <td>
+                    {% if invoiceLineItem['entry.description'] is not empty %}
+                        {{ invoiceLineItem['entry.description']|nl2br }}
+                    {% else %}
+                        {% if invoiceLineItem['entry.activity'] is defined %}
+                            {{ invoiceLineItem['entry.activity'] }} /
+                        {% endif %}
+                        {{ invoiceLineItem['entry.project'] }}
+                    {% endif %}
+                </td>
+                <td nowrap class="text-nowrap text-right">{{ invoiceLineItem['entry.rate'] }}</td>
+                <td nowrap class="text-nowrap text-right">{{ invoiceLineItem['entry.amount'] }}</td>
+                <td nowrap class="last text-nowrap text-right">{{ invoiceLineItem['entry.total'] }}</td>
+            </tr>
+        {% endfor %}
+        </tbody>
+        <tfoot>
+            {% if not invoice['invoice.tax_hide'] %}
+            <tr>
+                <td colspan="3" class="text-right">
+                    {{ 'invoice.subtotal'|trans }}
+                </td>
+                <td class="last text-right">{{ invoice['invoice.subtotal'] }}</td>
+            </tr>
+            <tr>
+                <td colspan="3" class="text-right">
+                    {{ 'invoice.tax'|trans }} ({{ invoice['invoice.vat'] }}%)
+                </td>
+                <td class="last text-right">{{ invoice['invoice.tax'] }}</td>
+            </tr>
+            {% endif %}
+            <tr>
+                <td colspan="3" class="text-right text-nowrap">
+                    <strong>{{ 'invoice.total'|trans }}</strong>
+                </td>
+                <td class="last text-right">
+                    <strong>{{ invoice['invoice.total'] }}</strong>
+                </td>
+            </tr>
+        </tfoot>
+    </table>
+
+    {% if invoice['template.payment_terms'] is not empty %}
+        <div class="paymentTerms">
+            {{ invoice['template.payment_terms']|md2html }}
+        </div>
+    {% endif %}
+</body>
+</html>


### PR DESCRIPTION
## Description
To make a sign-able timesheet on paper the pagebreak needs to be removed.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] I verified that my code applies to the guidelines (`composer code-check`)
- [ ] I updated the documentation (see [here](https://github.com/kimai/www.kimai.org/tree/master/_documentation))
- [x] I agree that this code is used in Kimai (see [license](https://github.com/kimai/kimai/blob/main/LICENSE))
