### PR TITLE
Make 'pagebreak' optional in pdf layout exporter

### DIFF
--- a/templates/export/pdf-layout.html.twig
+++ b/templates/export/pdf-layout.html.twig
@@ -8,6 +8,7 @@
 {% set showCustomerSummary = showCustomerSummary ?? true %}
 {% set showTotalSummary = showTotalSummary ?? true %}
 {% set showDateTimeShort = showDateTimeShort ?? false %}
+{% set showPageBreak = showPageBreak ?? true %}
 {% set now = create_date('now', app.user) %}
 {% set decimal = decimal ?? false %}
 {# this is only triggered, if a user exports from his personal timesheet screen #}
@@ -220,7 +221,9 @@ mpdf-->
         </tbody>
     </table>
 
-    <pagebreak>
+    {% if showPageBreak %}
+        <pagebreak>
+    {% endif %}
 {% endblock %}
 {% block items %}
     {% block items_header %}


### PR DESCRIPTION
## Description
To make a sign-able timesheet on paper the pagebreak needs to be removed.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] I verified that my code applies to the guidelines (`composer code-check`)
- [ ] I updated the documentation (see [here](https://github.com/kimai/www.kimai.org/tree/master/_documentation))
- [x] I agree that this code is used in Kimai (see [license](https://github.com/kimai/kimai/blob/main/LICENSE))
