### PR TITLE
support default time on date-time-picker

### DIFF
--- a/src/Form/Type/DateTimePickerType.php
+++ b/src/Form/Type/DateTimePickerType.php
@@ -166,9 +166,9 @@ class DateTimePickerType extends AbstractType
             'minute' => ''
         ];
 
-        if (is_string($time)) {
+        if (\is_string($time)) {
             $times = explode(':', $time);
-            if (count($times) > 1) {
+            if (\count($times) > 1) {
                 $values['hour'] = $times[0];
                 $values['minute'] = $times[1];
             }

--- a/src/Form/Type/DateTimePickerType.php
+++ b/src/Form/Type/DateTimePickerType.php
@@ -48,6 +48,17 @@ class DateTimePickerType extends AbstractType
             'view_timezone',
         ]));
 
+        $defaultTime = ['hour' => '', 'minute' => ''];
+
+        if (\array_key_exists('force_time', $options)) {
+            $tmp = $options['force_time'];
+            if (\is_string($tmp)) {
+                $defaultTime = $this->parseTime($tmp);
+                unset($options['force_time']);
+                $timeOptions['required'] = false;
+            }
+        }
+
         if (false === $options['label']) {
             $dateOptions['label'] = false;
             $timeOptions['label'] = false;
@@ -79,7 +90,7 @@ class DateTimePickerType extends AbstractType
                     function ($transform) {
                         return $transform;
                     },
-                    function ($reverseTransform) {
+                    function ($reverseTransform) use ($defaultTime) {
                         if (\array_key_exists('date', $reverseTransform) && $reverseTransform['date'] === null) {
                             $reverseTransform['time'] = [
                                 'year' => '',
@@ -89,10 +100,7 @@ class DateTimePickerType extends AbstractType
                         }
                         // happened in DateTimePickerType - made it impossible to create an empty DateTime
                         if (\array_key_exists('time', $reverseTransform) && $reverseTransform['time'] === null) {
-                            $reverseTransform['time'] = [
-                                'hour' => '',
-                                'minute' => '',
-                            ];
+                            $reverseTransform['time'] = $defaultTime;
                         }
 
                         return $reverseTransform;
@@ -132,6 +140,7 @@ class DateTimePickerType extends AbstractType
                 return $options['compound'] ? [] : '';
             },
             'invalid_message' => 'Please enter a valid date and time.',
+            'force_time' => null, // one of: string (start, end) or a string to as argument for DateTime->modify() or null
         ]);
 
         // Don't add some defaults in order to preserve the defaults
@@ -145,6 +154,27 @@ class DateTimePickerType extends AbstractType
             'datetime',
             'string',
         ]);
+    }
+
+    /**
+     * @return array{'hour': string, 'minute': string}
+     */
+    private function parseTime(?string $time): array
+    {
+        $values = [
+            'hour' => '',
+            'minute' => ''
+        ];
+
+        if (is_string($time)) {
+            $times = explode(':', $time);
+            if (count($times) > 1) {
+                $values['hour'] = $times[0];
+                $values['minute'] = $times[1];
+            }
+        }
+
+        return $values;
     }
 
     public function getBlockPrefix(): string


### PR DESCRIPTION
## Description

allows to set a default time on date-time-picker, which will be used as fallback if time = null

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist
- [x] I verified that my code applies to the guidelines (`composer code-check`)
- [x] I agree that this code is used in Kimai (see [license](https://github.com/kimai/kimai/blob/main/LICENSE))
