### PR TITLE
use skopeo to preserve multi-arch lists during the tag operation

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -63,44 +63,30 @@ jobs:
                   username: ${{secrets.DOCKERHUB_USERNAME}}
                   password: ${{secrets.DOCKERHUB_PASSWORD}}
 
-            - name: Pull images
-              run: |
-                  docker pull kimai/kimai2:fpm-prod
-                  docker pull kimai/kimai2:fpm-dev
-                  docker pull kimai/kimai2:apache-prod
-                  docker pull kimai/kimai2:apache-dev
-
             - name: Tag fpm
               run: |
-                  docker tag kimai/kimai2:fpm-prod kimai/kimai2:fpm
-                  docker push kimai/kimai2:fpm
+                  skopeo copy --all docker://kimai/kimai2:fpm-prod docker://kimai/kimai2:fpm
 
             - name: Tag fpm latest
               run: |
-                  docker tag kimai/kimai2:fpm-prod kimai/kimai2:fpm-latest
-                  docker push kimai/kimai2:fpm-latest
+                  skopeo copy --all docker://kimai/kimai2:fpm-prod docker://kimai/kimai2:fpm-latest
 
             - name: Tag latest
               run: |
-                  docker tag kimai/kimai2:fpm-prod kimai/kimai2:latest
-                  docker push kimai/kimai2:latest
+                  skopeo copy --all docker://kimai/kimai2:fpm-prod docker://kimai/kimai2:latest
 
             - name: Tag prod
               run: |
-                  docker tag kimai/kimai2:fpm-prod kimai/kimai2:prod
-                  docker push kimai/kimai2:prod
+                  skopeo copy --all docker://kimai/kimai2:fpm-prod docker://kimai/kimai2:prod
 
             - name: Tag apache
               run: |
-                  docker tag kimai/kimai2:apache-prod kimai/kimai2:apache
-                  docker push kimai/kimai2:apache
+                  skopeo copy --all docker://kimai/kimai2:apache-prod docker://kimai/kimai2:apache
 
             - name: Tag apache latest
               run: |
-                  docker tag kimai/kimai2:apache-prod kimai/kimai2:apache-latest
-                  docker push kimai/kimai2:apache-latest
+                  skopeo copy --all docker://kimai/kimai2:apache-prod docker://kimai/kimai2:apache-latest
 
             - name: Tag dev
               run: |
-                  docker tag kimai/kimai2:apache-dev kimai/kimai2:dev
-                  docker push kimai/kimai2:dev
+                  skopeo copy --all docker://kimai/kimai2:apache-dev docker://kimai/kimai2:dev


### PR DESCRIPTION
## Description
This is an attempt to resolve #4591 using skopeo instead of docker: skopeo has the capability to clone list of images.

ubuntu-latest runner that Kimai is actually using comes with skopeo already [preinstalled](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md) and skopeo should fallback to credentials created in step _Login to DockerHub_.

Before approving this PR, @tobybatch or @kevinpapst should verifiy that everything is fine because I'm not able to test a complete workflow. 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] I verified that my code applies to the guidelines (`composer code-check`)
- [ ] I updated the documentation (see [here](https://github.com/kimai/www.kimai.org/tree/master/_documentation))
- [x] I agree that this code is used in Kimai (see [license](https://github.com/kimai/kimai/blob/main/LICENSE))
