### PR TITLE
Docker: Fix TLS certificate verification for LDAP connections

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -171,6 +171,7 @@ RUN apt-get update && \
         bash \
         haveged \
         libicu72 \
+        libldap-common \
         libpng16-16 \
         libzip4 \
         libxslt1.1 \


### PR DESCRIPTION
## Description
PR #4476 changed the Debian version of the Docker base image to Bookworm. Since then, LDAP connections with TLS are failing. We noticed this only several days after updating Kimai from 2.3.0 to 2.9.0, because logins don't occur that often.

It was quite tricky to find the source of this. Logins of existing users simply looked like one was using the wrong password, logging in with usernames unknown to Kimai resulted in an HTTP status code 500 (`Can't contact LDAP server; (unknown error code)`).

In the end, the the only missing thing was the file `/etc/ldap/ldap.conf` which sets the path where to find the Root CA certificates. Final confirmation came from https://github.com/docker-library/php/issues/1194. 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] I verified that my code applies to the guidelines (`composer code-check`)
- [ ] I updated the documentation (see [here](https://github.com/kimai/www.kimai.org/tree/master/_documentation))
- [x] I agree that this code is used in Kimai (see [license](https://github.com/kimai/kimai/blob/main/LICENSE))
