### PR TITLE
Use duration instead of durationBillable for time budget

### DIFF
--- a/templates/embeds/budgets.html.twig
+++ b/templates/embeds/budgets.html.twig
@@ -32,7 +32,7 @@
                         </tr>
                         {% set totalPercentReached = 100 %}
                         {% if entity.timeBudget > 0 %}
-                            {% set totalPercentReached = (stats.durationBillable / (entity.timeBudget / 100)) %}
+                            {% set totalPercentReached = (stats.duration / (entity.timeBudget / 100)) %}
                         {% endif %}
                         <tr>
                             <td>{{ durationTrans|trans }}</td>
@@ -64,7 +64,7 @@
                         <tr>
                             <th colspan="3" class="text-nowrap text-end">
                                 {% if totalPercentReached < 100 %}
-                                    {{ 'stats.percentUsedLeft'|trans({'%percent%': totalPercentReached|number_format(2), '%left%': (entity.timeBudget - stats.durationBillable)|duration}) }}
+                                    {{ 'stats.percentUsedLeft'|trans({'%percent%': totalPercentReached|number_format(2), '%left%': (entity.timeBudget - stats.duration)|duration}) }}
                                 {% else %}
                                     {{ 'stats.percentUsed'|trans({'%percent%': totalPercentReached|number_format(2)}) }}
                                 {% endif %}
@@ -75,7 +75,7 @@
                 </div>
                 <div class="col-12 col-md-6 order-0 order-md-1 p-3">
                     {% if entity.timeBudget > 0 %}
-                        <div class="mb-3">{{ progress.progressbar(entity.timeBudget, stats.durationBillable, durationTrans|trans, stats.durationBillable|duration ~ ' / ' ~ entity.timeBudget|duration) }}</div>
+                        <div class="mb-3">{{ progress.progressbar(entity.timeBudget, stats.duration, durationTrans|trans, stats.duration|duration ~ ' / ' ~ entity.timeBudget|duration) }}</div>
                     {% endif %}
                     <div class="mb-3">{{ progress.progressbar(stats.duration, stats.durationBillable, 'billable'|trans, stats.durationBillable|duration ~ ' / ' ~ stats.duration|duration, true) }}</div>
                 </div>


### PR DESCRIPTION
## Description
Use the ``duration`` field for Working Hours calculations, since ``durationBillable`` field is already used for the Billable calculations

I am unsure if this should be considered a bug-fix or a breaking change (rule https://xkcd.com/1172/ applies :-) ), but for my use case this is a fix, hence marking as such.

The behavior before this change is not considering working hours that are not billable in the statistics against the time budget for an activity, as per the following screenshot:
![before](https://github.com/kimai/kimai/assets/352756/7970cbc5-a737-4429-922e-dbcdaa5a1b2a)

With the changes applied, the same activity looks as follows:
![after](https://github.com/kimai/kimai/assets/352756/e77783de-5f82-4475-aa98-b783e5444852)

I consider this an improvement since the "Working Hours" are a subset of the "Time Budget", and the "Billable" hours are a subset of the "Working Hours".

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] I verified that my code applies to the guidelines (`composer code-check`)
- [ ] I updated the documentation (see [here](https://github.com/kimai/www.kimai.org/tree/master/_documentation))
- [x] I agree that this code is used in Kimai (see [license](https://github.com/kimai/kimai/blob/main/LICENSE))

