### PR TITLE
Add Project and Activity grouping for invoice entries

### DIFF
--- a/src/Invoice/Calculator/ProjectActivityInvoiceCalculator.php
+++ b/src/Invoice/Calculator/ProjectActivityInvoiceCalculator.php
@@ -1,0 +1,62 @@
+<?php
+
+/*
+ * This file is part of the Kimai time-tracking app.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Invoice\Calculator;
+
+use App\Entity\ExportableItem;
+use App\Invoice\CalculatorInterface;
+use App\Invoice\InvoiceItem;
+
+/**
+ * A calculator that sums up the invoice item records by project and activity.
+ */
+final class ProjectActivityInvoiceCalculator extends AbstractSumInvoiceCalculator implements CalculatorInterface
+{
+    public function getIdentifiers(ExportableItem $invoiceItem): array
+    {
+        if ($invoiceItem->getProject() === null) {
+            throw new \Exception('Cannot handle invoice items without project');
+        }
+
+        if ($invoiceItem->getProject()->getId() === null) {
+            throw new \Exception('Cannot handle un-persisted projects');
+        }
+
+        if ($invoiceItem->getActivity() === null) {
+            throw new \Exception('Cannot handle invoice items without activity');
+        }
+
+        if ($invoiceItem->getActivity()->getId() === null) {
+            throw new \Exception('Cannot handle un-persisted activities');
+        }
+
+        return [
+            $invoiceItem->getProject()->getId(),
+            $invoiceItem->getActivity()->getId()
+        ];
+    }
+
+    protected function mergeSumInvoiceItem(InvoiceItem $invoiceItem, ExportableItem $entry): void
+    {
+        if ($entry->getProject() === null) {
+            return;
+        }
+
+        if ($entry->getProject()->getInvoiceText() !== null) {
+            $invoiceItem->setDescription($entry->getProject()->getInvoiceText());
+        } else {
+            $invoiceItem->setDescription($entry->getProject()->getName());
+        }
+    }
+
+    public function getId(): string
+    {
+        return 'project_activity';
+    }
+}

--- a/tests/Invoice/Calculator/ProjectActivityInvoiceCalculatorTest.php
+++ b/tests/Invoice/Calculator/ProjectActivityInvoiceCalculatorTest.php
@@ -1,0 +1,146 @@
+<?php
+
+/*
+ * This file is part of the Kimai time-tracking app.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Tests\Invoice\Calculator;
+
+use App\Entity\Activity;
+use App\Entity\Customer;
+use App\Entity\InvoiceTemplate;
+use App\Entity\Project;
+use App\Entity\Timesheet;
+use App\Entity\User;
+use App\Invoice\Calculator\ProjectActivityInvoiceCalculator;
+use App\Invoice\CalculatorInterface;
+use App\Repository\Query\InvoiceQuery;
+use App\Tests\Invoice\DebugFormatter;
+use App\Tests\Mocks\InvoiceModelFactoryFactory;
+use DateTime;
+
+/**
+ * @covers \App\Invoice\Calculator\ProjectActivityInvoiceCalculator
+ * @covers \App\Invoice\Calculator\AbstractSumInvoiceCalculator
+ * @covers \App\Invoice\Calculator\AbstractMergedCalculator
+ * @covers \App\Invoice\Calculator\AbstractCalculator
+ */
+class ProjectActivityInvoiceCalculatorTest extends AbstractCalculatorTest
+{
+    protected function getCalculator(): CalculatorInterface
+    {
+        return new ProjectActivityInvoiceCalculator();
+    }
+
+    public function testWithMultipleEntries(): void
+    {
+        $customer = new Customer('foo');
+        $template = new InvoiceTemplate();
+        $template->setVat(19);
+
+        $user = $this->getMockBuilder(User::class)->onlyMethods(['getId'])->disableOriginalConstructor()->getMock();
+        $user->method('getId')->willReturn(1);
+
+        $activity1 = $this->getMockBuilder(Activity::class)->onlyMethods(['getId'])->disableOriginalConstructor()->getMock();
+        $activity1->method('getId')->willReturn(1);
+
+        $activity2 = $this->getMockBuilder(Activity::class)->onlyMethods(['getId'])->disableOriginalConstructor()->getMock();
+        $activity2->method('getId')->willReturn(2);
+
+        $project1 = $this->getMockBuilder(Project::class)->onlyMethods(['getId'])->disableOriginalConstructor()->getMock();
+        $project1->method('getId')->willReturn(1);
+
+        $project2 = $this->getMockBuilder(Project::class)->onlyMethods(['getId'])->disableOriginalConstructor()->getMock();
+        $project2->method('getId')->willReturn(2);
+
+        $project3 = $this->getMockBuilder(Project::class)->onlyMethods(['getId'])->disableOriginalConstructor()->getMock();
+        $project3->method('getId')->willReturn(3);
+
+        $timesheet = new Timesheet();
+        $timesheet
+            ->setBegin(new DateTime('2018-11-29'))
+            ->setEnd(new DateTime())
+            ->setDuration(3600)
+            ->setRate(293.27)
+            ->setUser($user)
+            ->setActivity($activity1)
+            ->setProject($project1);
+
+        $timesheet2 = new Timesheet();
+        $timesheet2
+            ->setBegin(new DateTime('2018-11-28'))
+            ->setEnd(new DateTime())
+            ->setDuration(400)
+            ->setRate(84.75)
+            ->setUser($user)
+            ->setActivity($activity1)
+            ->setProject($project2);
+
+        $timesheet3 = new Timesheet();
+        $timesheet3
+            ->setBegin(new DateTime('2018-11-29'))
+            ->setEnd(new DateTime())
+            ->setDuration(1800)
+            ->setRate(111.11)
+            ->setUser($user)
+            ->setActivity($activity1)
+            ->setProject($project1);
+
+        $timesheet4 = new Timesheet();
+        $timesheet4
+            ->setBegin(new DateTime('2018-11-08'))
+            ->setEnd(new DateTime())
+            ->setDuration(400)
+            ->setRate(1947.99)
+            ->setUser($user)
+            ->setActivity($activity1)
+            ->setProject($project2);
+
+        $timesheet5 = new Timesheet();
+        $timesheet5
+            ->setBegin(new DateTime('2018-11-28'))
+            ->setEnd(new DateTime())
+            ->setDuration(400)
+            ->setRate(84)
+            ->setUser($user)
+            ->setActivity($activity2)
+            ->setProject($project3);
+
+        $entries = [$timesheet, $timesheet2, $timesheet3, $timesheet4, $timesheet5];
+
+        $query = new InvoiceQuery();
+        $query->setProjects([$project1]);
+
+        $model = (new InvoiceModelFactoryFactory($this))->create()->createModel(new DebugFormatter(), $customer, $template, $query);
+        $model->addEntries($entries);
+
+        $sut = $this->getCalculator();
+        $sut->setModel($model);
+
+        $this->assertEquals('project_activity', $sut->getId());
+        $this->assertEquals(3000.13, $sut->getTotal());
+        $this->assertEquals(19, $sut->getVat());
+        $this->assertEquals('EUR', $model->getCurrency());
+        $this->assertEquals(2521.12, $sut->getSubtotal());
+        $this->assertEquals(6600, $sut->getTimeWorked());
+
+        $entries = $sut->getEntries();
+        self::assertCount(3, $entries);
+
+        $this->assertEquals('2018-11-08', $entries[0]->getBegin()?->format('Y-m-d'));
+        $this->assertEquals('2018-11-28', $entries[1]->getBegin()?->format('Y-m-d'));
+        $this->assertEquals('2018-11-29', $entries[2]->getBegin()?->format('Y-m-d'));
+
+        $this->assertEquals(404.38, $entries[2]->getRate());
+        $this->assertEquals(2032.74, $entries[0]->getRate());
+        $this->assertEquals(84, $entries[1]->getRate());
+    }
+
+    public function testDescriptionByProject(): void
+    {
+        $this->assertDescription($this->getCalculator(), true, false);
+    }
+}


### PR DESCRIPTION
## Description
Addition of a 'project and activity' grouping for invoice entries. I have based this off the [ProjectUserInvoiceCalculator.php](https://github.com/kimai/kimai/blob/36c578452ec91a2e4e964f5d4ff7a6ccaa3da3a4/src/Invoice/Calculator/ProjectUserInvoiceCalculator.php) code and its associated tests. It was some relatively simple renames. I say this because I am absolutely not a web developer and do not have a great deal of experience with the Kimai codebase. I'm just hoping this can be the starting point of a relatively simple addition to invoicing that would mean simpler invoice templates for me!

I don't believe there is documentation that specifically calls out the invoice grouping options, but I've left the documentation box below unticked.

I had some trouble building kimai on my local Windows machine. This was likely some Windows specific quirks, and because it's my first time trying to build web components. I'm happy to detail the issues in a separate discussion if you're interested, but I suspect building on Windows isn't common.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] I verified that my code applies to the guidelines (`composer code-check`)
- [ ] I updated the documentation (see [here](https://github.com/kimai/www.kimai.org/tree/master/_documentation))
- [x] I agree that this code is used in Kimai (see [license](https://github.com/kimai/kimai/blob/main/LICENSE))
