### PR TITLE
more options for future times validation

### DIFF
--- a/src/API/ConfigurationController.php
+++ b/src/API/ConfigurationController.php
@@ -41,7 +41,7 @@ final class ConfigurationController extends BaseApiController
         $model->setTrackingMode($configuration->getTimesheetTrackingMode());
         $model->setDefaultBeginTime($configuration->getTimesheetDefaultBeginTime());
         $model->setActiveEntriesHardLimit($configuration->getTimesheetActiveEntriesHardLimit());
-        $model->setIsAllowFutureTimes($configuration->isTimesheetAllowFutureTimes());
+        $model->setIsAllowFutureTimes($configuration->getTimesheetAllowFutureRule());
         $model->setIsAllowOverlapping($configuration->isTimesheetAllowOverlappingRecords());
 
         $view = new View($model, 200);

--- a/src/API/Model/TimesheetConfig.php
+++ b/src/API/Model/TimesheetConfig.php
@@ -9,6 +9,7 @@
 
 namespace App\API\Model;
 
+use App\Timesheet\FutureTimesEnum;
 use JMS\Serializer\Annotation as Serializer;
 
 #[Serializer\ExclusionPolicy('none')]
@@ -36,7 +37,7 @@ final class TimesheetConfig
     #[Serializer\Type(name: 'integer')]
     public int $activeEntriesHardLimit = 1;
     /**
-     * Whether entries for future times are allowed
+     * Whether entries for future times are allowed (end time maybe limited)
      */
     #[Serializer\Expose]
     #[Serializer\Groups(['Default'])]
@@ -65,9 +66,9 @@ final class TimesheetConfig
         $this->activeEntriesHardLimit = $activeEntriesHardLimit;
     }
 
-    public function setIsAllowFutureTimes(bool $isAllowFutureTimes): void
+    public function setIsAllowFutureTimes(FutureTimesEnum $futureTimesEnum): void
     {
-        $this->isAllowFutureTimes = $isAllowFutureTimes;
+        $this->isAllowFutureTimes = ($futureTimesEnum !== FutureTimesEnum::DENY);
     }
 
     public function setIsAllowOverlapping(bool $isAllowOverlapping): void

--- a/src/Configuration/SystemConfiguration.php
+++ b/src/Configuration/SystemConfiguration.php
@@ -9,6 +9,8 @@
 
 namespace App\Configuration;
 
+use App\Timesheet\FutureTimesEnum;
+
 final class SystemConfiguration
 {
     private bool $initialized = false;
@@ -377,9 +379,35 @@ final class SystemConfiguration
         return (string) $this->find('timesheet.default_begin');
     }
 
+    /**
+     * @deprecated since 2.4
+     */
     public function isTimesheetAllowFutureTimes(): bool
     {
-        return (bool) $this->find('timesheet.rules.allow_future_times');
+        @trigger_error('isTimesheetAllowFutureTimes() is deprecated and will be removed with 2.2.0, use getTimesheetAllowFutureRule() instead', E_USER_DEPRECATED);
+
+        $rule = $this->getTimesheetAllowFutureRule();
+
+        if ($rule === FutureTimesEnum::DENY) {
+            return false;
+        }
+
+        return true;
+    }
+
+    public function getTimesheetAllowFutureRule(): FutureTimesEnum
+    {
+        $value = $this->getString('timesheet.rules.allow_future_times', 'allow');
+
+        if (($rule = FutureTimesEnum::tryFrom($value)) === null) {
+            if ((bool) $value === false) {
+                return FutureTimesEnum::DENY;
+            }
+
+            return FutureTimesEnum::ALLOW;
+        }
+
+        return $rule;
     }
 
     public function isTimesheetAllowZeroDuration(): bool

--- a/src/Timesheet/FutureTimesEnum.php
+++ b/src/Timesheet/FutureTimesEnum.php
@@ -1,0 +1,18 @@
+<?php
+
+/*
+ * This file is part of the Kimai time-tracking app.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Timesheet;
+
+enum FutureTimesEnum: string
+{
+    case ALLOW = 'allow';
+    case DENY = 'deny';
+    case END_OF_DAY = 'end_of_day';
+    case END_OF_WEEK = 'end_of_week';
+}

--- a/src/Validator/Constraints/TimesheetFutureTimesValidator.php
+++ b/src/Validator/Constraints/TimesheetFutureTimesValidator.php
@@ -11,6 +11,7 @@ namespace App\Validator\Constraints;
 
 use App\Configuration\SystemConfiguration;
 use App\Entity\Timesheet as TimesheetEntity;
+use App\Timesheet\FutureTimesEnum;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
 use Symfony\Component\Validator\Exception\UnexpectedTypeException;
@@ -35,9 +36,13 @@ final class TimesheetFutureTimesValidator extends ConstraintValidator
             throw new UnexpectedTypeException($value, TimesheetEntity::class);
         }
 
-        if ($this->configuration->isTimesheetAllowFutureTimes()) {
+        $rule = $this->configuration->getTimesheetAllowFutureRule();
+
+        if ($rule === FutureTimesEnum::ALLOW) {
             return;
         }
+
+        // TODO apply configured future times validation rule
 
         $now = new \DateTime('now', $value->getBegin()->getTimezone());
 

--- a/tests/API/Model/TimesheetConfigTest.php
+++ b/tests/API/Model/TimesheetConfigTest.php
@@ -10,6 +10,7 @@
 namespace App\Tests\API\Model;
 
 use App\API\Model\TimesheetConfig;
+use App\Timesheet\FutureTimesEnum;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -20,7 +21,7 @@ class TimesheetConfigTest extends TestCase
     public function testSetter(): void
     {
         $sut = new TimesheetConfig();
-        $sut->setIsAllowFutureTimes(false);
+        $sut->setIsAllowFutureTimes(FutureTimesEnum::DENY);
         $sut->setIsAllowOverlapping(false);
         $sut->setDefaultBeginTime('08:00');
         $sut->setTrackingMode('punch');


### PR DESCRIPTION
## Description

Currently there is a boolean rule to disallow future times.

This PR (which is not yet done) adds more options, e.g. to 
- disallow starting in the future
- disallow ending in the future
- allow starting now (or in the past) and ending in the future

TODO validator/translations/more options

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] I verified that my code applies to the guidelines (`composer code-check`)
- [ ] I updated the documentation (see [here](https://github.com/kimai/www.kimai.org/tree/master/_documentation))
- [x] I agree that this code is used in Kimai (see [license](https://github.com/kimai/kimai/blob/main/LICENSE))
