### PR TITLE
Add support for negative durations in All Users reports

### DIFF
--- a/templates/reporting/user_list_period_data.html.twig
+++ b/templates/reporting/user_list_period_data.html.twig
@@ -39,18 +39,12 @@
         {% set usersTotalInternalRate = 0 %}
         {% set usersTotalRate = 0 %}
         {% for period in attribute(userPeriod, period_attribute) %}
-            {% if period.totalDuration != 0 %}
-                {% set usersTotalDuration = usersTotalDuration + period.totalDuration %}
-                {% set absoluteDuration = absoluteDuration + period.totalDuration %}
-            {% endif %}
-            {% if period.totalInternalRate > 0 %}
-                {% set usersTotalInternalRate = usersTotalInternalRate + period.totalInternalRate %}
-                {% set absoluteInternalRate = absoluteInternalRate + period.totalInternalRate %}
-            {% endif %}
-            {% if period.totalRate > 0 %}
-                {% set usersTotalRate = usersTotalRate + period.totalRate %}
-                {% set absoluteRate = absoluteRate + period.totalRate %}
-            {% endif %}
+            {% set usersTotalDuration = usersTotalDuration + period.totalDuration %}
+            {% set absoluteDuration = absoluteDuration + period.totalDuration %}
+            {% set usersTotalInternalRate = usersTotalInternalRate + period.totalInternalRate %}
+            {% set absoluteInternalRate = absoluteInternalRate + period.totalInternalRate %}
+            {% set usersTotalRate = usersTotalRate + period.totalRate %}
+            {% set absoluteRate = absoluteRate + period.totalRate %}
             {% set reportDateKey = period.date|report_date %}
             {% set totalsDuration = totalsDuration|merge({(reportDateKey): (totalsDuration[reportDateKey] + period.totalDuration)}) %}
             {% set totalsInternalRate = totalsInternalRate|merge({(reportDateKey): (totalsInternalRate[reportDateKey] + period.totalInternalRate)}) %}

--- a/templates/reporting/user_list_period_data.html.twig
+++ b/templates/reporting/user_list_period_data.html.twig
@@ -39,7 +39,7 @@
         {% set usersTotalInternalRate = 0 %}
         {% set usersTotalRate = 0 %}
         {% for period in attribute(userPeriod, period_attribute) %}
-            {% if period.totalDuration > 0 %}
+            {% if period.totalDuration != 0 %}
                 {% set usersTotalDuration = usersTotalDuration + period.totalDuration %}
                 {% set absoluteDuration = absoluteDuration + period.totalDuration %}
             {% endif %}
@@ -56,7 +56,7 @@
             {% set totalsInternalRate = totalsInternalRate|merge({(reportDateKey): (totalsInternalRate[reportDateKey] + period.totalInternalRate)}) %}
             {% set totalsRate = totalsRate|merge({(reportDateKey): (totalsRate[reportDateKey] + period.totalRate)}) %}
         {% endfor %}
-        {% if userPeriod.user.enabled or usersTotalDuration > 0 %}
+        {% if userPeriod.user.enabled or usersTotalDuration != 0 %}
         <tr class="user">
             {% if with_avatar %}
                 <td class="w-avatar">
@@ -81,7 +81,7 @@
             </td>
             {% for period in attribute(userPeriod, period_attribute) %}
                 <td class="text-nowrap text-center day-total{% block period_cell_class %}{% endblock %}"{% block period_cell_attribute %}{% endblock %}>
-                    {% if period.totalDuration > 0 or period.totalRate > 0 or period.totalInternalRate > 0 %}
+                    {% if period.totalDuration != 0 or period.totalRate > 0 or period.totalInternalRate > 0 %}
                         {% if dataType == 'rate' %}
                             {% block rate %}{% endblock %}
                         {% elseif dataType == 'internalRate' %}

--- a/templates/reporting/user_list_period_data.html.twig
+++ b/templates/reporting/user_list_period_data.html.twig
@@ -81,7 +81,7 @@
             </td>
             {% for period in attribute(userPeriod, period_attribute) %}
                 <td class="text-nowrap text-center day-total{% block period_cell_class %}{% endblock %}"{% block period_cell_attribute %}{% endblock %}>
-                    {% if period.totalDuration != 0 or period.totalRate > 0 or period.totalInternalRate > 0 %}
+                    {% if period.totalDuration != 0 or period.totalRate != 0 or period.totalInternalRate != 0 %}
                         {% if dataType == 'rate' %}
                             {% block rate %}{% endblock %}
                         {% elseif dataType == 'internalRate' %}


### PR DESCRIPTION
## Description
Fix negative times created by the [Deduction-Time Bundle](https://github.com/Keleo/DeductionTimeBundle) not being displayed in the "All Users" report pages (Weekly, Monthly and Yearly view for all users).

Fixes [this issue](https://github.com/Keleo/DeductionTimeBundle/issues/13)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] I verified that my code applies to the guidelines (`composer code-check`)
- [x] I updated the documentation (see [here](https://github.com/kimai/www.kimai.org/tree/master/_documentation))
- [x] I agree that this code is used in Kimai (see [license](https://github.com/kimai/kimai/blob/main/LICENSE))
