### PR TITLE
Add command to stop time exceeding timesheets

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -543,6 +543,11 @@ parameters:
             path: src/Command/ResetTestCommand.php
 
         -
+            message: "#^Parameter \\#1 \\$value of function floatval expects array|bool|float|int|resource|string|null, mixed given\\.$#"
+            count: 1
+            path: src/Command/TimesheetStopTimeExceeding.php
+
+        -
             message: "#^Access to an undefined property SimpleXMLElement\\|false\\:\\:\\$file\\.$#"
             count: 1
             path: src/Command/TranslationCommand.php

--- a/src/Command/TimesheetStopTimeExceeding.php
+++ b/src/Command/TimesheetStopTimeExceeding.php
@@ -1,0 +1,70 @@
+<?php
+
+/*
+ * This file is part of the Kimai time-tracking app.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Command;
+
+use App\Repository\TimesheetRepository;
+use App\Timesheet\TimesheetService;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+/**
+ * @codeCoverageIgnore
+ */
+#[AsCommand(name: 'kimai:timesheet:stop-time-exceeding')]
+final class TimesheetStopTimeExceeding extends Command
+{
+    public function __construct(
+        private readonly TimesheetService $timesheetService,
+        private readonly TimesheetRepository $timesheetRepository
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this->setDescription('Stop all running timesheets, that have exceeded the specified time limit and do not yet have an end value.');
+        $this->addArgument(
+            'max-hours',
+            InputArgument::REQUIRED,
+            'Maximum number (int or decimal) of hours after which a timesheet is stopped'
+        );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $activeEntries = $this->timesheetRepository->getActiveEntries();
+        $counter = 0;
+
+        foreach ($activeEntries as $timesheet) {
+            if ($timesheet->getEnd() === null) {
+                // set temporary end, just for the calculation
+                $timesheet->setEnd(new \DateTime('now', $timesheet->getBegin()?->getTimezone()));
+                // calculate time diff based on seconds
+                if (($timesheet->getCalculatedDuration() ?? 0) > \floatval($input->getArgument('max-hours')) * 60 * 60) {
+                    // reset end value, otherwise stopTimesheet would not stop the timesheet
+                    $timesheet->setEnd(null);
+                    $this->timesheetService->stopTimesheet($timesheet, false);
+                    $counter++;
+                }
+            }
+        }
+
+        if (!$output->isQuiet()) {
+            $io = new SymfonyStyle($input, $output);
+            $io->success(sprintf('Stopped %s timesheet records.', $counter));
+        }
+
+        return Command::SUCCESS;
+    }
+}


### PR DESCRIPTION
## Description
Currently there's no option to automatically stop timesheets, you forgot to stop manually.
If you have something like a company rule for a maximum work time per timesheets (or you're just forgetful :D), the implemented command helps enforcing that.

---

This pull request adds a command that stops timesheets with a duration longer than the specified amount of hours (as command argument), if they do not yet have an end value set.

---

Example usage would be a cron job that runs the command once a hour like:
`bin/console kimai:timesheet:stop-time-exceeding 12` to disallow timesheets longer than 12 hours.


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] I verified that my code applies to the guidelines (`composer code-check`)
- [ ] I updated the documentation (see [here](https://github.com/kimai/www.kimai.org/tree/master/_documentation))
- [x] I agree that this code is used in Kimai (see [license](https://github.com/kimai/kimai/blob/main/LICENSE))
