### PR TITLE
Docker: Fix TLS certificate verification for LDAP authentication

### DIFF
--- a/.docker/Dockerfile.kimai-base
+++ b/.docker/Dockerfile.kimai-base
@@ -144,6 +144,7 @@ RUN apt-get update && \
         bash \
         haveged \
         libicu72 \
+        libldap-common \
         libpng16-16 \
         libzip4 \
         libxslt1.1 \


### PR DESCRIPTION
Fixes #4796 

## Description
This PR adds back the Debian package `libldap-common` into the Apache base Docker image. This allows the verification of TLS certificates when using LDAPS for authentication.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] I verified that my code applies to the guidelines (`composer code-check`)
- [ ] I updated the documentation (see [here](https://github.com/kimai/www.kimai.org/tree/master/_documentation))
- [x] I agree that this code is used in Kimai (see [license](https://github.com/kimai/kimai/blob/main/LICENSE))
