### PR TITLE
Default-Farben hinzugefügt

### DIFF
--- a/assets/chart.js
+++ b/assets/chart.js
@@ -23,6 +23,7 @@ import {
     Legend,
     Title,
     Tooltip,
+	Colors,
 //    SubTitle
 } from 'chart.js';
 
@@ -50,6 +51,7 @@ Chart.register(
     Legend,
     Title,
     Tooltip,
+	Colors,
 //    SubTitle
 );
 


### PR DESCRIPTION
Es ist zwar nicht getestet, sollte aber funktionieren.
Wäre es möglich die Default-Farbpalette von ChartJs aufzunehmen?