### PR TITLE
New System Configuration for Timesheet's description field optional or mandatory.

### DIFF
--- a/src/API/ConfigurationController.php
+++ b/src/API/ConfigurationController.php
@@ -38,9 +38,10 @@ final class ConfigurationController extends BaseApiController
         $model->setTrackingMode($configuration->getTimesheetTrackingMode());
         $model->setDefaultBeginTime($configuration->getTimesheetDefaultBeginTime());
         $model->setActiveEntriesHardLimit($configuration->getTimesheetActiveEntriesHardLimit());
+        $model->setIsTimesheetDescriptionMandatory($configuration->isTimesheetDescriptionMandatory());
         $model->setIsAllowFutureTimes($configuration->isTimesheetAllowFutureTimes());
         $model->setIsAllowOverlapping($configuration->isTimesheetAllowOverlappingRecords());
-
+        
         $view = new View($model, 200);
         $view->getContext()->setGroups(['Default', 'Config']);
 

--- a/src/Configuration/SystemConfiguration.php
+++ b/src/Configuration/SystemConfiguration.php
@@ -379,6 +379,12 @@ final class SystemConfiguration
         return (bool) $this->find('timesheet.rules.allow_future_times');
     }
 
+    public function isTimesheetDescriptionMandatory(): bool
+    {
+        return (bool) $this->find('timesheet.rules.descriptionmandatory');
+    }
+    
+
     public function isTimesheetAllowZeroDuration(): bool
     {
         return (bool) $this->find('timesheet.rules.allow_zero_duration');

--- a/src/Controller/SystemConfigurationController.php
+++ b/src/Controller/SystemConfigurationController.php
@@ -302,7 +302,10 @@ final class SystemConfigurationController extends AbstractController
                         ->setType(DateTimeTextType::class)
                         ->setConstraints([new DateTimeFormat(), new NotNull()])
                         ->setTranslationDomain('system-configuration'),
-                    (new Configuration('timesheet.rules.allow_future_times'))
+                    (new Configuration('timesheet.rules.descriptionmandatory'))
+                        ->setType(YesNoType::class)
+                        ->setTranslationDomain('system-configuration'),
+                        (new Configuration('timesheet.rules.allow_future_times'))
                         ->setType(YesNoType::class)
                         ->setTranslationDomain('system-configuration'),
                     (new Configuration('timesheet.rules.allow_zero_duration'))

--- a/src/Form/TimesheetEditForm.php
+++ b/src/Form/TimesheetEditForm.php
@@ -131,7 +131,7 @@ class TimesheetEditForm extends AbstractType
             // 'allow_create' => $allowCreate && $options['create_activity'],
         ]);
 
-        $descriptionOptions = ['required' => false];
+        $descriptionOptions = ['required' => $this->systemConfiguration->isTimesheetDescriptionMandatory()];
         if (!$isNew) {
             $descriptionOptions['attr'] = ['autofocus' => 'autofocus'];
         }

--- a/translations/system-configuration.en.xlf
+++ b/translations/system-configuration.en.xlf
@@ -34,6 +34,10 @@
         <source>timesheet.mode_punch</source>
         <target>[Time-clock] user can start and stop records, but not edit the times or duration</target>
       </trans-unit>
+      <trans-unit id="Aaal234" resname="timesheet.rules.descriptionmandatory">
+        <source>timesheet.rules.descriptionmandatory</source>
+        <target>Description field is mandatory</target>
+      </trans-unit>
       <trans-unit id="k4pl27g" resname="timesheet.rules.allow_future_times">
         <source>timesheet.rules.allow_future_times</source>
         <target>Allow time entries in the future</target>

--- a/translations/system-configuration.hu.xlf
+++ b/translations/system-configuration.hu.xlf
@@ -6,6 +6,10 @@
         <source>Time tracking</source>
         <target>Rögzített órák</target>
       </trans-unit>
+      <trans-unit id="Aaal234" resname="timesheet.rules.descriptionmandatory">
+        <source>timesheet.rules.descriptionmandatory</source>
+        <target>Leírás mező kötelezően kitöltendő</target>
+      </trans-unit>
       <trans-unit id="k4pl27g" resname="timesheet.rules.allow_future_times">
         <source>timesheet.rules.allow_future_times</source>
         <target>Jövőbeli rögzítések engedélyezése</target>


### PR DESCRIPTION
## Description
Add opportunity users to make timesheet's description field mandatory.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] I verified that my code applies to the guidelines (`composer code-check`)
- [x] I updated the documentation (see [here](https://github.com/kimai/www.kimai.org/tree/master/_documentation))
- [x] I agree that this code is used in Kimai (see [license](https://github.com/kimai/kimai/blob/main/LICENSE))
