### PR TITLE
Update Util.php

### DIFF
--- a/src/Timesheet/Util.php
+++ b/src/Timesheet/Util.php
@@ -27,7 +27,7 @@ final class Util
      */
     public static function calculateRate(float $hourlyRate, int $seconds): float
     {
-        $rate = $hourlyRate * ($seconds / 3600);
+        $rate = $hourlyRate * round(($seconds / 3600), 2);
 
         return round($rate, 4);
     }


### PR DESCRIPTION
Proposal to fix rate rounding issues on invoices. Since the invoices show the duration as a decimal number with two decimal points.

Example: 
assuming that the hourly rate is 34.34 and the duration is 25 minutes Current algorithm calculates 1500/3600*34.34 = 14.31 € proposal algorithm calculates 0.42 (number on the invoice) * 34.34 = 14.42 €

It's dirty but works for me. I don't expect that to be part of the repo

## Description
A clear and concise description of what this pull request adds or changes.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] I verified that my code applies to the guidelines (`composer code-check`)
- [ ] I updated the documentation (see [here](https://github.com/kimai/www.kimai.org/tree/master/_documentation))
- [ ] I agree that this code is used in Kimai (see [license](https://github.com/kimai/kimai/blob/main/LICENSE))
