### PR TITLE
INVOICE: do not use activity name as fallback for description

### DIFF
--- a/src/Invoice/Calculator/AbstractMergedCalculator.php
+++ b/src/Invoice/Calculator/AbstractMergedCalculator.php
@@ -88,10 +88,6 @@ abstract class AbstractMergedCalculator extends AbstractCalculator
             $invoiceItem->setProject($entry->getProject());
         }
 
-        if (empty($invoiceItem->getDescription()) && null !== $entry->getActivity()) {
-            $invoiceItem->setDescription($entry->getActivity()->getName());
-        }
-
         if ($entry instanceof Timesheet) {
             foreach ($entry->getTagsAsArray() as $tag) {
                 $invoiceItem->addTag($tag);

--- a/src/Invoice/Hydrator/InvoiceItemDefaultHydrator.php
+++ b/src/Invoice/Hydrator/InvoiceItemDefaultHydrator.php
@@ -47,10 +47,6 @@ final class InvoiceItemDefaultHydrator implements InvoiceItemHydrator
         $begin = $item->getBegin();
         $end = $item->getEnd();
 
-        if (empty($description) && null !== $activity) {
-            $description = $activity->getName();
-        }
-
         // this should never happen!
         if (empty($appliedRate)) {
             $appliedRate = 0;

--- a/src/Invoice/Hydrator/InvoiceItemDefaultHydrator.php
+++ b/src/Invoice/Hydrator/InvoiceItemDefaultHydrator.php
@@ -55,6 +55,7 @@ final class InvoiceItemDefaultHydrator implements InvoiceItemHydrator
         $values = [
             'entry.row' => '',
             'entry.description' => $description ?? '',
+            'entry.description_safe' => ($description === null || $description === '' ? ($activity?->getName() ?? $project?->getName() ?? '') : $description),
             'entry.amount' => $amount,
             'entry.type' => $item->getType(),
             'entry.tags' => implode(', ', $item->getTags()),

--- a/tests/Invoice/Calculator/ShortInvoiceCalculatorTest.php
+++ b/tests/Invoice/Calculator/ShortInvoiceCalculatorTest.php
@@ -111,7 +111,7 @@ class ShortInvoiceCalculatorTest extends AbstractCalculatorTest
         $result = $entries[0];
 
         $this->assertEquals('2018-11-28', $result->getBegin()?->format('Y-m-d'));
-        $this->assertEquals('activity description', $result->getDescription());
+        $this->assertEquals('', $result->getDescription());
         $this->assertEquals(293.27, $result->getHourlyRate());
         $this->assertNull($result->getFixedRate());
         $this->assertEquals(472.5, $result->getRate());
@@ -190,7 +190,7 @@ class ShortInvoiceCalculatorTest extends AbstractCalculatorTest
 
         /** @var InvoiceItem $result */
         $result = $sut->getEntries()[0];
-        $this->assertEquals('activity description', $result->getDescription());
+        $this->assertNull($result->getDescription());
         $this->assertEquals(488.38, $result->getHourlyRate());
         $this->assertEquals(488.38, $result->getFixedRate());
         $this->assertEquals(488.38, $result->getRate());
@@ -266,7 +266,7 @@ class ShortInvoiceCalculatorTest extends AbstractCalculatorTest
 
         /** @var InvoiceItem $result */
         $result = $sut->getEntries()[0];
-        $this->assertEquals('activity description', $result->getDescription());
+        $this->assertNull($result->getDescription());
         $this->assertEquals(488.38, $result->getHourlyRate());
         $this->assertEquals(488.38, $result->getRate());
         $this->assertEquals(5800, $result->getDuration());

--- a/tests/Invoice/Hydrator/InvoiceItemDefaultHydratorTest.php
+++ b/tests/Invoice/Hydrator/InvoiceItemDefaultHydratorTest.php
@@ -28,9 +28,9 @@ class InvoiceItemDefaultHydratorTest extends TestCase
         $sut->setInvoiceModel($model);
 
         $expected = [
-            ['meta_fields' => ['entry.meta.foo-timesheet'], 'description' => '== jhg ljhg '],
-            ['meta_fields' => ['entry.meta.foo-timesheet', 'entry.meta.foo-timesheet2'], 'description' => ''],
-            ['meta_fields' => ['entry.meta.foo-timesheet'], 'description' => ''],
+            ['meta_fields' => ['entry.meta.foo-timesheet'], 'description' => '== jhg ljhg ', 'description_safe' => '== jhg ljhg '],
+            ['meta_fields' => ['entry.meta.foo-timesheet', 'entry.meta.foo-timesheet2'], 'description' => '', 'description_safe' => 'activity description'],
+            ['meta_fields' => ['entry.meta.foo-timesheet'], 'description' => '', 'description_safe' => 'activity description'],
             ['meta_fields' => ['entry.meta.foo-timesheet3']],
             ['meta_fields' => []],
         ];
@@ -40,11 +40,13 @@ class InvoiceItemDefaultHydratorTest extends TestCase
             $result = $sut->hydrate($entry);
             $exp = $expected[$i++];
             $this->assertEntryStructure($result, $exp['meta_fields']);
-            if (array_key_exists('description', $exp)) {
+            if (\array_key_exists('description', $exp)) {
                 $this->assertEquals($exp['description'], $result['entry.description']);
             }
+            if (\array_key_exists('description_safe', $exp)) {
+                $this->assertEquals($exp['description_safe'], $result['entry.description_safe']);
+            }
         }
-
     }
 
     public function assertEntryStructure(array $model, array $metaFields): void
@@ -52,6 +54,7 @@ class InvoiceItemDefaultHydratorTest extends TestCase
         $keys = [
             'entry.row',
             'entry.description',
+            'entry.description_safe',
             'entry.amount',
             'entry.rate',
             'entry.rate_nc',
@@ -98,7 +101,7 @@ class InvoiceItemDefaultHydratorTest extends TestCase
             'entry.tags',
         ];
 
-        if (count($metaFields) > 0) {
+        if (\count($metaFields) > 0) {
             $keys = array_merge($keys, $metaFields);
         }
 

--- a/tests/Invoice/Hydrator/InvoiceItemDefaultHydratorTest.php
+++ b/tests/Invoice/Hydrator/InvoiceItemDefaultHydratorTest.php
@@ -27,13 +27,24 @@ class InvoiceItemDefaultHydratorTest extends TestCase
         $sut = new InvoiceItemDefaultHydrator();
         $sut->setInvoiceModel($model);
 
-        $result = $sut->hydrate($model->getCalculator()->getEntries()[0]);
-        $metaFields = ['entry.meta.foo-timesheet'];
-        $this->assertEntryStructure($result, $metaFields);
+        $expected = [
+            ['meta_fields' => ['entry.meta.foo-timesheet'], 'description' => '== jhg ljhg '],
+            ['meta_fields' => ['entry.meta.foo-timesheet', 'entry.meta.foo-timesheet2'], 'description' => ''],
+            ['meta_fields' => ['entry.meta.foo-timesheet'], 'description' => ''],
+            ['meta_fields' => ['entry.meta.foo-timesheet3']],
+            ['meta_fields' => []],
+        ];
 
-        $result = $sut->hydrate($model->getCalculator()->getEntries()[1]);
-        $metaFields = ['entry.meta.foo-timesheet', 'entry.meta.foo-timesheet2'];
-        $this->assertEntryStructure($result, $metaFields);
+        $i = 0;
+        foreach ($model->getCalculator()->getEntries() as $entry) {
+            $result = $sut->hydrate($entry);
+            $exp = $expected[$i++];
+            $this->assertEntryStructure($result, $exp['meta_fields']);
+            if (array_key_exists('description', $exp)) {
+                $this->assertEquals($exp['description'], $result['entry.description']);
+            }
+        }
+
     }
 
     public function assertEntryStructure(array $model, array $metaFields): void
@@ -87,7 +98,9 @@ class InvoiceItemDefaultHydratorTest extends TestCase
             'entry.tags',
         ];
 
-        $keys = array_merge($keys, $metaFields);
+        if (count($metaFields) > 0) {
+            $keys = array_merge($keys, $metaFields);
+        }
 
         foreach ($keys as $key) {
             $this->assertArrayHasKey($key, $model);

--- a/tests/Invoice/Renderer/DebugRendererTest.php
+++ b/tests/Invoice/Renderer/DebugRendererTest.php
@@ -262,6 +262,7 @@ class DebugRendererTest extends TestCase
         $keys = [
             'entry.row',
             'entry.description',
+            'entry.description_safe',
             'entry.amount',
             'entry.rate',
             'entry.rate_nc',

--- a/tests/phpstan.neon
+++ b/tests/phpstan.neon
@@ -2250,7 +2250,7 @@ parameters:
 
         -
             message: "#^Cannot call method getEntries\\(\\) on App\\\\Invoice\\\\CalculatorInterface\\|null\\.$#"
-            count: 2
+            count: 1
             path: Invoice/Hydrator/InvoiceItemDefaultHydratorTest.php
 
         -


### PR DESCRIPTION
## Description

Currently an empty description in a timesheet (and expense) causes Kimai to inject the activity name as invoice variable `entry.description` in the default calculator (one row per entry).

This makes it impossible to detect whether the description was set or not and apply custom fallback logic.

This was removed: the field `entry.description` contains now the content from the timesheet. If empty then this field is empty as well.

A replacement field was added called `entry.description_safe` which will use the activity name as fallback and if that is empty the project name. 

This is technically both a bug fix and BC break.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] I verified that my code applies to the guidelines (`composer code-check`)
- [ ] I updated the documentation (see [here](https://github.com/kimai/www.kimai.org/tree/master/_documentation))
- [x] I agree that this code is used in Kimai (see [license](https://github.com/kimai/kimai/blob/main/LICENSE))
