### PR TITLE
copy & paste slip fix

### DIFF
--- a/src/Repository/TimesheetRepository.php
+++ b/src/Repository/TimesheetRepository.php
@@ -577,7 +577,7 @@ class TimesheetRepository extends EntityRepository
         }
 
         if (null !== $query->getEnd()) {
-            $qb->andWhere($qb->expr()->lte('t.begin', ':end'))
+            $qb->andWhere($qb->expr()->lte('t.end', ':end'))
                 ->setParameter('end', $query->getEnd());
         }
 


### PR DESCRIPTION
## Description
fixed a copy & paste mistake: comparing the timesheet-query's 'end'-date with the timesheet's 'end'-date instead of its 'start'-date.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] I verified that my code applies to the guidelines (`composer code-check`)
- [ ] I updated the documentation (see [here](https://github.com/kimai/www.kimai.org/tree/master/_documentation))
- [x] I agree that this code is used in Kimai (see [license](https://github.com/kimai/kimai/blob/main/LICENSE))
