### PR TITLE
fixed case of `AS` keyword for consistency in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,10 +33,10 @@ RUN rm -r tests
 
 
 # FPM base
-FROM kimai/kimai-base:fpm as fpm-base
+FROM kimai/kimai-base:fpm AS fpm-base
 
 # Apache base
-FROM kimai/kimai-base:apache as apache-base
+FROM kimai/kimai-base:apache AS apache-base
 COPY .docker/000-default.conf /etc/apache2/sites-available/000-default.conf
 
 ###########################


### PR DESCRIPTION
## Description
When building the image I realised an inconsistency with the naming with `AS` keyword in dockerfile.

It was flagged off like this

<img width="662" alt="image" src="https://github.com/kimai/kimai/assets/70144052/ac0eede1-8cb9-41d6-8629-1dbd547f672a">

I had received similar warning when using Sonarqube analysis in one of my projects. It SHOULD BE uppercase.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] I verified that my code applies to the guidelines (`composer code-check`)
- [ ] I updated the documentation (see [here](https://github.com/kimai/www.kimai.org/tree/master/_documentation))
- [x] I agree that this code is used in Kimai (see [license](https://github.com/kimai/kimai/blob/main/LICENSE))
