### PR TITLE
unify CSRF token usage in comment sections

### DIFF
--- a/src/Controller/CustomerController.php
+++ b/src/Controller/CustomerController.php
@@ -185,13 +185,13 @@ final class CustomerController extends AbstractController
     {
         $customerId = $comment->getCustomer()->getId();
 
-        if (!$csrfTokenManager->isTokenValid(new CsrfToken('customer.delete_comment', $token))) {
+        if (!$csrfTokenManager->isTokenValid(new CsrfToken('comment.delete', $token))) {
             $this->flashError('action.csrf.error');
 
             return $this->redirectToRoute('customer_details', ['id' => $customerId]);
         }
 
-        $csrfTokenManager->refreshToken('customer.delete_comment');
+        $csrfTokenManager->refreshToken('comment.delete');
 
         try {
             $this->repository->deleteComment($comment);
@@ -228,13 +228,13 @@ final class CustomerController extends AbstractController
     {
         $customerId = $comment->getCustomer()->getId();
 
-        if (!$csrfTokenManager->isTokenValid(new CsrfToken('customer.pin_comment', $token))) {
+        if (!$csrfTokenManager->isTokenValid(new CsrfToken('comment.pin', $token))) {
             $this->flashError('action.csrf.error');
 
             return $this->redirectToRoute('customer_details', ['id' => $customerId]);
         }
 
-        $csrfTokenManager->refreshToken('customer.pin_comment');
+        $csrfTokenManager->refreshToken('comment.pin');
 
         $comment->setPinned(!$comment->isPinned());
         try {

--- a/src/Controller/ProjectController.php
+++ b/src/Controller/ProjectController.php
@@ -218,13 +218,13 @@ final class ProjectController extends AbstractController
     {
         $projectId = $comment->getProject()->getId();
 
-        if (!$csrfTokenManager->isTokenValid(new CsrfToken('project.delete_comment', $token))) {
+        if (!$csrfTokenManager->isTokenValid(new CsrfToken('comment.delete', $token))) {
             $this->flashError('action.csrf.error');
 
             return $this->redirectToRoute('project_details', ['id' => $projectId]);
         }
 
-        $csrfTokenManager->refreshToken('project.delete_comment');
+        $csrfTokenManager->refreshToken('comment.delete');
 
         try {
             $this->repository->deleteComment($comment);
@@ -261,13 +261,13 @@ final class ProjectController extends AbstractController
     {
         $projectId = $comment->getProject()->getId();
 
-        if (!$csrfTokenManager->isTokenValid(new CsrfToken('project.pin_comment', $token))) {
+        if (!$csrfTokenManager->isTokenValid(new CsrfToken('comment.pin', $token))) {
             $this->flashError('action.csrf.error');
 
             return $this->redirectToRoute('project_details', ['id' => $projectId]);
         }
 
-        $csrfTokenManager->refreshToken('project.pin_comment');
+        $csrfTokenManager->refreshToken('comment.pin');
 
         $comment->setPinned(!$comment->isPinned());
         try {

--- a/templates/customer/details.html.twig
+++ b/templates/customer/details.html.twig
@@ -147,7 +147,7 @@
     {% if comments is not null %}
         {% set options = {'form': commentForm, 'comments': comments} %}
         {% if can_edit %}
-            {% set options = options|merge({'route_pin': 'customer_comment_pin', 'route_delete': 'customer_comment_delete', 'csrf_delete': 'customer.delete_comment', 'csrf_pin': 'customer.pin_comment'}) %}
+            {% set options = options|merge({'route_pin': 'customer_comment_pin', 'route_delete': 'customer_comment_delete'}) %}
         {% endif %}
         {{ include('embeds/comments.html.twig', options) }}
     {% endif %}

--- a/templates/embeds/comments.html.twig
+++ b/templates/embeds/comments.html.twig
@@ -1,4 +1,4 @@
-{% embed '@theme/embeds/card.html.twig' with {'form': form, 'comments': comments, 'route_pin': route_pin|default(null), 'route_delete': route_delete|default(null), 'delete_by_user': delete_by_user|default(false), 'csrf_delete': csrf_token(csrf_delete|default('comment.delete')), 'csrf_pin': csrf_token(csrf_pin|default('comment.pin'))} %}
+{% embed '@theme/embeds/card.html.twig' with {'form': form, 'comments': comments, 'route_pin': route_pin|default(null), 'route_delete': route_delete|default(null), 'delete_by_user': delete_by_user|default(false)} %}
     {% import "macros/widgets.html.twig" as widgets %}
     {% block box_title %}{{ 'comment'|trans }}{% endblock %}
     {% block box_attributes %}id="comments_box"{% endblock %}
@@ -26,12 +26,12 @@
                         </div>
                         <div class="col-auto align-self-center">
                             {% if route_pin is not null %}
-                                <a href="{{ path(route_pin, {'id': comment.id, 'token': csrf_pin}) }}" class="btn{% if not comment.pinned %} btn-ghost-secondary{% else %} btn-ghost-info{% endif%} btn-icon {% if comment.pinned %}active{% endif %} pin-comment-link">{{ icon('pin') }}</a>
+                                <a href="{{ path(route_pin, {'id': comment.id, 'token': csrf_token('comment.pin')}) }}" class="btn{% if not comment.pinned %} btn-ghost-secondary{% else %} btn-ghost-info{% endif%} btn-icon {% if comment.pinned %}active{% endif %} pin-comment-link">{{ icon('pin') }}</a>
                             {% elseif comment.pinned %}
                                 {{ icon('pin') }}
                             {% endif %}
                             {% if route_delete is not null and ((not delete_by_user) or (delete_by_user and comment.createdBy.id == app.user.id)) %}
-                                <a href="{{ path(route_delete, {'id': comment.id, 'token': csrf_delete}) }}" class="confirmation-link btn btn-ghost-secondary btn-icon delete-comment-link" data-question="confirm.delete">{{ icon('delete') }}</a>
+                                <a href="{{ path(route_delete, {'id': comment.id, 'token': csrf_token('comment.delete')}) }}" class="confirmation-link btn btn-ghost-secondary btn-icon delete-comment-link" data-question="confirm.delete">{{ icon('delete') }}</a>
                             {% endif %}
                         </div>
                     </div>

--- a/templates/project/details.html.twig
+++ b/templates/project/details.html.twig
@@ -166,7 +166,7 @@
     {% if comments is not null %}
         {% set options = {'form': commentForm, 'comments': comments} %}
         {% if can_edit %}
-            {% set options = options|merge({'route_pin': 'project_comment_pin', 'route_delete': 'project_comment_delete', 'csrf_delete': 'project.delete_comment', 'csrf_pin': 'project.pin_comment'}) %}
+            {% set options = options|merge({'route_pin': 'project_comment_pin', 'route_delete': 'project_comment_delete'}) %}
         {% endif %}
         {{ include('embeds/comments.html.twig', options) }}
     {% endif %}


### PR DESCRIPTION
## Description

- unify CSRF token usage in comment sections

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] I verified that my code applies to the guidelines (`composer code-check`)
- [ ] I updated the documentation (see [here](https://github.com/kimai/www.kimai.org/tree/master/_documentation))
- [x] I agree that this code is used in Kimai (see [license](https://github.com/kimai/kimai/blob/main/LICENSE))
