### PR TITLE
Cleanup Docker tags

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -81,7 +81,6 @@ jobs:
             - name: Pull images
               run: |
                   docker pull kimai/kimai2:fpm
-                  docker pull kimai/kimai2:apache
 
             - name: Tag latest
               run: |

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -10,7 +10,6 @@ jobs:
     build:
         strategy:
             matrix:
-                type: [ dev, prod ]
                 server: [ fpm, apache ]
         runs-on: ubuntu-latest
 
@@ -43,11 +42,26 @@ jobs:
                       KIMAI=${{ env.kimai_version }}
                       TIMEZONE=Europe/London
                       BASE=${{ matrix.server }}
-                  target: ${{ matrix.type }}
-                  platforms: linux/amd64,linux/arm64 #,linux/arm/v8,linux/arm/v7,linux/arm/v6
+                  target: prod
+                  platforms: linux/amd64,linux/arm64
                   tags: |
-                      kimai/kimai2:${{ matrix.server }}-${{ matrix.type }}
-                      kimai/kimai2:${{ matrix.server }}-${{ env.kimai_version }}-${{ matrix.type }}
+                      kimai/kimai2:${{ matrix.server }}
+                      kimai/kimai2:${{ matrix.server }}-${{ env.kimai_version }}
+                  push: true
+
+            - name: Build dev image
+              if: matrix.server == 'apache'
+              uses: docker/build-push-action@v5
+              with:
+                  context: .
+                  build-args: |
+                      KIMAI=${{ env.kimai_version }}
+                      TIMEZONE=Europe/London
+                      BASE=apache
+                  target: dev
+                  platforms: linux/amd64,linux/arm64
+                  tags: |
+                      kimai/kimai2:dev
                   push: true
 
     tag:
@@ -66,35 +80,9 @@ jobs:
 
             - name: Pull images
               run: |
-                  docker pull kimai/kimai2:fpm-prod
-                  docker pull kimai/kimai2:fpm-dev
-                  docker pull kimai/kimai2:apache-prod
-                  docker pull kimai/kimai2:apache-dev
-
-            - name: Tag fpm
-              run: |
-                  docker buildx imagetools create -t kimai/kimai2:fpm kimai/kimai2:fpm-prod
-
-            - name: Tag fpm latest
-              run: |
-                  docker buildx imagetools create -t kimai/kimai2:fpm-latest kimai/kimai2:fpm-prod
+                  docker pull kimai/kimai2:fpm
+                  docker pull kimai/kimai2:apache
 
             - name: Tag latest
               run: |
-                  docker buildx imagetools create -t kimai/kimai2:latest kimai/kimai2:fpm-prod
-
-            - name: Tag prod
-              run: |
-                  docker buildx imagetools create -t kimai/kimai2:prod kimai/kimai2:fpm-prod
-
-            - name: Tag apache
-              run: |
-                  docker buildx imagetools create -t kimai/kimai2:apache kimai/kimai2:apache-prod
-
-            - name: Tag apache latest
-              run: |
-                  docker buildx imagetools create -t kimai/kimai2:apache-latest kimai/kimai2:apache-prod
-
-            - name: Tag dev
-              run: |
-                  docker buildx imagetools create -t kimai/kimai2:dev kimai/kimai2:apache-dev
+                  docker buildx imagetools create -t kimai/kimai2:latest kimai/kimai2:fpm


### PR DESCRIPTION
## Description

This will remove many deprecated Docker tags.

It is a breaking change for users of these deprecated tags, but it is easy to fix by simply switching to one of the three main tags `apache` or `fpm` (and its alias `latest`).

- [ ] Add blog post to on-premise section
- [x] Change Kimai Docker documentation
- [ ] Add Documentation to Docker Hub

This PR will remove the following tags and recommend replacements:

- kimai/kimai2:apache-prod (replaced by `kimai/kimai2:apache`)
- kimai/kimai2:apache-latest (replaced by `kimai/kimai2:apache`)
- kimai/kimai2:fpm-prod (replaced by `kimai/kimai2:fpm`)
- kimai/kimai2:fpm-latest (replaced by `kimai/kimai2:fpm`)
- kimai/kimai2:prod (replaced by `kimai/kimai2:fpm`)
- kimai/kimai2:apache-dev (replaced by `kimai/kimai2:dev`)
- kimai/kimai2:fpm-dev (**no replacement**)
- kimai/kimai2:apache-x.xx.x-prod (replaced by `kimai/kimai2:apache-x.xx.x`)
- kimai/kimai2:apache-x.xx.x-dev (**no replacement**)
- kimai/kimai2:fpm-x.xx.x-prod (replaced by `kimai/kimai2:fpm-x.xx.x`)
- kimai/kimai2:fpm-x.xx.x-dev (**no replacement**)

## Types of changes
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] I verified that my code applies to the guidelines (`composer code-check`)
- [ ] I updated the documentation (see [here](https://github.com/kimai/www.kimai.org/tree/master/_documentation))
- [x] I agree that this code is used in Kimai (see [license](https://github.com/kimai/kimai/blob/main/LICENSE))
