### PR TITLE
better support for special characters in DATABASE_URL

### DIFF
--- a/.docker/dbtest.php
+++ b/.docker/dbtest.php
@@ -1,6 +1,6 @@
 <?php
-$DB_HOST = urldecode(str_replace('+', '%2B', $argv[1]));
-$DB_BASE = urldecode(str_replace('+', '%2B', $argv[2]));
+$DB_HOST = urldecode($argv[1]);
+$DB_BASE = urldecode($argv[2]);
 $DB_PORT = $argv[3];
 $DB_USER = urldecode(str_replace('+', '%2B', $argv[4]));
 $DB_PASS = urldecode(str_replace('+', '%2B', $argv[5]));

--- a/.docker/dbtest.php
+++ b/.docker/dbtest.php
@@ -2,8 +2,8 @@
 $DB_HOST = urldecode($argv[1]);
 $DB_BASE = urldecode($argv[2]);
 $DB_PORT = $argv[3];
-$DB_USER = urldecode(str_replace('+', '%2B', $argv[4]));
-$DB_PASS = urldecode(str_replace('+', '%2B', $argv[5]));
+$DB_USER = urldecode($argv[4]);
+$DB_PASS = urldecode($argv[5]);
 
 echo "Testing DB:";
 echo "*";

--- a/.docker/dbtest.php
+++ b/.docker/dbtest.php
@@ -1,9 +1,9 @@
 <?php
-$DB_HOST = $argv[1];
-$DB_BASE = $argv[2];
+$DB_HOST = urldecode(str_replace('+', '%2B', $argv[1]));
+$DB_BASE = urldecode(str_replace('+', '%2B', $argv[2]));
 $DB_PORT = $argv[3];
-$DB_USER = $argv[4];
-$DB_PASS = $argv[5];
+$DB_USER = urldecode(str_replace('+', '%2B', $argv[4]));
+$DB_PASS = urldecode(str_replace('+', '%2B', $argv[5]));
 
 echo "Testing DB:";
 echo "*";


### PR DESCRIPTION
## Description
This is a fix for the previous implemetation with handling for the '+' charakter

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] I verified that my code applies to the guidelines (`composer code-check`)
- [ ] I updated the documentation (see [here](https://github.com/kimai/www.kimai.org/tree/master/_documentation))
- [x] I agree that this code is used in Kimai (see [license](https://github.com/kimai/kimai/blob/main/LICENSE))
