### PR TITLE
fix hydration issues in favorites

### DIFF
--- a/src/Controller/FavoriteController.php
+++ b/src/Controller/FavoriteController.php
@@ -32,7 +32,7 @@ final class FavoriteController extends AbstractController
     {
         $favoriteRecordService->addFavorite($timesheet);
 
-        return $this->render('favorite/index.html.twig');
+        return $this->redirectToRoute('favorites_timesheets');
     }
 
     #[Route(path: '/timesheet/remove/{id}', name: 'favorites_timesheets_remove', methods: ['GET'])]
@@ -41,6 +41,6 @@ final class FavoriteController extends AbstractController
     {
         $favoriteRecordService->removeFavorite($timesheet);
 
-        return $this->render('favorite/index.html.twig');
+        return $this->redirectToRoute('favorites_timesheets');
     }
 }

--- a/src/Timesheet/FavoriteRecordService.php
+++ b/src/Timesheet/FavoriteRecordService.php
@@ -112,11 +112,11 @@ final class FavoriteRecordService
     public function removeFavorite(Timesheet $timesheet): void
     {
         if ($timesheet->getUser() === null) {
-            throw new \InvalidArgumentException('Cannot favorite timesheet without user');
+            throw new \InvalidArgumentException('Cannot remove favorite without user');
         }
 
         if ($timesheet->getId() === null) {
-            throw new \InvalidArgumentException('Cannot favorite unsaved timesheet');
+            throw new \InvalidArgumentException('Cannot remove unsaved favorite');
         }
 
         $this->removeFavoriteById($timesheet->getUser(), $timesheet->getId());


### PR DESCRIPTION
## Description

Fixes error:
```
Uncaught PHP Exception Twig\Error\RuntimeError: "An exception has been thrown during the rendering of a template ("Typed property App\Entity\Project::$visible must not be accessed before initialization")." at index.html.twig line 12 
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] I verified that my code applies to the guidelines (`composer code-check`)
- [ ] I updated the documentation (see [here](https://github.com/kimai/www.kimai.org/tree/master/_documentation))
- [x] I agree that this code is used in Kimai (see [license](https://github.com/kimai/kimai/blob/main/LICENSE))
