### PR TITLE
Docker: Cleanup environment variables

### DIFF
--- a/.docker/dbtest.php
+++ b/.docker/dbtest.php
@@ -1,17 +1,17 @@
 <?php
-$DB_HOST = urldecode($argv[1]);
-$DB_BASE = urldecode($argv[2]);
-$DB_PORT = $argv[3];
-$DB_USER = urldecode($argv[4]);
-$DB_PASS = urldecode($argv[5]);
+$DATABASE_HOST = urldecode($argv[1]);
+$DATABASE_BASE = urldecode($argv[2]);
+$DATABASE_PORT = $argv[3];
+$DATABASE_USER = urldecode($argv[4]);
+$DATABASE_PASS = urldecode($argv[5]);
 
 echo "Testing DB:";
 echo "*";
-echo "* new \PDO(mysql:host=$DB_HOST;dbname=$DB_BASE;port=$DB_PORT, $DB_USER, $DB_PASS, [ \PDO::ATTR_ERRMODE => \PDO::ERRMODE_EXCEPTION ]);";
+echo "* new \PDO(mysql:host=$DATABASE_HOST;dbname=$DATABASE_BASE;port=$DATABASE_PORT, $DATABASE_USER, $DATABASE_PASS, [ \PDO::ATTR_ERRMODE => \PDO::ERRMODE_EXCEPTION ]);";
 echo "*";
 
 try {
-    $pdo = new \PDO("mysql:host=$DB_HOST;dbname=$DB_BASE;port=$DB_PORT", "$DB_USER", "$DB_PASS", [
+    $pdo = new \PDO("mysql:host=$DATABASE_HOST;dbname=$DATABASE_BASE;port=$DATABASE_PORT", "$DATABASE_USER", "$DATABASE_PASS", [
         \PDO::ATTR_ERRMODE => \PDO::ERRMODE_EXCEPTION
     ]);
 } catch(\Exception $ex) {

--- a/.docker/service.sh
+++ b/.docker/service.sh
@@ -2,30 +2,19 @@
 
 function waitForDB() {
   # Parse sql connection data
-  if [ ! -z "$DATABASE_URL" ]; then
-    DB_TYPE=$(awk -F '[/:@]' '{print $1}' <<< "$DATABASE_URL")
-    DB_USER=$(awk -F '[/:@]' '{print $4}' <<< "$DATABASE_URL")
-    DB_PASS=$(awk -F '[/:@]' '{print $5}' <<< "$DATABASE_URL")
-    DB_HOST=$(awk -F '[/:@]' '{print $6}' <<< "$DATABASE_URL")
-    DB_PORT=$(awk -F '[/:@]' '{print $7}' <<< "$DATABASE_URL")
-    DB_BASE=$(awk -F '[/?]' '{print $4}' <<< "$DATABASE_URL")
-  else
-    DB_TYPE=${DB_TYPE:mysql}
-    if [ "$DB_TYPE" == "mysql" ]; then
-      export DATABASE_URL="${DB_TYPE}://${DB_USER:=kimai}:${DB_PASS:=kimai}@${DB_HOST:=sqldb}:${DB_PORT:=3306}/${DB_BASE:=kimai}"
-    else
-      echo "Unknown database type, cannot proceed. Only 'mysql' is supported, received: [$DB_TYPE]"
-      exit 1
-    fi
-  fi
+  DATABASE_USER=$(awk -F '[/:@]' '{print $4}' <<< "$DATABASE_URL")
+  DATABASE_PASS=$(awk -F '[/:@]' '{print $5}' <<< "$DATABASE_URL")
+  DATABASE_HOST=$(awk -F '[/:@]' '{print $6}' <<< "$DATABASE_URL")
+  DATABASE_PORT=$(awk -F '[/:@]' '{print $7}' <<< "$DATABASE_URL")
+  DATABASE_BASE=$(awk -F '[/?]' '{print $4}' <<< "$DATABASE_URL")
 
   re='^[0-9]+$'
-  if ! [[ $DB_PORT =~ $re ]] ; then
-     DB_PORT=3306
+  if ! [[ $DATABASE_PORT =~ $re ]] ; then
+     DATABASE_PORT=3306
   fi
 
-  echo "Wait for MySQL DB connection ..."
-  until php /dbtest.php $DB_HOST $DB_BASE $DB_PORT $DB_USER $DB_PASS; do
+  echo "Wait for database connection ..."
+  until php /dbtest.php "$DATABASE_HOST" "$DATABASE_BASE" "$DATABASE_PORT" "$DATABASE_USER" "$DATABASE_PASS"; do
     echo Checking DB: $?
     sleep 3
   done
@@ -33,14 +22,14 @@ function waitForDB() {
 }
 
 function handleStartup() {
-  # These are idempotent, run them anyway
+  # These are idempotent, so we can run them on every start-up
   /opt/kimai/bin/console -n kimai:install
   /opt/kimai/bin/console -n kimai:update
   if [ ! -z "$ADMINPASS" ] && [ ! -a "$ADMINMAIL" ]; then
-    /opt/kimai/bin/console kimai:user:create superadmin "$ADMINMAIL" ROLE_SUPER_ADMIN "$ADMINPASS"
+    /opt/kimai/bin/console kimai:user:create admin "$ADMINMAIL" ROLE_SUPER_ADMIN "$ADMINPASS"
   fi
   echo "$KIMAI" > /opt/kimai/var/installed
-  echo "Kimai2 ready"
+  echo "Kimai is ready"
 }
 
 function runServer() {

--- a/.docker/startup.sh
+++ b/.docker/startup.sh
@@ -3,39 +3,25 @@
 KIMAI=$(cat /opt/kimai/version.txt)
 echo $KIMAI
 
-
 function config() {
   # set mem limits and copy in custom logger config
   if [ -z "$memory_limit" ]; then
     memory_limit=256M
   fi
 
-
-  # Parse sql connection data
-  if [ ! -z "$DATABASE_URL" ]; then
-    DB_TYPE=$(awk -F '[/:@]' '{print $1}' <<< "$DATABASE_URL")
-    DB_USER=$(awk -F '[/:@]' '{print $4}' <<< "$DATABASE_URL")
-    DB_PASS=$(awk -F '[/:@]' '{print $5}' <<< "$DATABASE_URL")
-    DB_HOST=$(awk -F '[/:@]' '{print $6}' <<< "$DATABASE_URL")
-    DB_PORT=$(awk -F '[/:@]' '{print $7}' <<< "$DATABASE_URL")
-    DB_BASE=$(awk -F '[/?]' '{print $4}' <<< "$DATABASE_URL")
-  else
-    DB_TYPE=${DB_TYPE:mysql}
-    if [ "$DB_TYPE" == "mysql" ]; then
-      export DATABASE_URL="${DB_TYPE}://${DB_USER:=kimai}:${DB_PASS:=kimai}@${DB_HOST:=sqldb}:${DB_PORT:=3306}/${DB_BASE:=kimai}"
-    else
-      echo "Unknown database type, cannot proceed. Only 'mysql' is supported, received: [$DB_TYPE]"
-      exit 1
-    fi
-  fi
+  DATABASE_USER=$(awk -F '[/:@]' '{print $4}' <<< "$DATABASE_URL")
+  DATABASE_PASS=$(awk -F '[/:@]' '{print $5}' <<< "$DATABASE_URL")
+  DATABASE_HOST=$(awk -F '[/:@]' '{print $6}' <<< "$DATABASE_URL")
+  DATABASE_PORT=$(awk -F '[/:@]' '{print $7}' <<< "$DATABASE_URL")
+  DATABASE_BASE=$(awk -F '[/?]' '{print $4}' <<< "$DATABASE_URL")
 
   re='^[0-9]+$'
-  if ! [[ $DB_PORT =~ $re ]] ; then
-     DB_PORT=3306
+  if ! [[ $DATABASE_PORT =~ $re ]] ; then
+     DATABASE_PORT=3306
   fi
 
-  echo "Wait for MySQL DB connection ..."
-  until php /dbtest.php $DB_HOST $DB_BASE $DB_PORT $DB_USER $DB_PASS; do
+  echo "Wait for database connection ..."
+  until php /dbtest.php "$DATABASE_HOST" "$DATABASE_BASE" "$DATABASE_PORT" "$DATABASE_USER" "$DATABASE_PASS"; do
     echo Checking DB: $?
     sleep 3
   done

--- a/Dockerfile
+++ b/Dockerfile
@@ -79,18 +79,11 @@ ENV MAILER_FROM=kimai@example.com
 ENV MAILER_URL=null://localhost
 ENV ADMINPASS=
 ENV ADMINMAIL=
-ENV DB_TYPE=
-ENV DB_USER=
-ENV DB_PASS=
-ENV DB_HOST=
-ENV DB_PORT=
-ENV DB_BASE=
-ENV COMPOSER_MEMORY_LIMIT=-1
-# If this set then the image will start, run a self test and then exit. It's used for the release process
-ENV TEST_AND_EXIT=
-ENV COMPOSER_ALLOW_SUPERUSER=1
 ENV USER_ID=
 ENV GROUP_ID=
+# default values to configure composer behavior
+ENV COMPOSER_MEMORY_LIMIT=-1
+ENV COMPOSER_ALLOW_SUPERUSER=1
 
 VOLUME [ "/opt/kimai/var" ]
 


### PR DESCRIPTION
## Description

- Cleanup the list of old ENV variables: some Docker tools show them and validate that they have a value (e.g. the Docker Container Manager from Synology) and that causes issues. As Kimai uses the DATABASE_URL everywhere, we should remove the old ones completely. I already removed them from the docs.
- The other bigger changes are renamed variables.
- And the username for the initial user account is changed from `superadmin` to `admin`.


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] I verified that my code applies to the guidelines (`composer code-check`)
- [x] I updated the documentation (see [here](https://github.com/kimai/www.kimai.org/tree/master/_documentation))
- [x] I agree that this code is used in Kimai (see [license](https://github.com/kimai/kimai/blob/main/LICENSE))
