### PR TITLE
API begin and end fields for Admins

### DIFF
--- a/src/Timesheet/TrackingMode/DefaultMode.php
+++ b/src/Timesheet/TrackingMode/DefaultMode.php
@@ -16,7 +16,7 @@ use Symfony\Component\HttpFoundation\Request;
 
 final class DefaultMode extends AbstractTrackingMode
 {
-    public function __construct(private RoundingService $rounding)
+    public function __construct(private readonly RoundingService $rounding)
     {
     }
 

--- a/src/Timesheet/TrackingMode/DurationFixedBeginMode.php
+++ b/src/Timesheet/TrackingMode/DurationFixedBeginMode.php
@@ -13,12 +13,16 @@ use App\Configuration\SystemConfiguration;
 use App\Entity\Timesheet;
 use DateTime;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 
 final class DurationFixedBeginMode implements TrackingModeInterface
 {
     use TrackingModeTrait;
 
-    public function __construct(private SystemConfiguration $configuration)
+    public function __construct(
+        private readonly SystemConfiguration $configuration,
+        private readonly AuthorizationCheckerInterface $authorizationChecker
+    )
     {
     }
 
@@ -39,7 +43,7 @@ final class DurationFixedBeginMode implements TrackingModeInterface
 
     public function canUpdateTimesWithAPI(): bool
     {
-        return false;
+        return $this->authorizationChecker->isGranted('view_other_timesheet');
     }
 
     public function create(Timesheet $timesheet, ?Request $request = null): void

--- a/src/Timesheet/TrackingMode/PunchInOutMode.php
+++ b/src/Timesheet/TrackingMode/PunchInOutMode.php
@@ -12,10 +12,17 @@ namespace App\Timesheet\TrackingMode;
 use App\Entity\Timesheet;
 use DateTime;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 
 final class PunchInOutMode implements TrackingModeInterface
 {
     use TrackingModeTrait;
+
+    public function __construct(
+        private readonly AuthorizationCheckerInterface $authorizationChecker
+    )
+    {
+    }
 
     public function canEditBegin(): bool
     {
@@ -34,7 +41,7 @@ final class PunchInOutMode implements TrackingModeInterface
 
     public function canUpdateTimesWithAPI(): bool
     {
-        return false;
+        return $this->authorizationChecker->isGranted('view_other_timesheet');
     }
 
     public function create(Timesheet $timesheet, ?Request $request = null): void

--- a/src/Timesheet/TrackingMode/TrackingModeInterface.php
+++ b/src/Timesheet/TrackingMode/TrackingModeInterface.php
@@ -23,61 +23,44 @@ use Symfony\Component\HttpFoundation\Request;
 interface TrackingModeInterface
 {
     /**
-     * Set default values on this new timesheet entity,
-     * before form data is rendered/processed.
-     *
-     * @param Timesheet $timesheet
-     * @param Request|null $request
+     * Set default values on this new timesheet entity, before form data is rendered/processed.
      */
     public function create(Timesheet $timesheet, ?Request $request = null): void;
 
     /**
      * Whether the user can edit the begin datetime.
-     *
-     * @return bool
      */
     public function canEditBegin(): bool;
 
     /**
      * Whether the user can edit the end datetime.
-     *
-     * @return bool
      */
     public function canEditEnd(): bool;
 
     /**
      * Whether the user can edit the duration.
-     * If this is true, the result of canEditEnd() will be ignored.
      *
-     * @return bool
+     * If this is true, the result of canEditEnd() will be ignored.
      */
     public function canEditDuration(): bool;
 
     /**
      * Whether the API can be used to manipulate the start and end times.
-     *
-     * @return bool
      */
     public function canUpdateTimesWithAPI(): bool;
 
     /**
      * Returns the edit template path for this tracking mode for regular user mode.
-     *
-     * @return string
      */
     public function getEditTemplate(): string;
 
     /**
      * Whether the real begin and end times are shown in the user timesheet.
-     *
-     * @return bool
      */
     public function canSeeBeginAndEndTimes(): bool;
 
     /**
      * Returns a unique identifier for this tracking mode.
-     *
-     * @return string
      */
     public function getId(): string;
 }

--- a/src/Timesheet/TrackingModeService.php
+++ b/src/Timesheet/TrackingModeService.php
@@ -16,8 +16,9 @@ use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
 
 final class TrackingModeService
 {
+    private ?TrackingModeInterface $active = null;
+
     /**
-     * @param SystemConfiguration $configuration
      * @param TrackingModeInterface[] $modes
      */
     public function __construct(
@@ -38,14 +39,23 @@ final class TrackingModeService
 
     public function getActiveMode(): TrackingModeInterface
     {
-        $trackingMode = $this->configuration->getTimesheetTrackingMode();
+        // internal caching for the current request
+        // there is no use-case to change that during one requests lifetime
+        if ($this->active === null) {
+            $trackingMode = $this->configuration->getTimesheetTrackingMode();
 
-        foreach ($this->getModes() as $mode) {
-            if ($mode->getId() === $trackingMode) {
-                return $mode;
+            foreach ($this->getModes() as $mode) {
+                if ($mode->getId() === $trackingMode) {
+                    $this->active = $mode;
+                    break;
+                }
+            }
+
+            if ($this->active === null) {
+                throw new ServiceNotFoundException($trackingMode);
             }
         }
 
-        throw new ServiceNotFoundException($trackingMode);
+        return $this->active;
     }
 }

--- a/tests/API/APIControllerBaseTest.php
+++ b/tests/API/APIControllerBaseTest.php
@@ -211,7 +211,7 @@ abstract class APIControllerBaseTest extends ControllerBaseTest
      * @param bool $extraFields test for the error "This form should not contain extra fields"
      * @param array<int, string>|array<string, mixed> $globalError
      */
-    protected function assertApiCallValidationError(Response $response, array $failedFields, bool $extraFields = false, array $globalError = []): void
+    protected function assertApiCallValidationError(Response $response, array $failedFields, bool $extraFields = false, array $globalError = [], array $expectedFields = [], array $missingFields = []): void
     {
         self::assertFalse($response->isSuccessful());
         $result = json_decode($response->getContent(), true);
@@ -231,6 +231,18 @@ abstract class APIControllerBaseTest extends ControllerBaseTest
 
         self::assertArrayHasKey('children', $result['errors']);
         $data = $result['errors']['children'];
+
+        if (\count($expectedFields) > 0) {
+            foreach ($expectedFields as $expectedField) {
+                $this->assertArrayHasKey($expectedField, $data, 'Expected field is missing: ' . $expectedField);
+            }
+        }
+
+        if (\count($missingFields) > 0) {
+            foreach ($missingFields as $missingField) {
+                $this->assertArrayNotHasKey($missingField, $data, 'Expected missing field is available: ' . $missingField);
+            }
+        }
 
         $foundErrors = [];
 

--- a/tests/Controller/TimesheetControllerTest.php
+++ b/tests/Controller/TimesheetControllerTest.php
@@ -295,6 +295,33 @@ class TimesheetControllerTest extends ControllerBaseTest
         $this->assertFalse($form->has('fixedRate'));
     }
 
+    public function getTrackingModeTestData(): array
+    {
+        return [
+            ['duration_fixed_begin', User::ROLE_USER, false, false],
+            ['duration_fixed_begin', User::ROLE_SUPER_ADMIN, false, false],
+            ['punch', User::ROLE_USER, false, false],
+            ['punch', User::ROLE_SUPER_ADMIN, false, false],
+            ['default', User::ROLE_USER, true, true],
+            ['default', User::ROLE_SUPER_ADMIN, true, true],
+        ];
+    }
+
+    /**
+     * @dataProvider getTrackingModeTestData
+     */
+    public function testCreateActionWithTrackingModeHasFieldsForUser(string $trackingMode, string $user, bool $showBeginTime, bool $showEndTime): void
+    {
+        $client = $this->getClientForAuthenticatedUser($user);
+        $this->setSystemConfiguration('timesheet.mode', $trackingMode);
+        $this->request($client, '/timesheet/create');
+        $this->assertTrue($client->getResponse()->isSuccessful());
+
+        $form = $client->getCrawler()->filter('form[name=timesheet_edit_form]')->form();
+        $this->assertEquals($showBeginTime, $form->has('timesheet_edit_form[begin_time]'));
+        $this->assertEquals($showEndTime, $form->has('timesheet_edit_form[end_time]'));
+    }
+
     public function testCreateActionWithFromAndToValues(): void
     {
         $client = $this->getClientForAuthenticatedUser(User::ROLE_ADMIN);

--- a/tests/Mocks/TrackingModeServiceFactory.php
+++ b/tests/Mocks/TrackingModeServiceFactory.php
@@ -14,6 +14,7 @@ use App\Timesheet\TrackingMode\DefaultMode;
 use App\Timesheet\TrackingMode\DurationFixedBeginMode;
 use App\Timesheet\TrackingMode\PunchInOutMode;
 use App\Timesheet\TrackingModeService;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 
 class TrackingModeServiceFactory extends AbstractMockFactory
 {
@@ -26,12 +27,13 @@ class TrackingModeServiceFactory extends AbstractMockFactory
         $loader = new TestConfigLoader([]);
 
         $configuration = SystemConfigurationFactory::create($loader, ['timesheet' => ['mode' => $mode]]);
+        $auth = $this->createMock(AuthorizationCheckerInterface::class);
 
         if (null === $modes) {
             $modes = [
                 new DefaultMode((new RoundingServiceFactory($this->getTestCase()))->create()),
-                new PunchInOutMode(),
-                new DurationFixedBeginMode($configuration),
+                new PunchInOutMode($auth),
+                new DurationFixedBeginMode($configuration, $auth),
             ];
         }
 

--- a/tests/Timesheet/TrackingMode/DurationFixedBeginModeTest.php
+++ b/tests/Timesheet/TrackingMode/DurationFixedBeginModeTest.php
@@ -16,18 +16,22 @@ use App\Tests\Mocks\SystemConfigurationFactory;
 use App\Timesheet\TrackingMode\DurationFixedBeginMode;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 
 /**
  * @covers \App\Timesheet\TrackingMode\DurationFixedBeginMode
  */
 class DurationFixedBeginModeTest extends TestCase
 {
-    protected function createSut($default = '13:47')
+    private function createSut(string $default = '13:47', bool $allowApiTimes = false): DurationFixedBeginMode
     {
         $loader = new TestConfigLoader([]);
         $configuration = SystemConfigurationFactory::create($loader, ['timesheet' => ['default_begin' => $default]]);
 
-        return new DurationFixedBeginMode($configuration);
+        $auth = $this->createMock(AuthorizationCheckerInterface::class);
+        $auth->method('isGranted')->willReturn($allowApiTimes);
+
+        return new DurationFixedBeginMode($configuration, $auth);
     }
 
     public function testDefaultValues(): void
@@ -38,6 +42,18 @@ class DurationFixedBeginModeTest extends TestCase
         self::assertFalse($sut->canEditEnd());
         self::assertTrue($sut->canEditDuration());
         self::assertFalse($sut->canUpdateTimesWithAPI());
+        self::assertFalse($sut->canSeeBeginAndEndTimes());
+        self::assertEquals('duration_fixed_begin', $sut->getId());
+    }
+
+    public function testValuesForAdmin(): void
+    {
+        $sut = $this->createSut('now', true);
+
+        self::assertFalse($sut->canEditBegin());
+        self::assertFalse($sut->canEditEnd());
+        self::assertTrue($sut->canEditDuration());
+        self::assertTrue($sut->canUpdateTimesWithAPI());
         self::assertFalse($sut->canSeeBeginAndEndTimes());
         self::assertEquals('duration_fixed_begin', $sut->getId());
     }

--- a/tests/phpstan.neon
+++ b/tests/phpstan.neon
@@ -3350,16 +3350,6 @@ parameters:
             path: Timesheet/TrackingMode/DurationFixedBeginModeTest.php
 
         -
-            message: "#^Method App\\\\Tests\\\\Timesheet\\\\TrackingMode\\\\DurationFixedBeginModeTest\\:\\:createSut\\(\\) has no return type specified\\.$#"
-            count: 1
-            path: Timesheet/TrackingMode/DurationFixedBeginModeTest.php
-
-        -
-            message: "#^Method App\\\\Tests\\\\Timesheet\\\\TrackingMode\\\\DurationFixedBeginModeTest\\:\\:createSut\\(\\) has parameter \\$default with no type specified\\.$#"
-            count: 1
-            path: Timesheet/TrackingMode/DurationFixedBeginModeTest.php
-
-        -
             message: "#^Method App\\\\Tests\\\\Timesheet\\\\UtilTest\\:\\:getRateCalculationData\\(\\) has no return type specified\\.$#"
             count: 1
             path: Timesheet/UtilTest.php


### PR DESCRIPTION
## Description

Changes API behavior for users with `view_other_timesheet` permission when one of `duration` or `mode` time-tracking mode is active.

Fixes #2241

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] I verified that my code applies to the guidelines (`composer code-check`)
- [ ] I updated the documentation (see [here](https://github.com/kimai/www.kimai.org/tree/master/_documentation))
- [x] I agree that this code is used in Kimai (see [license](https://github.com/kimai/kimai/blob/main/LICENSE))
