### PR TITLE
Use relative height for overlap line

### DIFF
--- a/assets/sass/tables.scss
+++ b/assets/sass/tables.scss
@@ -98,7 +98,7 @@ table.dataTable {
             width: 15px;
         }
         &.overlapping {
-            border-top: 2px solid rgba(214,57,57,.1);
+            border-top: 0.2rem solid rgba(214,57,57,.1);
         }
         &.exported {
             opacity: 0.7;

--- a/assets/sass/tables.scss
+++ b/assets/sass/tables.scss
@@ -98,7 +98,7 @@ table.dataTable {
             width: 15px;
         }
         &.overlapping {
-            border-top: 0.2rem solid rgba(214,57,57,.1);
+            border-top: 0.2rem solid rgba(214,57,57,.5);
         }
         &.exported {
             opacity: 0.7;


### PR DESCRIPTION
## Description
This PR fixes #2113 by using a relative height instead of an absolute one.
The height looks almost the same.

This PR, however, also makes the red line more visible.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] I verified that my code applies to the guidelines (`composer code-check`)
- [ ] I updated the documentation (see [here](https://github.com/kimai/www.kimai.org/tree/master/_documentation))
- [x] I agree that this code is used in Kimai (see [license](https://github.com/kimai/kimai/blob/main/LICENSE))

---

I ran `composer code-check` and there were some errors:

```
 ------ ----------------------------------------------------------------------------------------------------------------------------
  Line   Repository/RepositorySearchTrait.php (in context of class App\Repository\ActivityRepository)
 ------ ----------------------------------------------------------------------------------------------------------------------------
  68     PHPDoc tag @var with type literal-string&non-falsy-string is not subtype of native type lowercase-string&non-falsy-string.
 ------ ----------------------------------------------------------------------------------------------------------------------------

 ------ ----------------------------------------------------------------------------------------------------------------------------
  Line   Repository/RepositorySearchTrait.php (in context of class App\Repository\CustomerRepository)
 ------ ----------------------------------------------------------------------------------------------------------------------------
  68     PHPDoc tag @var with type literal-string&non-falsy-string is not subtype of native type lowercase-string&non-falsy-string.
 ------ ----------------------------------------------------------------------------------------------------------------------------

 ------ ----------------------------------------------------------------------------------------------------------------------------
  Line   Repository/RepositorySearchTrait.php (in context of class App\Repository\InvoiceRepository)
 ------ ----------------------------------------------------------------------------------------------------------------------------
  68     PHPDoc tag @var with type literal-string&non-falsy-string is not subtype of native type lowercase-string&non-falsy-string.
 ------ ----------------------------------------------------------------------------------------------------------------------------

 ------ ----------------------------------------------------------------------------------------------------------------------------
  Line   Repository/RepositorySearchTrait.php (in context of class App\Repository\ProjectRepository)
 ------ ----------------------------------------------------------------------------------------------------------------------------
  68     PHPDoc tag @var with type literal-string&non-falsy-string is not subtype of native type lowercase-string&non-falsy-string.
 ------ ----------------------------------------------------------------------------------------------------------------------------

 ------ ----------------------------------------------------------------------------------------------------------------------------
  Line   Repository/RepositorySearchTrait.php (in context of class App\Repository\TimesheetRepository)
 ------ ----------------------------------------------------------------------------------------------------------------------------
  68     PHPDoc tag @var with type literal-string&non-falsy-string is not subtype of native type lowercase-string&non-falsy-string.
 ------ ----------------------------------------------------------------------------------------------------------------------------
```