### PR TITLE
More daterange-picker selections

### DIFF
--- a/src/Form/Type/DateRangeType.php
+++ b/src/Form/Type/DateRangeType.php
@@ -88,8 +88,6 @@ final class DateRangeType extends AbstractType
                 'daterangepicker.yesterday' => [$factory->createDateTime('-1 day 00:00:00'), $factory->createDateTime('-1 day 23:59:59')],
                 'daterangepicker.thisWeek' => [$factory->getStartOfWeek(), $factory->getEndOfWeek()],
                 'daterangepicker.lastWeek' => [$factory->getStartOfWeek('-1 week'), $factory->getEndOfWeek('-1 week')],
-                'daterangepicker.thisMonth' => [$factory->getStartOfMonth(), $factory->getEndOfMonth()],
-                'daterangepicker.lastMonth' => [$factory->getStartOfLastMonth(), $factory->getEndOfLastMonth()],
                 'daterangepicker.thisYearUntilNow' => [$factory->createStartOfYear(), $factory->createDateTime('23:59:59')],
                 'divider1' => [],
             ];

--- a/src/Form/Type/DateRangeType.php
+++ b/src/Form/Type/DateRangeType.php
@@ -50,6 +50,7 @@ final class DateRangeType extends AbstractType
             'max_day' => null,
             'locale' => \Locale::getDefault(),
         ]);
+        $resolver->setAllowedTypes('locale', 'string');
         $resolver->setAllowedTypes('separator', 'string');
         $resolver->addAllowedTypes('timezone', 'string');
         $resolver->addAllowedTypes('min_day', ['null', 'string', \DateTimeInterface::class]);
@@ -75,6 +76,10 @@ final class DateRangeType extends AbstractType
 
     public function buildView(FormView $view, FormInterface $form, array $options): void
     {
+        if (!\is_string($options['locale'])) {
+            throw new \InvalidArgumentException('Locale needs to be a string');
+        }
+
         /** @var User $user */
         $user = $options['user'];
         $factory = DateTimeFactory::createByUser($user);
@@ -104,7 +109,7 @@ final class DateRangeType extends AbstractType
             // last quarters
             $month = clone $thisMonth;
             $quarterStartMonth = (int) (floor(($month->format('n') - 1) / 3) * 3) + 1;
-            $month = \DateTimeImmutable::createFromInterface($factory->getStartOfMonth($month->setDate($month->format('Y'), $quarterStartMonth, 1)));
+            $month = \DateTimeImmutable::createFromInterface($factory->getStartOfMonth($month->setDate((int) $month->format('Y'), $quarterStartMonth, 1)));
 
             for ($i = 0; $i < 4; $i++) {
                 $end = $factory->getEndOfMonth($month->add(new \DateInterval('P2M')));

--- a/src/Utils/LocaleFormatter.php
+++ b/src/Utils/LocaleFormatter.php
@@ -308,6 +308,11 @@ final class LocaleFormatter
         return $this->formatIntl($dateTime, ($withYear ? 'LLLL yyyy' : 'LLLL'));
     }
 
+    public function quarterName(\DateTimeInterface $dateTime, bool $withYear = false): string
+    {
+        return $this->formatIntl($dateTime, ($withYear ? 'QQQ yyyy' : 'QQQ'));
+    }
+
     public function dayName(\DateTimeInterface $dateTime, bool $short = false): string
     {
         return $this->formatIntl($dateTime, ($short ? 'EE' : 'EEEE'));

--- a/templates/form/blocks.html.twig
+++ b/templates/form/blocks.html.twig
@@ -180,7 +180,11 @@
         <button type="button" class="input-group-text dropdown-toggle btn-duration-preset" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false"></button>
         <div class="dropdown-menu dropdown-menu-start pre-scrollable">
             {% for title, range in ranges %}
-                <a class="dropdown-item" href="#" data-form-widget="copy-data" data-target="#{{ form.vars.id }}" data-value="{% if range[0] is not null %}{{ range[0]|format_date('short', rangeFormat) }}{{ attr['data-separator'] }}{{ range[1]|format_date('short', rangeFormat) }}{% endif %}" data-event="change keyup">{{ title|trans({}, 'daterangepicker') }}</a>
+                {% if range|length == 0 %}
+                    <hr class="dropdown-divider">
+                {% else %}
+                    <a class="dropdown-item" href="#" data-form-widget="copy-data" data-target="#{{ form.vars.id }}" data-value="{% if range[0] is not null %}{{ range[0]|format_date('short', rangeFormat) }}{{ attr['data-separator'] }}{{ range[1]|format_date('short', rangeFormat) }}{% endif %}" data-event="change keyup">{{ title|trans({}, 'daterangepicker') }}</a>
+                {% endif %}
             {% endfor %}
         </div>
         {% endif %}

--- a/tests/API/TimesheetControllerTest.php
+++ b/tests/API/TimesheetControllerTest.php
@@ -881,7 +881,7 @@ class TimesheetControllerTest extends APIControllerBaseTestCase
             'activity' => 10,
             'project' => 1,
             'begin' => (new \DateTime())->format('Y-m-d H:m'),
-            'end' => (new \DateTime('- 1 hours'))->format('Y-m-d H:m'),
+            'end' => (new \DateTime('-1 day'))->format('Y-m-d H:m'),
             'description' => 'foo',
         ];
         $json = json_encode($data);

--- a/tests/API/TimesheetControllerTest.php
+++ b/tests/API/TimesheetControllerTest.php
@@ -890,7 +890,7 @@ class TimesheetControllerTest extends APIControllerBaseTestCase
 
         $response = $client->getResponse();
         self::assertEquals(400, $response->getStatusCode());
-        $this->assertApiCallValidationError($response, ['activity'], false, ['End date must not be earlier then start date.']);
+        $this->assertApiCallValidationError($response, ['activity'], false, ['The end date must not be earlier than the start date.']);
     }
 
     // TODO: TEST PATCH FOR EXPORTED TIMESHEET FOR USER WITHOUT PERMISSION IS REJECTED

--- a/translations/daterangepicker.ar.xlf
+++ b/translations/daterangepicker.ar.xlf
@@ -18,14 +18,6 @@
         <source>daterangepicker.thisWeek</source>
         <target>هذا الأسبوع</target>
       </trans-unit>
-      <trans-unit id="AdEC6w4" resname="daterangepicker.lastMonth">
-        <source>daterangepicker.lastMonth</source>
-        <target>الشهر الماضي</target>
-      </trans-unit>
-      <trans-unit id="8f61k.L" resname="daterangepicker.thisMonth">
-        <source>daterangepicker.thisMonth</source>
-        <target>هذا الشهر</target>
-      </trans-unit>
       <trans-unit id="_9rEFED" resname="daterangepicker.lastYear">
         <source>daterangepicker.lastYear</source>
         <target>العام الماضي</target>

--- a/translations/daterangepicker.cs.xlf
+++ b/translations/daterangepicker.cs.xlf
@@ -18,14 +18,6 @@
         <source>daterangepicker.thisWeek</source>
         <target>Tento týden</target>
       </trans-unit>
-      <trans-unit id="AdEC6w4" resname="daterangepicker.lastMonth">
-        <source>daterangepicker.lastMonth</source>
-        <target>Minulý měsíc</target>
-      </trans-unit>
-      <trans-unit id="8f61k.L" resname="daterangepicker.thisMonth">
-        <source>daterangepicker.thisMonth</source>
-        <target>Tento měsíc</target>
-      </trans-unit>
       <trans-unit id="_9rEFED" resname="daterangepicker.lastYear">
         <source>daterangepicker.lastYear</source>
         <target>Minulý rok</target>

--- a/translations/daterangepicker.da.xlf
+++ b/translations/daterangepicker.da.xlf
@@ -18,14 +18,6 @@
         <source>daterangepicker.thisWeek</source>
         <target>Denne uge</target>
       </trans-unit>
-      <trans-unit id="AdEC6w4" resname="daterangepicker.lastMonth">
-        <source>daterangepicker.lastMonth</source>
-        <target>Sidste måned</target>
-      </trans-unit>
-      <trans-unit id="8f61k.L" resname="daterangepicker.thisMonth">
-        <source>daterangepicker.thisMonth</source>
-        <target>Denne måned</target>
-      </trans-unit>
       <trans-unit id="_9rEFED" resname="daterangepicker.lastYear">
         <source>daterangepicker.lastYear</source>
         <target>Sidste år</target>

--- a/translations/daterangepicker.de.xlf
+++ b/translations/daterangepicker.de.xlf
@@ -18,14 +18,6 @@
         <source>daterangepicker.thisWeek</source>
         <target>Diese Woche</target>
       </trans-unit>
-      <trans-unit id="AdEC6w4" resname="daterangepicker.lastMonth">
-        <source>daterangepicker.lastMonth</source>
-        <target>Letzter Monat</target>
-      </trans-unit>
-      <trans-unit id="8f61k.L" resname="daterangepicker.thisMonth">
-        <source>daterangepicker.thisMonth</source>
-        <target>Dieser Monat</target>
-      </trans-unit>
       <trans-unit id="_9rEFED" resname="daterangepicker.lastYear">
         <source>daterangepicker.lastYear</source>
         <target>Letztes Jahr</target>

--- a/translations/daterangepicker.de_CH.xlf
+++ b/translations/daterangepicker.de_CH.xlf
@@ -10,10 +10,6 @@
         <source>daterangepicker.thisYear</source>
         <target state="translated">Dieses Jahr</target>
       </trans-unit>
-      <trans-unit id="AdEC6w4" resname="daterangepicker.lastMonth">
-        <source>daterangepicker.lastMonth</source>
-        <target state="translated">Vergangener Monat</target>
-      </trans-unit>
       <trans-unit id="m0lJOke" resname="daterangepicker.allTime">
         <source>daterangepicker.allTime</source>
         <target state="translated">Gesamtzeitraum</target>
@@ -21,10 +17,6 @@
       <trans-unit id="HfcD1_y" resname="daterangepicker.thisWeek">
         <source>daterangepicker.thisWeek</source>
         <target state="translated">Diese Woche</target>
-      </trans-unit>
-      <trans-unit id="8f61k.L" resname="daterangepicker.thisMonth">
-        <source>daterangepicker.thisMonth</source>
-        <target state="translated">Dieser Monat</target>
       </trans-unit>
       <trans-unit id="s9Hdo7E" resname="daterangepicker.today">
         <source>daterangepicker.today</source>

--- a/translations/daterangepicker.el.xlf
+++ b/translations/daterangepicker.el.xlf
@@ -18,14 +18,6 @@
         <source>daterangepicker.thisWeek</source>
         <target>Τρέχων εβδομάδα</target>
       </trans-unit>
-      <trans-unit id="AdEC6w4" resname="daterangepicker.lastMonth">
-        <source>daterangepicker.lastMonth</source>
-        <target>Προηγούμενος μήνας</target>
-      </trans-unit>
-      <trans-unit id="8f61k.L" resname="daterangepicker.thisMonth">
-        <source>daterangepicker.thisMonth</source>
-        <target>Τρέχων μήνας</target>
-      </trans-unit>
       <trans-unit id="_9rEFED" resname="daterangepicker.lastYear">
         <source>daterangepicker.lastYear</source>
         <target>Προηγούμενο έτος</target>

--- a/translations/daterangepicker.en.xlf
+++ b/translations/daterangepicker.en.xlf
@@ -18,14 +18,6 @@
         <source>daterangepicker.thisWeek</source>
         <target>This week</target>
       </trans-unit>
-      <trans-unit id="AdEC6w4" resname="daterangepicker.lastMonth">
-        <source>daterangepicker.lastMonth</source>
-        <target>Last month</target>
-      </trans-unit>
-      <trans-unit id="8f61k.L" resname="daterangepicker.thisMonth">
-        <source>daterangepicker.thisMonth</source>
-        <target>This month</target>
-      </trans-unit>
       <trans-unit id="_9rEFED" resname="daterangepicker.lastYear">
         <source>daterangepicker.lastYear</source>
         <target>Last year</target>

--- a/translations/daterangepicker.eo.xlf
+++ b/translations/daterangepicker.eo.xlf
@@ -18,14 +18,6 @@
         <source>daterangepicker.thisWeek</source>
         <target>Ĉi-semajne</target>
       </trans-unit>
-      <trans-unit id="AdEC6w4" resname="daterangepicker.lastMonth">
-        <source>daterangepicker.lastMonth</source>
-        <target>Pasintmonate</target>
-      </trans-unit>
-      <trans-unit id="8f61k.L" resname="daterangepicker.thisMonth">
-        <source>daterangepicker.thisMonth</source>
-        <target>Ĉi-monate</target>
-      </trans-unit>
       <trans-unit id="_9rEFED" resname="daterangepicker.lastYear">
         <source>daterangepicker.lastYear</source>
         <target>Pasintjare</target>

--- a/translations/daterangepicker.es.xlf
+++ b/translations/daterangepicker.es.xlf
@@ -18,14 +18,6 @@
         <source>daterangepicker.thisWeek</source>
         <target>Esta semana</target>
       </trans-unit>
-      <trans-unit id="AdEC6w4" resname="daterangepicker.lastMonth">
-        <source>daterangepicker.lastMonth</source>
-        <target>El mes pasado</target>
-      </trans-unit>
-      <trans-unit id="8f61k.L" resname="daterangepicker.thisMonth">
-        <source>daterangepicker.thisMonth</source>
-        <target>Este mes</target>
-      </trans-unit>
       <trans-unit id="_9rEFED" resname="daterangepicker.lastYear">
         <source>daterangepicker.lastYear</source>
         <target>El año pasado</target>

--- a/translations/daterangepicker.et.xlf
+++ b/translations/daterangepicker.et.xlf
@@ -18,14 +18,6 @@
         <source>daterangepicker.thisWeek</source>
         <target state="translated">See nädal</target>
       </trans-unit>
-      <trans-unit id="AdEC6w4" resname="daterangepicker.lastMonth" xml:space="preserve">
-        <source>daterangepicker.lastMonth</source>
-        <target state="translated">Eelmine kuu</target>
-      </trans-unit>
-      <trans-unit id="8f61k.L" resname="daterangepicker.thisMonth" xml:space="preserve">
-        <source>daterangepicker.thisMonth</source>
-        <target state="translated">See kuu</target>
-      </trans-unit>
       <trans-unit id="_9rEFED" resname="daterangepicker.lastYear" xml:space="preserve">
         <source>daterangepicker.lastYear</source>
         <target state="translated">Eelmine aasta</target>

--- a/translations/daterangepicker.eu.xlf
+++ b/translations/daterangepicker.eu.xlf
@@ -18,14 +18,6 @@
         <source>daterangepicker.thisWeek</source>
         <target>Aste hau</target>
       </trans-unit>
-      <trans-unit id="AdEC6w4" resname="daterangepicker.lastMonth">
-        <source>daterangepicker.lastMonth</source>
-        <target>Azken hilabetea</target>
-      </trans-unit>
-      <trans-unit id="8f61k.L" resname="daterangepicker.thisMonth">
-        <source>daterangepicker.thisMonth</source>
-        <target>Hilabete hau</target>
-      </trans-unit>
       <trans-unit id="_9rEFED" resname="daterangepicker.lastYear">
         <source>daterangepicker.lastYear</source>
         <target>Azken urtea</target>

--- a/translations/daterangepicker.fa.xlf
+++ b/translations/daterangepicker.fa.xlf
@@ -18,14 +18,6 @@
         <source>daterangepicker.thisWeek</source>
         <target state="translated">این هفته</target>
       </trans-unit>
-      <trans-unit id="AdEC6w4" resname="daterangepicker.lastMonth">
-        <source>daterangepicker.lastMonth</source>
-        <target state="translated">ماه گذشته</target>
-      </trans-unit>
-      <trans-unit id="8f61k.L" resname="daterangepicker.thisMonth">
-        <source>daterangepicker.thisMonth</source>
-        <target state="translated">این ماه</target>
-      </trans-unit>
       <trans-unit id="_9rEFED" resname="daterangepicker.lastYear">
         <source>daterangepicker.lastYear</source>
         <target state="translated">سال گذشته</target>

--- a/translations/daterangepicker.fi.xlf
+++ b/translations/daterangepicker.fi.xlf
@@ -18,14 +18,6 @@
         <source>daterangepicker.thisWeek</source>
         <target state="translated">Tämä viikko</target>
       </trans-unit>
-      <trans-unit id="AdEC6w4" resname="daterangepicker.lastMonth">
-        <source>daterangepicker.lastMonth</source>
-        <target state="translated">Edellinen kuukausi</target>
-      </trans-unit>
-      <trans-unit id="8f61k.L" resname="daterangepicker.thisMonth">
-        <source>daterangepicker.thisMonth</source>
-        <target state="translated">Tämä kuukausi</target>
-      </trans-unit>
       <trans-unit id="_9rEFED" resname="daterangepicker.lastYear">
         <source>daterangepicker.lastYear</source>
         <target state="translated">Edellinen vuosi</target>

--- a/translations/daterangepicker.fo.xlf
+++ b/translations/daterangepicker.fo.xlf
@@ -18,14 +18,6 @@
         <source>daterangepicker.thisWeek</source>
         <target state="translated">Hesa vikuna</target>
       </trans-unit>
-      <trans-unit id="AdEC6w4" resname="daterangepicker.lastMonth">
-        <source>daterangepicker.lastMonth</source>
-        <target state="translated">Síðsta mánaða</target>
-      </trans-unit>
-      <trans-unit id="8f61k.L" resname="daterangepicker.thisMonth">
-        <source>daterangepicker.thisMonth</source>
-        <target state="translated">Hendan mánaðin</target>
-      </trans-unit>
       <trans-unit id="_9rEFED" resname="daterangepicker.lastYear">
         <source>daterangepicker.lastYear</source>
         <target state="translated">Síðsta ár</target>

--- a/translations/daterangepicker.fr.xlf
+++ b/translations/daterangepicker.fr.xlf
@@ -18,14 +18,6 @@
         <source>daterangepicker.thisWeek</source>
         <target>Cette semaine</target>
       </trans-unit>
-      <trans-unit id="AdEC6w4" resname="daterangepicker.lastMonth">
-        <source>daterangepicker.lastMonth</source>
-        <target>Mois dernier</target>
-      </trans-unit>
-      <trans-unit id="8f61k.L" resname="daterangepicker.thisMonth">
-        <source>daterangepicker.thisMonth</source>
-        <target>Ce mois-ci</target>
-      </trans-unit>
       <trans-unit id="_9rEFED" resname="daterangepicker.lastYear">
         <source>daterangepicker.lastYear</source>
         <target>L'an dernier</target>

--- a/translations/daterangepicker.he.xlf
+++ b/translations/daterangepicker.he.xlf
@@ -18,14 +18,6 @@
         <source>daterangepicker.thisWeek</source>
         <target>שבוע נוכחי</target>
       </trans-unit>
-      <trans-unit id="AdEC6w4" resname="daterangepicker.lastMonth">
-        <source>daterangepicker.lastMonth</source>
-        <target>חודש שעבר</target>
-      </trans-unit>
-      <trans-unit id="8f61k.L" resname="daterangepicker.thisMonth">
-        <source>daterangepicker.thisMonth</source>
-        <target>חודש נוכחי</target>
-      </trans-unit>
       <trans-unit id="_9rEFED" resname="daterangepicker.lastYear">
         <source>daterangepicker.lastYear</source>
         <target>שנה שעברה</target>

--- a/translations/daterangepicker.hr.xlf
+++ b/translations/daterangepicker.hr.xlf
@@ -18,14 +18,6 @@
         <source>daterangepicker.thisWeek</source>
         <target>Ovaj tjedan</target>
       </trans-unit>
-      <trans-unit id="AdEC6w4" resname="daterangepicker.lastMonth">
-        <source>daterangepicker.lastMonth</source>
-        <target>Prošli mjesec</target>
-      </trans-unit>
-      <trans-unit id="8f61k.L" resname="daterangepicker.thisMonth">
-        <source>daterangepicker.thisMonth</source>
-        <target>Ovaj mjesec</target>
-      </trans-unit>
       <trans-unit id="_9rEFED" resname="daterangepicker.lastYear">
         <source>daterangepicker.lastYear</source>
         <target>Prošla godina</target>

--- a/translations/daterangepicker.hu.xlf
+++ b/translations/daterangepicker.hu.xlf
@@ -18,14 +18,6 @@
         <source>daterangepicker.thisWeek</source>
         <target>Jelenlegi hét</target>
       </trans-unit>
-      <trans-unit id="AdEC6w4" resname="daterangepicker.lastMonth">
-        <source>daterangepicker.lastMonth</source>
-        <target>Előző hónap</target>
-      </trans-unit>
-      <trans-unit id="8f61k.L" resname="daterangepicker.thisMonth">
-        <source>daterangepicker.thisMonth</source>
-        <target>Jelenlegi hónap</target>
-      </trans-unit>
       <trans-unit id="_9rEFED" resname="daterangepicker.lastYear">
         <source>daterangepicker.lastYear</source>
         <target>Előző év</target>

--- a/translations/daterangepicker.id.xlf
+++ b/translations/daterangepicker.id.xlf
@@ -18,14 +18,6 @@
         <source>daterangepicker.thisWeek</source>
         <target state="translated">Minggu ini</target>
       </trans-unit>
-      <trans-unit id="AdEC6w4" resname="daterangepicker.lastMonth" xml:space="preserve">
-        <source>daterangepicker.lastMonth</source>
-        <target state="translated">Bulan lalu</target>
-      </trans-unit>
-      <trans-unit id="8f61k.L" resname="daterangepicker.thisMonth" xml:space="preserve">
-        <source>daterangepicker.thisMonth</source>
-        <target state="translated">Bulan Ini</target>
-      </trans-unit>
       <trans-unit id="_9rEFED" resname="daterangepicker.lastYear" xml:space="preserve">
         <source>daterangepicker.lastYear</source>
         <target state="translated">Tahun lalu</target>

--- a/translations/daterangepicker.it.xlf
+++ b/translations/daterangepicker.it.xlf
@@ -18,14 +18,6 @@
         <source>daterangepicker.thisWeek</source>
         <target state="final">Questa settimana</target>
       </trans-unit>
-      <trans-unit id="AdEC6w4" resname="daterangepicker.lastMonth" approved="yes">
-        <source>daterangepicker.lastMonth</source>
-        <target state="final">Mese scorso</target>
-      </trans-unit>
-      <trans-unit id="8f61k.L" resname="daterangepicker.thisMonth" approved="yes">
-        <source>daterangepicker.thisMonth</source>
-        <target state="final">Questo mese</target>
-      </trans-unit>
       <trans-unit id="_9rEFED" resname="daterangepicker.lastYear" approved="yes">
         <source>daterangepicker.lastYear</source>
         <target state="final">Anno scorso</target>

--- a/translations/daterangepicker.ja.xlf
+++ b/translations/daterangepicker.ja.xlf
@@ -18,14 +18,6 @@
         <source>daterangepicker.thisWeek</source>
         <target>今週</target>
       </trans-unit>
-      <trans-unit id="AdEC6w4" resname="daterangepicker.lastMonth">
-        <source>daterangepicker.lastMonth</source>
-        <target>先月</target>
-      </trans-unit>
-      <trans-unit id="8f61k.L" resname="daterangepicker.thisMonth">
-        <source>daterangepicker.thisMonth</source>
-        <target>今月</target>
-      </trans-unit>
       <trans-unit id="_9rEFED" resname="daterangepicker.lastYear">
         <source>daterangepicker.lastYear</source>
         <target>去年</target>

--- a/translations/daterangepicker.ko.xlf
+++ b/translations/daterangepicker.ko.xlf
@@ -18,14 +18,6 @@
         <source>daterangepicker.thisWeek</source>
         <target state="translated">이번 주</target>
       </trans-unit>
-      <trans-unit id="AdEC6w4" resname="daterangepicker.lastMonth">
-        <source>daterangepicker.lastMonth</source>
-        <target state="translated">지난달</target>
-      </trans-unit>
-      <trans-unit id="8f61k.L" resname="daterangepicker.thisMonth">
-        <source>daterangepicker.thisMonth</source>
-        <target state="translated">이번 달</target>
-      </trans-unit>
       <trans-unit id="_9rEFED" resname="daterangepicker.lastYear">
         <source>daterangepicker.lastYear</source>
         <target state="translated">작년</target>

--- a/translations/daterangepicker.nb_NO.xlf
+++ b/translations/daterangepicker.nb_NO.xlf
@@ -18,14 +18,6 @@
         <source>daterangepicker.thisWeek</source>
         <target>Denne uken</target>
       </trans-unit>
-      <trans-unit id="AdEC6w4" resname="daterangepicker.lastMonth">
-        <source>daterangepicker.lastMonth</source>
-        <target>Forrige måned</target>
-      </trans-unit>
-      <trans-unit id="8f61k.L" resname="daterangepicker.thisMonth">
-        <source>daterangepicker.thisMonth</source>
-        <target>Denne måneden</target>
-      </trans-unit>
       <trans-unit id="_9rEFED" resname="daterangepicker.lastYear">
         <source>daterangepicker.lastYear</source>
         <target>I fjor</target>

--- a/translations/daterangepicker.nl.xlf
+++ b/translations/daterangepicker.nl.xlf
@@ -18,14 +18,6 @@
         <source>daterangepicker.thisWeek</source>
         <target>Deze week</target>
       </trans-unit>
-      <trans-unit id="AdEC6w4" resname="daterangepicker.lastMonth">
-        <source>daterangepicker.lastMonth</source>
-        <target>Vorige maand</target>
-      </trans-unit>
-      <trans-unit id="8f61k.L" resname="daterangepicker.thisMonth">
-        <source>daterangepicker.thisMonth</source>
-        <target>Deze maand</target>
-      </trans-unit>
       <trans-unit id="_9rEFED" resname="daterangepicker.lastYear">
         <source>daterangepicker.lastYear</source>
         <target>Vorig jaar</target>

--- a/translations/daterangepicker.pl.xlf
+++ b/translations/daterangepicker.pl.xlf
@@ -18,14 +18,6 @@
         <source>daterangepicker.thisWeek</source>
         <target>Ten tydzień</target>
       </trans-unit>
-      <trans-unit id="AdEC6w4" resname="daterangepicker.lastMonth">
-        <source>daterangepicker.lastMonth</source>
-        <target state="translated">Ostatni miesiąc</target>
-      </trans-unit>
-      <trans-unit id="8f61k.L" resname="daterangepicker.thisMonth">
-        <source>daterangepicker.thisMonth</source>
-        <target>Ten miesiąc</target>
-      </trans-unit>
       <trans-unit id="_9rEFED" resname="daterangepicker.lastYear">
         <source>daterangepicker.lastYear</source>
         <target>Zeszły rok</target>

--- a/translations/daterangepicker.pt.xlf
+++ b/translations/daterangepicker.pt.xlf
@@ -18,14 +18,6 @@
         <source>daterangepicker.thisWeek</source>
         <target>Essa semana</target>
       </trans-unit>
-      <trans-unit id="AdEC6w4" resname="daterangepicker.lastMonth">
-        <source>daterangepicker.lastMonth</source>
-        <target>Último mês</target>
-      </trans-unit>
-      <trans-unit id="8f61k.L" resname="daterangepicker.thisMonth">
-        <source>daterangepicker.thisMonth</source>
-        <target>Esse mês</target>
-      </trans-unit>
       <trans-unit id="_9rEFED" resname="daterangepicker.lastYear">
         <source>daterangepicker.lastYear</source>
         <target>Último ano</target>

--- a/translations/daterangepicker.pt_BR.xlf
+++ b/translations/daterangepicker.pt_BR.xlf
@@ -18,14 +18,6 @@
         <source>daterangepicker.thisWeek</source>
         <target>Essa semana</target>
       </trans-unit>
-      <trans-unit id="AdEC6w4" resname="daterangepicker.lastMonth">
-        <source>daterangepicker.lastMonth</source>
-        <target>Último mês</target>
-      </trans-unit>
-      <trans-unit id="8f61k.L" resname="daterangepicker.thisMonth">
-        <source>daterangepicker.thisMonth</source>
-        <target>Esse mês</target>
-      </trans-unit>
       <trans-unit id="_9rEFED" resname="daterangepicker.lastYear">
         <source>daterangepicker.lastYear</source>
         <target>Último ano</target>

--- a/translations/daterangepicker.ro.xlf
+++ b/translations/daterangepicker.ro.xlf
@@ -18,14 +18,6 @@
         <source>daterangepicker.thisWeek</source>
         <target>Săptămâna aceasta</target>
       </trans-unit>
-      <trans-unit id="AdEC6w4" resname="daterangepicker.lastMonth">
-        <source>daterangepicker.lastMonth</source>
-        <target>Luna trecută</target>
-      </trans-unit>
-      <trans-unit id="8f61k.L" resname="daterangepicker.thisMonth">
-        <source>daterangepicker.thisMonth</source>
-        <target>Luna aceasta</target>
-      </trans-unit>
       <trans-unit id="_9rEFED" resname="daterangepicker.lastYear">
         <source>daterangepicker.lastYear</source>
         <target>Anul trecut</target>

--- a/translations/daterangepicker.ru.xlf
+++ b/translations/daterangepicker.ru.xlf
@@ -18,14 +18,6 @@
         <source>daterangepicker.thisWeek</source>
         <target>Эта неделя</target>
       </trans-unit>
-      <trans-unit id="AdEC6w4" resname="daterangepicker.lastMonth">
-        <source>daterangepicker.lastMonth</source>
-        <target>Прошлый месяц</target>
-      </trans-unit>
-      <trans-unit id="8f61k.L" resname="daterangepicker.thisMonth">
-        <source>daterangepicker.thisMonth</source>
-        <target>Этот месяц</target>
-      </trans-unit>
       <trans-unit id="_9rEFED" resname="daterangepicker.lastYear">
         <source>daterangepicker.lastYear</source>
         <target>Прошлый год</target>

--- a/translations/daterangepicker.sk.xlf
+++ b/translations/daterangepicker.sk.xlf
@@ -18,14 +18,6 @@
         <source>daterangepicker.thisWeek</source>
         <target>Tento týždeň</target>
       </trans-unit>
-      <trans-unit id="AdEC6w4" resname="daterangepicker.lastMonth">
-        <source>daterangepicker.lastMonth</source>
-        <target>Minulý mesiac</target>
-      </trans-unit>
-      <trans-unit id="8f61k.L" resname="daterangepicker.thisMonth">
-        <source>daterangepicker.thisMonth</source>
-        <target>Tento mesiac</target>
-      </trans-unit>
       <trans-unit id="_9rEFED" resname="daterangepicker.lastYear">
         <source>daterangepicker.lastYear</source>
         <target>Minulý rok</target>

--- a/translations/daterangepicker.sv.xlf
+++ b/translations/daterangepicker.sv.xlf
@@ -18,14 +18,6 @@
         <source>daterangepicker.thisWeek</source>
         <target state="translated">Denna veckan</target>
       </trans-unit>
-      <trans-unit id="AdEC6w4" resname="daterangepicker.lastMonth">
-        <source>daterangepicker.lastMonth</source>
-        <target state="translated">Förra månaden</target>
-      </trans-unit>
-      <trans-unit id="8f61k.L" resname="daterangepicker.thisMonth">
-        <source>daterangepicker.thisMonth</source>
-        <target state="translated">Denna månaden</target>
-      </trans-unit>
       <trans-unit id="_9rEFED" resname="daterangepicker.lastYear">
         <source>daterangepicker.lastYear</source>
         <target state="translated">Förra året</target>

--- a/translations/daterangepicker.ta.xlf
+++ b/translations/daterangepicker.ta.xlf
@@ -18,14 +18,6 @@
         <source>daterangepicker.thisWeek</source>
         <target state="final">இந்த வாரம்</target>
       </trans-unit>
-      <trans-unit id="AdEC6w4" resname="daterangepicker.lastMonth" xml:space="preserve" approved="yes">
-        <source>daterangepicker.lastMonth</source>
-        <target state="final">கடந்த திங்கள்</target>
-      </trans-unit>
-      <trans-unit id="8f61k.L" resname="daterangepicker.thisMonth" xml:space="preserve" approved="yes">
-        <source>daterangepicker.thisMonth</source>
-        <target state="final">இந்தத் திங்கள்</target>
-      </trans-unit>
       <trans-unit id="_9rEFED" resname="daterangepicker.lastYear" xml:space="preserve" approved="yes">
         <source>daterangepicker.lastYear</source>
         <target state="final">கடந்த ஆண்டு</target>

--- a/translations/daterangepicker.tr.xlf
+++ b/translations/daterangepicker.tr.xlf
@@ -18,14 +18,6 @@
         <source>daterangepicker.thisWeek</source>
         <target state="translated">Bu hafta</target>
       </trans-unit>
-      <trans-unit id="AdEC6w4" resname="daterangepicker.lastMonth">
-        <source>daterangepicker.lastMonth</source>
-        <target state="translated">Geçen ay</target>
-      </trans-unit>
-      <trans-unit id="8f61k.L" resname="daterangepicker.thisMonth">
-        <source>daterangepicker.thisMonth</source>
-        <target state="translated">Bu ay</target>
-      </trans-unit>
       <trans-unit id="_9rEFED" resname="daterangepicker.lastYear">
         <source>daterangepicker.lastYear</source>
         <target state="translated">Geçen yıl</target>

--- a/translations/daterangepicker.uk.xlf
+++ b/translations/daterangepicker.uk.xlf
@@ -18,14 +18,6 @@
         <source>daterangepicker.thisWeek</source>
         <target state="translated">Цей тиждень</target>
       </trans-unit>
-      <trans-unit id="AdEC6w4" resname="daterangepicker.lastMonth">
-        <source>daterangepicker.lastMonth</source>
-        <target state="translated">Минулий місяць</target>
-      </trans-unit>
-      <trans-unit id="8f61k.L" resname="daterangepicker.thisMonth">
-        <source>daterangepicker.thisMonth</source>
-        <target state="translated">Цей місяць</target>
-      </trans-unit>
       <trans-unit id="_9rEFED" resname="daterangepicker.lastYear">
         <source>daterangepicker.lastYear</source>
         <target state="translated">Минулий рік</target>

--- a/translations/daterangepicker.vi.xlf
+++ b/translations/daterangepicker.vi.xlf
@@ -18,14 +18,6 @@
         <source>daterangepicker.thisWeek</source>
         <target>Tuần này</target>
       </trans-unit>
-      <trans-unit id="AdEC6w4" resname="daterangepicker.lastMonth">
-        <source>daterangepicker.lastMonth</source>
-        <target>Tháng rồi</target>
-      </trans-unit>
-      <trans-unit id="8f61k.L" resname="daterangepicker.thisMonth">
-        <source>daterangepicker.thisMonth</source>
-        <target>Tháng này</target>
-      </trans-unit>
       <trans-unit id="_9rEFED" resname="daterangepicker.lastYear">
         <source>daterangepicker.lastYear</source>
         <target>Năm rồi</target>

--- a/translations/daterangepicker.zh_CN.xlf
+++ b/translations/daterangepicker.zh_CN.xlf
@@ -18,14 +18,6 @@
         <source>daterangepicker.thisWeek</source>
         <target>本周</target>
       </trans-unit>
-      <trans-unit id="AdEC6w4" resname="daterangepicker.lastMonth">
-        <source>daterangepicker.lastMonth</source>
-        <target>上月</target>
-      </trans-unit>
-      <trans-unit id="8f61k.L" resname="daterangepicker.thisMonth">
-        <source>daterangepicker.thisMonth</source>
-        <target>本月</target>
-      </trans-unit>
       <trans-unit id="_9rEFED" resname="daterangepicker.lastYear">
         <source>daterangepicker.lastYear</source>
         <target>去年</target>

--- a/translations/daterangepicker.zh_Hant.xlf
+++ b/translations/daterangepicker.zh_Hant.xlf
@@ -10,14 +10,6 @@
         <source>daterangepicker.lastYear</source>
         <target state="final">去年</target>
       </trans-unit>
-      <trans-unit id="AdEC6w4" resname="daterangepicker.lastMonth" xml:space="preserve" approved="yes">
-        <source>daterangepicker.lastMonth</source>
-        <target state="final">上個月</target>
-      </trans-unit>
-      <trans-unit id="8f61k.L" resname="daterangepicker.thisMonth" xml:space="preserve" approved="yes">
-        <source>daterangepicker.thisMonth</source>
-        <target state="final">本月</target>
-      </trans-unit>
       <trans-unit id="XgIrZS3" resname="daterangepicker.thisYear" xml:space="preserve" approved="yes">
         <source>daterangepicker.thisYear</source>
         <target state="final">今年</target>


### PR DESCRIPTION
## Description

- Added last months in dropdown
- Added last quarters in dropdown
- Removed "this month" (covered by last months)
- Removed "last month" (covered by last months)

<img width="205" alt="Bildschirmfoto 2025-01-24 um 13 39 15" src="https://github.com/user-attachments/assets/cdf78401-09af-4b22-b27d-028a463d4c2a" />
<img width="205" alt="Bildschirmfoto 2025-01-24 um 13 39 32" src="https://github.com/user-attachments/assets/48d78458-51f0-42b8-95f0-bfa2af2fe4e9" />

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] I verified that my code applies to the guidelines (`composer code-check`)
- [ ] I updated the documentation (see [here](https://github.com/kimai/www.kimai.org/tree/master/_documentation))
- [x] I agree that this code is used in Kimai (see [license](https://github.com/kimai/kimai/blob/main/LICENSE))
