### PR TITLE
[FEATURE] Allow time input without using colons

### DIFF
--- a/assets/js/forms/KimaiTimesheetForm.js
+++ b/assets/js/forms/KimaiTimesheetForm.js
@@ -433,7 +433,7 @@ export default class KimaiTimesheetForm extends KimaiFormPlugin {
     }
 
     /**
-     * Parses compact 12-hour input like "845am" into a formatted string like "8:45 AM".
+     * Parses compact 12-hour input (e.g., "845am", "1245 pm") and returns it as "h:mm AM/PM".
      * @private
      */
     parseCompact12HourTime(value) {
@@ -456,7 +456,7 @@ export default class KimaiTimesheetForm extends KimaiFormPlugin {
     }
 
     /**
-     * Parses numeric-only time like "1645" into 12h or 24h format.
+     * Parses numeric-only input (e.g., "545", "1645") and returns it as "h:mm AM/PM".
      * @private
      */
     parseCompact24HourTime(value, format) {

--- a/assets/js/forms/KimaiTimesheetForm.js
+++ b/assets/js/forms/KimaiTimesheetForm.js
@@ -404,13 +404,11 @@ export default class KimaiTimesheetForm extends KimaiFormPlugin {
      * Ruleset:
      * - if input already contains a colon and AM/PM, return unchanged
      * - if input matches compact 12-hour format (e.g., "845am", "1245 pm"), convert to "h:mm AM/PM"
-     * - if input is numeric-only (e.g., "545", "1645"):
-     *   - if 12-hour format is expected, convert to "h:mm AM/PM"
-     *   - if 24-hour format is expected, convert to "HH:mm"
+     * - if input is numeric-only (e.g., "545", "1645"), convert to "h:mm AM/PM"
      * - if input is invalid or cannot be parsed, return unchanged
      *
      * @param {string} input   Raw user-entered time string
-     * @param {string} format  Expected output format (e.g., "h:mm A" or "HH:mm")
+     * @param {string} format  Expected output format (should be a 12-hour format like "h:mm A")
      * @returns {string}       Formatted time string or original input
      */
     _formatTimeInput(input, format)

--- a/assets/js/forms/KimaiTimesheetForm.js
+++ b/assets/js/forms/KimaiTimesheetForm.js
@@ -419,12 +419,12 @@ export default class KimaiTimesheetForm extends KimaiFormPlugin {
             return trimmed;
         }
 
-        const twelveHour = this.parseCompact12HourTime(trimmed);
+        const twelveHour = this._parseCompact12HourTime(trimmed);
         if (twelveHour !== null) {
             return twelveHour;
         }
 
-        const twentyFourHour = this.parseCompact24HourTime(trimmed, format);
+        const twentyFourHour = this._parseCompact24HourTime(trimmed, format);
         if (twentyFourHour !== null) {
             return twentyFourHour;
         }
@@ -436,7 +436,7 @@ export default class KimaiTimesheetForm extends KimaiFormPlugin {
      * Parses compact 12-hour input (e.g., "845am", "1245 pm") and returns it as "h:mm AM/PM".
      * @private
      */
-    parseCompact12HourTime(value) {
+    _parseCompact12HourTime(value) {
         const match = value.match(/^(\d{3,4})\s*(am|pm)$/i);
         if (!match) {
             return null;
@@ -459,7 +459,7 @@ export default class KimaiTimesheetForm extends KimaiFormPlugin {
      * Parses numeric-only input (e.g., "545", "1645") and returns it as "h:mm AM/PM".
      * @private
      */
-    parseCompact24HourTime(value, format) {
+    _parseCompact24HourTime(value, format) {
         const digits = value.replace(/\D/g, '');
         if (!/^\d{3,4}$/.test(digits)) {
             return null;


### PR DESCRIPTION
## Description

This pull request provides a solution for [issue #4723](https://github.com/kimai/kimai/issues/4723), focusing on improving the UX of time input fields in the timesheet form.

### What it changes

Adds logic to automatically format user-entered time values when a time input field loses focus (`blur` event). This allows support for compact formats that users commonly type.

Examples:

| User Input | Resulting Value                              |
| ---------- | -------------------------------------------- |
| `545`      | `5:45 AM`                                    |
| `1645`     | `4:45 PM`                                    |
| `845am`    | `8:45 AM`                                    |
| `1245pm`   | `12:45 PM`                                   |
| `1245 pm`  | `12:45 PM`                                   |
| `2:15 PM`  | `2:15 PM`       *(unchanged, already valid)* |

[screencast.webm](https://github.com/user-attachments/assets/8d7c1b77-fa46-4fb3-876e-17c7229b5fd8)


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [X] I verified that my code applies to the guidelines (`composer code-check`)
- [ ] I updated the documentation (see [here](https://github.com/kimai/www.kimai.org/tree/master/_documentation))
- [X] I agree that this code is used in Kimai (see [license](https://github.com/kimai/kimai/blob/main/LICENSE))
