### PR TITLE
fix user update during LDAP authentication

### DIFF
--- a/src/Ldap/LdapManager.php
+++ b/src/Ldap/LdapManager.php
@@ -36,7 +36,6 @@ class LdapManager
 
         $criteria = [$params['usernameAttribute'] => $username];
 
-        $params = $this->config->getUserParameters();
         $filter = $this->buildFilter($criteria);
         $entries = $this->driver->search($params['baseDn'], $filter);
 
@@ -89,7 +88,9 @@ class LdapManager
         $user->setPreferenceValue('ldap_dn', $baseDn);
 
         $params = $this->config->getUserParameters();
-        $entries = $this->driver->search($baseDn, $params['attributesFilter']);
+        $criteria = [$params['usernameAttribute'] => $user->getUserIdentifier()];
+        $filter = $this->buildFilter($criteria);
+        $entries = $this->driver->search($params['baseDn'], $filter);
 
         if ($entries['count'] > 1) {
             throw new LdapDriverException('This search must only return a single user');


### PR DESCRIPTION
## Description
This PR fix an LDAP authentication problem. 
During LDAP authentication, the first phase consist of checking for user existence and binding with his password. 
Ones the binding is correct, the second phase is to update the user in database to reflect the LDAP informations. 

The problem is that the filters applied during the second phase where not the sames as in the first step.
This was leading to impossibly update the user although the LDAP binding was good. 
For exemple it was the case if an other entity with the same name outside the configured scope.

This PR consist of applying the same filters during LDAP binding and user update.  
It also removed a duplicated line in the findUserByUsername function.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] I verified that my code applies to the guidelines (`composer code-check`)
- [ ] I updated the documentation (see [here](https://github.com/kimai/www.kimai.org/tree/master/_documentation))
- [x] I agree that this code is used in Kimai (see [license](https://github.com/kimai/kimai/blob/main/LICENSE))
