### PR TITLE
Integrate WorkingTimeSpanBundle into core

### DIFF
--- a/src/EventSubscriber/WorkingTimeSpanConfigurationSubscriber.php
+++ b/src/EventSubscriber/WorkingTimeSpanConfigurationSubscriber.php
@@ -1,0 +1,62 @@
+<?php
+
+/*
+ * This file is part of the Kimai time-tracking app.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\EventSubscriber;
+
+use App\Event\SystemConfigurationEvent;
+use App\Form\Model\Configuration;
+use App\Form\Model\SystemConfiguration;
+use App\Form\Type\YesNoType;
+use App\WorkingTime\TimeSpanCalculator;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\Form\Extension\Core\Type\IntegerType;
+use Symfony\Component\Validator\Constraints\Range;
+
+final class WorkingTimeSpanConfigurationSubscriber implements EventSubscriberInterface
+{
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            SystemConfigurationEvent::class => ['onSystemConfiguration', 100],
+        ];
+    }
+
+    public function onSystemConfiguration(SystemConfigurationEvent $event): void
+    {
+        $event->addConfiguration(
+            (new SystemConfiguration('working_time_calc'))
+                ->setTranslationDomain('messages')
+                ->setConfiguration([
+                    (new Configuration('working_time_calc.enabled'))
+                        ->setLabel('working_time_calc.enabled')
+                        ->setType(YesNoType::class)
+                        ->setValue(true)
+                        ->setOptions([
+                            'help' => 'working_time_calc.enabled.help',
+                        ]),
+                    (new Configuration('working_time_calc.gap_tolerance'))
+                        ->setLabel('working_time_calc.gap_tolerance')
+                        ->setType(IntegerType::class)
+                        ->setValue(TimeSpanCalculator::DEFAULT_GAP_TOLERANCE_MINUTES)
+                        ->setConstraints([new Range(['min' => 0, 'max' => 60])])
+                        ->setOptions([
+                            'help' => 'working_time_calc.gap_tolerance.help',
+                        ]),
+                    (new Configuration('working_time_calc.max_duration'))
+                        ->setLabel('working_time_calc.max_duration')
+                        ->setType(IntegerType::class)
+                        ->setValue(TimeSpanCalculator::DEFAULT_MAX_DURATION_HOURS)
+                        ->setConstraints([new Range(['min' => 1, 'max' => 24])])
+                        ->setOptions([
+                            'help' => 'working_time_calc.max_duration.help',
+                        ]),
+                ])
+        );
+    }
+}

--- a/src/EventSubscriber/WorkingTimeSpanSubscriber.php
+++ b/src/EventSubscriber/WorkingTimeSpanSubscriber.php
@@ -1,0 +1,72 @@
+<?php
+
+/*
+ * This file is part of the Kimai time-tracking app.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\EventSubscriber;
+
+use App\Configuration\SystemConfiguration;
+use App\Event\WorkingTimeYearEvent;
+use App\WorkingTime\TimeSpanCalculator;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+final class WorkingTimeSpanSubscriber implements EventSubscriberInterface
+{
+    public function __construct(
+        private readonly SystemConfiguration $systemConfiguration,
+        private readonly TimeSpanCalculator $timeSpanCalculator,
+    ) {
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            // Priority > 150: must run before WorkContractBundle subscribers that read actualTime
+            WorkingTimeYearEvent::class => ['onWorkingTimeYear', 200],
+        ];
+    }
+
+    public function onWorkingTimeYear(WorkingTimeYearEvent $event): void
+    {
+        if (!$this->isEnabled()) {
+            return;
+        }
+
+        $year = $event->getYear();
+        $user = $year->getUser();
+        $until = $event->getUntil();
+
+        $yearDate = $year->getYear();
+        $stats = $this->timeSpanCalculator->calculateForYear($user, $yearDate);
+
+        foreach ($year->getMonths() as $month) {
+            foreach ($month->getDays() as $day) {
+                $dayDate = $day->getDay();
+
+                // Only process days up to "until" and not locked days
+                if ($dayDate > $until || $day->isLocked()) {
+                    continue;
+                }
+
+                $workingTime = $day->getWorkingTime();
+                if ($workingTime === null) {
+                    continue;
+                }
+
+                $key = $dayDate->format('Y-m-d');
+                if (\array_key_exists($key, $stats)) {
+                    $workingTime->setActualTime($stats[$key]);
+                }
+            }
+        }
+    }
+
+    private function isEnabled(): bool
+    {
+        return (bool) $this->systemConfiguration->find('working_time_calc.enabled');
+    }
+}

--- a/src/WorkingTime/TimeSpanCalculator.php
+++ b/src/WorkingTime/TimeSpanCalculator.php
@@ -1,0 +1,551 @@
+<?php
+
+/*
+ * This file is part of the Kimai time-tracking app.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\WorkingTime;
+
+use App\Configuration\SystemConfiguration;
+use App\Entity\Timesheet;
+use App\Entity\User;
+use App\Repository\TimesheetRepository;
+
+final class TimeSpanCalculator
+{
+    public const DEFAULT_GAP_TOLERANCE_MINUTES = 3;
+    public const DEFAULT_MAX_DURATION_HOURS = 16;
+
+    public function __construct(
+        private readonly SystemConfiguration $systemConfiguration,
+        private readonly TimesheetRepository $timesheetRepository,
+    ) {
+    }
+
+    /**
+     * Calculate working time for each day of the year.
+     *
+     * @return array<string, int> Format: ['Y-m-d' => seconds, ...]
+     */
+    public function calculateForYear(User $user, \DateTimeInterface $year): array
+    {
+        $maxDuration = $this->getMaxDuration();
+        $gapTolerance = $this->getGapTolerance();
+
+        // Load timesheets with buffer for year boundaries
+        $timesheets = $this->loadTimesheets($user, $year, $maxDuration);
+
+        // Filter out individual tasks that exceed max duration
+        $timesheets = $this->filterByMaxDuration($timesheets, $maxDuration);
+
+        // Group by start day (local date)
+        $groupedByDay = $this->groupByStartDay($timesheets);
+
+        // Track all days that originally had entries (before reassignment)
+        $daysWithEntries = array_keys($groupedByDay);
+
+        // Reassign entries that overlap with overnight entries from previous day
+        $groupedByDay = $this->reassignOverlappingEntries($groupedByDay, $gapTolerance);
+
+        // Process each day: merge overlapping entries
+        $results = [];
+        $carryOver = []; // Overflow from previous days due to 16h split
+
+        // Get year boundaries
+        $yearStart = new \DateTimeImmutable($year->format('Y') . '-01-01');
+        $yearEnd = new \DateTimeImmutable($year->format('Y') . '-12-31');
+
+        // Process from buffer start to buffer end to handle carry-overs correctly
+        $bufferStart = $yearStart->modify('-1 day');
+        $bufferEnd = $yearEnd->modify('+1 day');
+
+        $currentDay = $bufferStart;
+        while ($currentDay <= $bufferEnd) {
+            $dayKey = $currentDay->format('Y-m-d');
+            $dayEntries = $groupedByDay[$dayKey] ?? [];
+
+            // Add any carry-over from previous day's split
+            if (isset($carryOver[$dayKey])) {
+                $dayEntries = array_merge($carryOver[$dayKey], $dayEntries);
+                unset($carryOver[$dayKey]);
+            }
+
+            if (!empty($dayEntries)) {
+                // Merge overlapping/near entries into spans
+                $spans = $this->mergeEntriesToSpans($dayEntries, $gapTolerance);
+
+                // Check for 16h overnight split and process
+                $processedSpans = $this->processOvernightSplits(
+                    $spans,
+                    $currentDay,
+                    $maxDuration,
+                    $carryOver
+                );
+
+                // Calculate total duration minus breaks
+                $totalDuration = $this->calculateSpansDuration($processedSpans);
+
+                $results[$dayKey] = $totalDuration;
+            }
+
+            $currentDay = $currentDay->modify('+1 day');
+        }
+
+        // Add 0 for days that originally had entries but now have none (due to reassignment)
+        foreach ($daysWithEntries as $dayKey) {
+            if (!isset($results[$dayKey])) {
+                $results[$dayKey] = 0;
+            }
+        }
+
+        // Trim buffer days from results (results are sorted chronologically)
+        $yearStartStr = $yearStart->format('Y-m-d');
+        $yearEndStr = $yearEnd->format('Y-m-d');
+
+        // Trim from start: remove days before Jan 1
+        while (!empty($results)) {
+            $firstKey = array_key_first($results);
+            if ($firstKey < $yearStartStr) {
+                unset($results[$firstKey]);
+            } else {
+                break;
+            }
+        }
+
+        // Trim from end: remove days after Dec 31
+        while (!empty($results)) {
+            $lastKey = array_key_last($results);
+            if ($lastKey > $yearEndStr) {
+                unset($results[$lastKey]);
+            } else {
+                break;
+            }
+        }
+
+        return $results;
+    }
+
+    private function getGapTolerance(): int
+    {
+        $value = $this->systemConfiguration->find('working_time_calc.gap_tolerance');
+        $minutes = $value !== null ? (int) $value : self::DEFAULT_GAP_TOLERANCE_MINUTES;
+
+        return $minutes * 60;
+    }
+
+    private function getMaxDuration(): int
+    {
+        $value = $this->systemConfiguration->find('working_time_calc.max_duration');
+        $hours = $value !== null ? (int) $value : self::DEFAULT_MAX_DURATION_HOURS;
+
+        return $hours * 3600;
+    }
+
+    /**
+     * Load timesheets for the year with buffer for boundary handling.
+     *
+     * @return Timesheet[]
+     */
+    private function loadTimesheets(User $user, \DateTimeInterface $year, int $maxDuration): array
+    {
+        // Buffer: max_duration before year start, max_duration after year end
+        $begin = new \DateTimeImmutable($year->format('Y') . '-01-01 00:00:00');
+        $begin = $begin->modify("-{$maxDuration} seconds");
+
+        $end = new \DateTimeImmutable($year->format('Y') . '-12-31 23:59:59');
+        $end = $end->modify("+{$maxDuration} seconds");
+
+        $qb = $this->timesheetRepository->createQueryBuilder('t');
+
+        $qb
+            ->where($qb->expr()->isNotNull('t.end'))
+            ->andWhere($qb->expr()->gte('t.begin', ':begin'))
+            ->andWhere($qb->expr()->lte('t.begin', ':end'))
+            ->andWhere($qb->expr()->eq('t.user', ':user'))
+            ->setParameter('begin', $begin)
+            ->setParameter('end', $end)
+            ->setParameter('user', $user->getId())
+            ->orderBy('t.begin', 'ASC');
+
+        return $qb->getQuery()->getResult();
+    }
+
+    /**
+     * Filter out timesheets that exceed maximum duration.
+     *
+     * @param Timesheet[] $timesheets
+     * @return Timesheet[]
+     */
+    private function filterByMaxDuration(array $timesheets, int $maxDuration): array
+    {
+        return array_filter($timesheets, function (Timesheet $entry) use ($maxDuration) {
+            $end = $entry->getEnd();
+            $begin = $entry->getBegin();
+            if ($end === null || $begin === null) {
+                return false;
+            }
+            $duration = $end->getTimestamp() - $begin->getTimestamp();
+
+            return $duration <= $maxDuration;
+        });
+    }
+
+    /**
+     * Group timesheets by their start day (local date).
+     *
+     * getBegin() returns a localized DateTime (calls localizeDates() internally),
+     * so format('Y-m-d') gives the local date in the user's timezone.
+     *
+     * @param Timesheet[] $timesheets
+     * @return array<string, Timesheet[]>
+     */
+    private function groupByStartDay(array $timesheets): array
+    {
+        $grouped = [];
+
+        foreach ($timesheets as $entry) {
+            $begin = $entry->getBegin();
+            if ($begin === null) {
+                continue;
+            }
+            // getBegin() returns localized DateTime, so this is the local date
+            $dayKey = $begin->format('Y-m-d');
+            $grouped[$dayKey][] = $entry;
+        }
+
+        return $grouped;
+    }
+
+    /**
+     * Reassign entries that overlap with overnight entries from the previous day.
+     *
+     * Example: Entry A ends at 01:06 on day X+1 (started on day X).
+     * Entry B starts at 00:45 on day X+1 and overlaps with A.
+     * Entry B should be moved to day X to be merged with A.
+     *
+     * @param array<string, Timesheet[]> $groupedByDay
+     * @param int $gapTolerance
+     * @return array<string, Timesheet[]>
+     */
+    private function reassignOverlappingEntries(array $groupedByDay, int $gapTolerance): array
+    {
+        // Sort days chronologically
+        ksort($groupedByDay);
+        $days = array_keys($groupedByDay);
+
+        $previousDayKey = null;
+        $previousLatestEnd = null;
+
+        foreach ($days as $dayKey) {
+            // Check if we have an overnight overlap from previous day
+            if ($previousDayKey !== null && $previousLatestEnd !== null) {
+                // Verify this is actually the next calendar day
+                $expectedNextDay = (new \DateTimeImmutable($previousDayKey))
+                        ->modify('+1 day')
+                        ->format('Y-m-d');
+
+                if ($dayKey === $expectedNextDay) {
+                    $midnight = new \DateTimeImmutable(
+                        $dayKey . ' 00:00:00',
+                        $previousLatestEnd->getTimezone()
+                    );
+
+                    // Check if previous day extends past midnight
+                    if ($previousLatestEnd > $midnight) {
+                        // Find and move overlapping entries
+                        $entriesToMove = [];
+                        $entriesToKeep = [];
+
+                        foreach ($groupedByDay[$dayKey] as $entry) {
+                            $entryBegin = $entry->getBegin();
+                            if ($entryBegin === null) {
+                                continue;
+                            }
+                            $gap = $entryBegin->getTimestamp() - $previousLatestEnd->getTimestamp();
+
+                            if ($gap <= $gapTolerance) {
+                                $entriesToMove[] = $entry;
+                                // Update latestEnd if this entry extends further
+                                $entryEnd = $entry->getEnd();
+                                if ($entryEnd !== null && $entryEnd > $previousLatestEnd) {
+                                    $previousLatestEnd = $entryEnd;
+                                }
+                            } else {
+                                $entriesToKeep[] = $entry;
+                            }
+                        }
+
+                        if (!empty($entriesToMove)) {
+                            $groupedByDay[$previousDayKey] = array_merge(
+                                $groupedByDay[$previousDayKey],
+                                $entriesToMove
+                            );
+
+                            if (empty($entriesToKeep)) {
+                                unset($groupedByDay[$dayKey]);
+                                // Skip updating previous - continue with same overnight span
+                                continue;
+                            } else {
+                                $groupedByDay[$dayKey] = $entriesToKeep;
+                            }
+                        }
+                    }
+                }
+            }
+
+            // Calculate latest end for current day
+            $latestEnd = null;
+            foreach ($groupedByDay[$dayKey] ?? [] as $entry) {
+                if ($latestEnd === null || $entry->getEnd() > $latestEnd) {
+                    $latestEnd = $entry->getEnd();
+                }
+            }
+
+            $previousDayKey = $dayKey;
+            $previousLatestEnd = $latestEnd;
+        }
+
+        return $groupedByDay;
+    }
+
+    /**
+     * Merge overlapping or near entries into time spans.
+     *
+     * @param array<Timesheet|array{virtual: bool, start: \DateTimeInterface, end: \DateTimeInterface, break: int}> $entries
+     * @return array<array{start: \DateTimeInterface, end: \DateTimeInterface, entries: array<Timesheet|array{virtual: bool, start: \DateTimeInterface, end: \DateTimeInterface, break: int}>}>
+     */
+    private function mergeEntriesToSpans(array $entries, int $gapTolerance): array
+    {
+        if (empty($entries)) {
+            return [];
+        }
+
+        // Sort by start time
+        usort($entries, function ($a, $b) {
+            $startA = $a instanceof Timesheet ? $a->getBegin() : $a['start'];
+            $startB = $b instanceof Timesheet ? $b->getBegin() : $b['start'];
+
+            return $startA <=> $startB;
+        });
+
+        $spans = [];
+        $currentSpan = null;
+
+        foreach ($entries as $entry) {
+            $entryStart = $entry instanceof Timesheet ? $entry->getBegin() : $entry['start'];
+            $entryEnd = $entry instanceof Timesheet ? $entry->getEnd() : $entry['end'];
+
+            // Skip entries with null start/end
+            if ($entryStart === null || $entryEnd === null) {
+                continue;
+            }
+
+            if ($currentSpan === null) {
+                $currentSpan = [
+                    'start' => $entryStart,
+                    'end' => $entryEnd,
+                    'entries' => [$entry],
+                ];
+                continue;
+            }
+
+            // Check if entry overlaps or is near enough
+            /** @var \DateTimeInterface $currentSpanEnd */
+            $currentSpanEnd = $currentSpan['end'];
+            $gap = $entryStart->getTimestamp() - $currentSpanEnd->getTimestamp();
+
+            if ($gap <= $gapTolerance) {
+                // Merge: extend span if needed
+                if ($entryEnd > $currentSpanEnd) {
+                    $currentSpan['end'] = $entryEnd;
+                }
+                $currentSpan['entries'][] = $entry;
+            } else {
+                // Start new span
+                $spans[] = $currentSpan;
+                $currentSpan = [
+                    'start' => $entryStart,
+                    'end' => $entryEnd,
+                    'entries' => [$entry],
+                ];
+            }
+        }
+
+        if (!empty($currentSpan)) {
+            $spans[] = $currentSpan;
+        }
+
+        return $spans;
+    }
+
+    /**
+     * Process overnight splits for spans that extend >16h past midnight.
+     *
+     * @param array<array{start: \DateTimeInterface, end: \DateTimeInterface, entries: array<Timesheet|array{virtual: bool, start: \DateTimeInterface, end: \DateTimeInterface, break: int}>}> $spans
+     * @param array<string, array<array{virtual: bool, start: \DateTimeInterface, end: \DateTimeInterface, break: int}>> $carryOver
+     * @return array<array{start: \DateTimeInterface, end: \DateTimeInterface, entries: array<Timesheet|array{virtual: bool, start: \DateTimeInterface, end: \DateTimeInterface, break: int}>}>
+     */
+    private function processOvernightSplits(
+        array $spans,
+        \DateTimeInterface $currentDay,
+        int $maxDuration,
+        array &$carryOver
+    ): array {
+        $processedSpans = [];
+        $nextMidnight = new \DateTimeImmutable($currentDay->format('Y-m-d') . ' 00:00:00');
+        $nextMidnight = $nextMidnight->modify('+1 day');
+
+        foreach ($spans as $span) {
+            $spanEnd = $span['end'];
+
+            // Check if span extends past midnight
+            if ($spanEnd <= $nextMidnight) {
+                // Span ends before or at midnight - no overnight issue
+                $processedSpans[] = $span;
+                continue;
+            }
+
+            // Span extends into next day - calculate hours after midnight
+            $hoursAfterMidnight = $spanEnd->getTimestamp() - $nextMidnight->getTimestamp();
+
+            if ($hoursAfterMidnight <= $maxDuration) {
+                // Less than 16h after midnight - no split needed
+                $processedSpans[] = $span;
+                continue;
+            }
+
+            // More than 16h after midnight - need to split
+            // Find the split point: end of the last entry that ends before the 16h mark
+            $splitPoint = $this->findSplitPoint($span['entries'], $nextMidnight, $maxDuration);
+
+            if ($splitPoint !== null) {
+                // Create span for current day (up to split point)
+                $entriesBeforeSplit = $this->getEntriesEndingBefore($span['entries'], $splitPoint);
+                $processedSpans[] = [
+                    'start' => $span['start'],
+                    'end' => $splitPoint,
+                    'entries' => $entriesBeforeSplit,
+                ];
+
+                // Create carry-over for next day (from split point onwards)
+                $entriesAfterSplit = $this->getEntriesEndingAfter($span['entries'], $splitPoint);
+                if (!empty($entriesAfterSplit)) {
+                    $nextDayKey = $nextMidnight->format('Y-m-d');
+                    $carryOver[$nextDayKey][] = [
+                        'virtual' => true,
+                        'start' => $splitPoint,
+                        'end' => $spanEnd,
+                        'break' => $this->sumBreaksFromEntries($entriesAfterSplit),
+                    ];
+                }
+            } else {
+                // No valid split point found, include entire span
+                $processedSpans[] = $span;
+            }
+        }
+
+        return $processedSpans;
+    }
+
+    /**
+     * Find the split point for overnight split.
+     * Returns the end time of the last entry that ends at or before the 16h mark.
+     *
+     * @param array<Timesheet|array{virtual: bool, start: \DateTimeInterface, end: \DateTimeInterface, break: int}> $entries
+     */
+    private function findSplitPoint(array $entries, \DateTimeInterface $midnight, int $maxDuration): ?\DateTimeInterface
+    {
+        $maxTime = $midnight->getTimestamp() + $maxDuration;
+        $lastValidEnd = null;
+
+        foreach ($entries as $entry) {
+            $entryEnd = $entry instanceof Timesheet ? $entry->getEnd() : $entry['end'];
+            if ($entryEnd === null) {
+                continue;
+            }
+            if ($entryEnd->getTimestamp() <= $maxTime) {
+                if ($lastValidEnd === null || $entryEnd > $lastValidEnd) {
+                    $lastValidEnd = $entryEnd;
+                }
+            }
+        }
+
+        return $lastValidEnd;
+    }
+
+    /**
+     * Get entries that end at or before the given time.
+     *
+     * @param array<Timesheet|array{virtual: bool, start: \DateTimeInterface, end: \DateTimeInterface, break: int}> $entries
+     * @return array<Timesheet|array{virtual: bool, start: \DateTimeInterface, end: \DateTimeInterface, break: int}>
+     */
+    private function getEntriesEndingBefore(array $entries, \DateTimeInterface $time): array
+    {
+        return array_filter($entries, function ($entry) use ($time) {
+            $end = $entry instanceof Timesheet ? $entry->getEnd() : $entry['end'];
+
+            return $end <= $time;
+        });
+    }
+
+    /**
+     * Get entries that end after the given time.
+     *
+     * @param array<Timesheet|array{virtual: bool, start: \DateTimeInterface, end: \DateTimeInterface, break: int}> $entries
+     * @return array<Timesheet|array{virtual: bool, start: \DateTimeInterface, end: \DateTimeInterface, break: int}>
+     */
+    private function getEntriesEndingAfter(array $entries, \DateTimeInterface $time): array
+    {
+        return array_filter($entries, function ($entry) use ($time) {
+            $end = $entry instanceof Timesheet ? $entry->getEnd() : $entry['end'];
+
+            return $end > $time;
+        });
+    }
+
+    /**
+     * Sum breaks from entries (Timesheet or virtual).
+     *
+     * @param array<Timesheet|array{virtual: bool, start: \DateTimeInterface, end: \DateTimeInterface, break: int}> $entries
+     */
+    private function sumBreaksFromEntries(array $entries): int
+    {
+        $total = 0;
+        foreach ($entries as $entry) {
+            if ($entry instanceof Timesheet) {
+                $total += $entry->getBreak();
+            } elseif (\is_array($entry) && isset($entry['break'])) {
+                $total += (int) $entry['break'];
+            }
+        }
+
+        return $total;
+    }
+
+    /**
+     * Calculate total duration of spans minus breaks.
+     *
+     * @param array<array{start: \DateTimeInterface, end: \DateTimeInterface, entries: array<Timesheet|array{virtual: bool, start: \DateTimeInterface, end: \DateTimeInterface, break: int}>}> $spans
+     * @return int Duration in seconds (minimum 0)
+     */
+    private function calculateSpansDuration(array $spans): int
+    {
+        $totalDuration = 0;
+        $totalBreaks = 0;
+
+        foreach ($spans as $span) {
+            $spanDuration = $span['end']->getTimestamp() - $span['start']->getTimestamp();
+            $totalDuration += $spanDuration;
+
+            // Sum breaks from all entries in this span
+            if (isset($span['entries'])) {
+                $totalBreaks += $this->sumBreaksFromEntries($span['entries']);
+            }
+        }
+
+        return (int) max(0, $totalDuration - $totalBreaks);
+    }
+}

--- a/tests/Controller/SystemConfigurationControllerTest.php
+++ b/tests/Controller/SystemConfigurationControllerTest.php
@@ -90,6 +90,7 @@ class SystemConfigurationControllerTest extends AbstractControllerBaseTestCase
             ['form[name=system_configuration_form_theme]', $this->createUrl('/admin/system-config/update/theme')],
             ['form[name=system_configuration_form_calendar]', $this->createUrl('/admin/system-config/update/calendar')],
             ['form[name=system_configuration_form_branding]', $this->createUrl('/admin/system-config/update/branding')],
+            ['form[name=system_configuration_form_working_time_calc]', $this->createUrl('/admin/system-config/update/working_time_calc')],
         ];
     }
 

--- a/tests/WorkingTime/TimeSpanCalculatorTest.php
+++ b/tests/WorkingTime/TimeSpanCalculatorTest.php
@@ -1,0 +1,373 @@
+<?php
+
+/*
+ * This file is part of the Kimai time-tracking app.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Tests\WorkingTime;
+
+use App\Entity\Timesheet;
+use App\Entity\User;
+use App\Repository\TimesheetRepository;
+use App\Tests\Mocks\SystemConfigurationFactory;
+use App\WorkingTime\TimeSpanCalculator;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(TimeSpanCalculator::class)]
+class TimeSpanCalculatorTest extends TestCase
+{
+    private function getSut(array $timesheets, array $config = []): TimeSpanCalculator
+    {
+        $configuration = SystemConfigurationFactory::createStub($config);
+        $repository = $this->createRepositoryMock($timesheets);
+
+        return new TimeSpanCalculator($configuration, $repository);
+    }
+
+    private function createRepositoryMock(array $timesheets): TimesheetRepository
+    {
+        $qb = $this->createMock(\Doctrine\ORM\QueryBuilder::class);
+        $qb->method('where')->willReturnSelf();
+        $qb->method('andWhere')->willReturnSelf();
+        $qb->method('setParameter')->willReturnSelf();
+        $qb->method('orderBy')->willReturnSelf();
+        $qb->method('expr')->willReturn(new \Doctrine\ORM\Query\Expr());
+
+        $query = $this->createMock(\Doctrine\ORM\AbstractQuery::class);
+        $query->method('getResult')->willReturn($timesheets);
+        $qb->method('getQuery')->willReturn($query);
+
+        $repository = $this->createMock(TimesheetRepository::class);
+        $repository->method('createQueryBuilder')->willReturn($qb);
+
+        return $repository;
+    }
+
+    private function createUser(string $timezone = 'Europe/Berlin'): User
+    {
+        $user = new User();
+        $user->setUserIdentifier('test_user_span');
+        $user->setTimezone($timezone);
+
+        return $user;
+    }
+
+    private function createTimesheet(User $user, string $begin, string $end, int $break = 0): Timesheet
+    {
+        $timezone = new \DateTimeZone($user->getTimezone());
+
+        $timesheet = new Timesheet();
+        $timesheet->setUser($user);
+        $timesheet->setBegin(new \DateTime($begin, $timezone));
+        $timesheet->setEnd(new \DateTime($end, $timezone));
+        $timesheet->setBreak($break);
+
+        return $timesheet;
+    }
+
+    // ========== Basis-Tests ==========
+
+    public function testEmptyResult(): void
+    {
+        $user = $this->createUser();
+        $sut = $this->getSut([]);
+
+        $result = $sut->calculateForYear($user, new \DateTimeImmutable('2026-01-01'));
+
+        self::assertEmpty($result);
+    }
+
+    public function testDefaultGapTolerance(): void
+    {
+        $user = $this->createUser();
+
+        // Two entries with 3 min gap (= default tolerance) should merge
+        $timesheets = [
+            $this->createTimesheet($user, '2026-01-15 10:00:00', '2026-01-15 11:00:00'),
+            $this->createTimesheet($user, '2026-01-15 11:03:00', '2026-01-15 12:00:00'),
+        ];
+        $sut = $this->getSut($timesheets);
+
+        $result = $sut->calculateForYear($user, new \DateTimeImmutable('2026-01-01'));
+
+        // Should merge into 1 span: 10:00-12:00 = 120 min = 7200 sec
+        self::assertArrayHasKey('2026-01-15', $result);
+        self::assertEquals(7200, $result['2026-01-15']);
+    }
+
+    public function testDefaultMaxDuration(): void
+    {
+        $user = $this->createUser();
+
+        // Entry longer than 16h should be filtered out
+        $timesheets = [
+            $this->createTimesheet($user, '2026-01-15 08:00:00', '2026-01-16 02:00:00'), // 18h - too long
+            $this->createTimesheet($user, '2026-01-15 10:00:00', '2026-01-15 11:00:00'), // 1h - ok
+        ];
+        $sut = $this->getSut($timesheets);
+
+        $result = $sut->calculateForYear($user, new \DateTimeImmutable('2026-01-01'));
+
+        // Only the 1h entry should remain
+        self::assertArrayHasKey('2026-01-15', $result);
+        self::assertEquals(3600, $result['2026-01-15']);
+    }
+
+    public function testConfiguredGapTolerance(): void
+    {
+        $user = $this->createUser();
+
+        // Two entries with 5 min gap - should merge with 5 min tolerance, not with default 3 min
+        $timesheets = [
+            $this->createTimesheet($user, '2026-01-15 10:00:00', '2026-01-15 11:00:00'),
+            $this->createTimesheet($user, '2026-01-15 11:05:00', '2026-01-15 12:00:00'),
+        ];
+
+        // With default (3 min) they would stay separate
+        $sutDefault = $this->getSut($timesheets);
+        $resultDefault = $sutDefault->calculateForYear($user, new \DateTimeImmutable('2026-01-01'));
+        self::assertEquals(6900, $resultDefault['2026-01-15']); // 60 + 55 = 115 min = 6900 sec
+
+        // With configured 5 min tolerance they should merge
+        $sutConfigured = $this->getSut($timesheets, ['working_time_calc' => ['gap_tolerance' => 5]]);
+        $resultConfigured = $sutConfigured->calculateForYear($user, new \DateTimeImmutable('2026-01-01'));
+        self::assertEquals(7200, $resultConfigured['2026-01-15']); // 10:00-12:00 = 120 min = 7200 sec
+    }
+
+    public function testConfiguredMaxDuration(): void
+    {
+        $user = $this->createUser();
+
+        // Entry of 14h - should be filtered with 12h max, but kept with default 16h
+        $timesheets = [
+            $this->createTimesheet($user, '2026-01-15 08:00:00', '2026-01-15 22:00:00'), // 14h
+        ];
+
+        // With default (16h) it should be kept
+        $sutDefault = $this->getSut($timesheets);
+        $resultDefault = $sutDefault->calculateForYear($user, new \DateTimeImmutable('2026-01-01'));
+        self::assertEquals(50400, $resultDefault['2026-01-15']); // 14h = 50400 sec
+
+        // With configured 12h max it should be filtered out
+        $sutConfigured = $this->getSut($timesheets, ['working_time_calc' => ['max_duration' => 12]]);
+        $resultConfigured = $sutConfigured->calculateForYear($user, new \DateTimeImmutable('2026-01-01'));
+        self::assertEmpty($resultConfigured);
+    }
+
+    // ========== Break-Handling ==========
+
+    public function testBreakSubtractedFromDuration(): void
+    {
+        $user = $this->createUser();
+
+        // Entry from 10:00-12:00 (2h) with 30 min break = 1.5h effective
+        $timesheets = [
+            $this->createTimesheet($user, '2026-01-15 10:00:00', '2026-01-15 12:00:00', 1800), // 30 min break
+        ];
+        $sut = $this->getSut($timesheets);
+
+        $result = $sut->calculateForYear($user, new \DateTimeImmutable('2026-01-01'));
+
+        // 2h span - 30 min break = 1.5h = 5400 sec
+        self::assertArrayHasKey('2026-01-15', $result);
+        self::assertEquals(5400, $result['2026-01-15']);
+    }
+
+    public function testBreakSubtractedFromMergedSpan(): void
+    {
+        $user = $this->createUser();
+
+        // Two overlapping entries, each with breaks
+        $timesheets = [
+            $this->createTimesheet($user, '2026-01-15 10:00:00', '2026-01-15 12:00:00', 900),  // 15 min break
+            $this->createTimesheet($user, '2026-01-15 11:00:00', '2026-01-15 13:00:00', 900),  // 15 min break
+        ];
+        $sut = $this->getSut($timesheets);
+
+        $result = $sut->calculateForYear($user, new \DateTimeImmutable('2026-01-01'));
+
+        // Merged span: 10:00-13:00 = 3h = 10800 sec
+        // Total breaks: 15 + 15 = 30 min = 1800 sec
+        // Effective: 10800 - 1800 = 9000 sec
+        self::assertArrayHasKey('2026-01-15', $result);
+        self::assertEquals(9000, $result['2026-01-15']);
+    }
+
+    // ========== Szenario 1: Gap Tolerance ==========
+
+    public function testGapWithinTolerance(): void
+    {
+        $user = $this->createUser();
+
+        // Two entries with exactly 3 min gap (= tolerance) should merge
+        $timesheets = [
+            $this->createTimesheet($user, '2026-01-15 10:00:00', '2026-01-15 11:00:00'),
+            $this->createTimesheet($user, '2026-01-15 11:03:00', '2026-01-15 12:00:00'),
+        ];
+        $sut = $this->getSut($timesheets);
+
+        $result = $sut->calculateForYear($user, new \DateTimeImmutable('2026-01-01'));
+
+        // Merged: 10:00-12:00 = 120 min = 7200 sec
+        self::assertArrayHasKey('2026-01-15', $result);
+        self::assertEquals(7200, $result['2026-01-15']);
+    }
+
+    public function testGapExceedsTolerance(): void
+    {
+        $user = $this->createUser();
+
+        // Two entries with 4 min gap (> tolerance) should stay separate
+        $timesheets = [
+            $this->createTimesheet($user, '2026-01-15 10:00:00', '2026-01-15 11:00:00'),
+            $this->createTimesheet($user, '2026-01-15 11:04:00', '2026-01-15 12:00:00'),
+        ];
+        $sut = $this->getSut($timesheets);
+
+        $result = $sut->calculateForYear($user, new \DateTimeImmutable('2026-01-01'));
+
+        // 2 separate spans: 60 min + 56 min = 116 min = 6960 sec
+        self::assertArrayHasKey('2026-01-15', $result);
+        self::assertEquals(6960, $result['2026-01-15']);
+    }
+
+    // ========== Szenario 2: Overlapping Entries Same Day ==========
+
+    public function testOverlappingEntriesSameDay(): void
+    {
+        $user = $this->createUser();
+
+        // Scenario from simpleWorkContract DB (local times Europe/Berlin):
+        // Entry 4: 10:35-12:07 (isolated)
+        // Entry 1: 15:34-16:19
+        // Entry 2: 15:35-17:03 (overlaps with Entry 1)
+        $timesheets = [
+            $this->createTimesheet($user, '2026-01-22 10:35:00', '2026-01-22 12:07:00'),
+            $this->createTimesheet($user, '2026-01-22 15:34:00', '2026-01-22 16:19:00'),
+            $this->createTimesheet($user, '2026-01-22 15:35:00', '2026-01-22 17:03:00'),
+        ];
+        $sut = $this->getSut($timesheets);
+
+        $result = $sut->calculateForYear($user, new \DateTimeImmutable('2026-01-01'));
+
+        // Span1: 10:35-12:07 = 92 min
+        // Span2: 15:34-17:03 = 89 min (merged)
+        // Total: 181 min = 10860 sec
+        self::assertArrayHasKey('2026-01-22', $result);
+        self::assertEquals(10860, $result['2026-01-22']);
+    }
+
+    // ========== Szenario 3: Overnight with Reassignment + 16h Split ==========
+
+    public function testOvernightWithReassignmentAndSplit(): void
+    {
+        $user = $this->createUser();
+
+        // Scenario from simpleWorkContract DB (local times Europe/Berlin):
+        // Entry 7: 06.01. 22:30 - 23:45
+        // Entry 8: 06.01. 23:30 - 07.01. 15:15 (overnight, overlaps with 7)
+        // Entry 9: 07.01. 15:00 - 16:15 (overlaps with end of 8, gets reassigned to 06.01)
+        // Entry 10: 07.01. 19:00 - 19:14 (isolated)
+        $timesheets = [
+            $this->createTimesheet($user, '2026-01-06 22:30:00', '2026-01-06 23:45:00'),
+            $this->createTimesheet($user, '2026-01-06 23:30:00', '2026-01-07 15:15:00'),
+            $this->createTimesheet($user, '2026-01-07 15:00:00', '2026-01-07 16:15:00'),
+            $this->createTimesheet($user, '2026-01-07 19:00:00', '2026-01-07 19:14:00'),
+        ];
+        $sut = $this->getSut($timesheets);
+
+        $result = $sut->calculateForYear($user, new \DateTimeImmutable('2026-01-01'));
+
+        // 06.01: Span 22:30 -> 15:15 (split at 15:15 because 16:15 > 16:00)
+        // = 16h 45min = 60300 sec
+        self::assertArrayHasKey('2026-01-06', $result);
+        self::assertEquals(60300, $result['2026-01-06']);
+
+        // 07.01: Carry-over (15:15-16:15 = 60min) + Entry 10 (19:00-19:14 = 14min)
+        // = 74 min = 4440 sec
+        self::assertArrayHasKey('2026-01-07', $result);
+        self::assertEquals(4440, $result['2026-01-07']);
+    }
+
+    // ========== Szenario 4: Two Overnight Entries Overlapping ==========
+
+    public function testTwoOvernightEntriesOverlapping(): void
+    {
+        $user = $this->createUser();
+
+        // Scenario from simpleWorkContract DB (local times Europe/Berlin):
+        // Entry 5: 13.01. 15:35 -> 14.01. 01:06 (overnight)
+        // Entry 6: 14.01. 00:45 -> 14.01. 01:16 (starts after midnight, overlaps with 5, gets reassigned)
+        $timesheets = [
+            $this->createTimesheet($user, '2026-01-13 15:35:00', '2026-01-14 01:06:00'),
+            $this->createTimesheet($user, '2026-01-14 00:45:00', '2026-01-14 01:16:00'),
+        ];
+        $sut = $this->getSut($timesheets);
+
+        $result = $sut->calculateForYear($user, new \DateTimeImmutable('2026-01-01'));
+
+        // 13.01: Merged span 15:35 -> 01:16 = 9h 41min = 34860 sec
+        self::assertArrayHasKey('2026-01-13', $result);
+        self::assertEquals(34860, $result['2026-01-13']);
+
+        // 14.01: 0 sec (Entry 6 reassigned to 13.01)
+        if (isset($result['2026-01-14'])) {
+            self::assertEquals(0, $result['2026-01-14']);
+        }
+    }
+
+    // ========== Szenario 5: Year Boundary ==========
+
+    public function testYearBoundary(): void
+    {
+        $user = $this->createUser();
+
+        // Scenario from simpleWorkContract DB (local times Europe/Berlin):
+        // Entry 11: 31.12. 14:25 - 14:30 (5 min)
+        // Entry 13: 31.12. 23:45 -> 01.01. 01:15 (overnight over year boundary, 90 min)
+        // Entry 3: 01.01. 14:25 - 14:30 (5 min)
+        $timesheets = [
+            $this->createTimesheet($user, '2025-12-31 14:25:00', '2025-12-31 14:30:00'),
+            $this->createTimesheet($user, '2025-12-31 23:45:00', '2026-01-01 01:15:00'),
+            $this->createTimesheet($user, '2026-01-01 14:25:00', '2026-01-01 14:30:00'),
+        ];
+        $sut = $this->getSut($timesheets);
+
+        // Test for year 2026
+        $result = $sut->calculateForYear($user, new \DateTimeImmutable('2026-01-01'));
+
+        // 01.01.2026: 1 span (14:25-14:30) = 5 min = 300 sec
+        self::assertArrayHasKey('2026-01-01', $result);
+        self::assertEquals(300, $result['2026-01-01']);
+
+        // 31.12.2025 should not be in 2026 results (trimmed by year boundary)
+        self::assertArrayNotHasKey('2025-12-31', $result);
+    }
+
+    public function testYearBoundaryPreviousYear(): void
+    {
+        $user = $this->createUser();
+
+        // Same data but testing for year 2025
+        $timesheets = [
+            $this->createTimesheet($user, '2025-12-31 14:25:00', '2025-12-31 14:30:00'),
+            $this->createTimesheet($user, '2025-12-31 23:45:00', '2026-01-01 01:15:00'),
+            $this->createTimesheet($user, '2026-01-01 14:25:00', '2026-01-01 14:30:00'),
+        ];
+        $sut = $this->getSut($timesheets);
+
+        // Test for year 2025
+        $result = $sut->calculateForYear($user, new \DateTimeImmutable('2025-01-01'));
+
+        // 31.12.2025: 2 spans (5 min + 90 min) = 95 min = 5700 sec
+        self::assertArrayHasKey('2025-12-31', $result);
+        self::assertEquals(5700, $result['2025-12-31']);
+
+        // 01.01.2026 should not be in 2025 results
+        self::assertArrayNotHasKey('2026-01-01', $result);
+    }
+}

--- a/translations/messages.de.xlf
+++ b/translations/messages.de.xlf
@@ -2082,6 +2082,34 @@
         <source>count_as_expected_time_help</source>
         <target>Wenn diese Option aktiviert ist, wird %type% als gearbeitete Stunden auf die erwarteten täglichen Stunden angerechnet. Wenn diese Option deaktiviert ist, werden die erwarteten Stunden für diese Tage auf 0 gesetzt. Beide Einstellungen sorgen für ein ausgeglichenes Stundenkonto, wirken sich jedoch unterschiedlich auf die Gesamtzahlen des Monats aus.</target>
       </trans-unit>
+      <trans-unit id="wts001" resname="working_time_calc">
+        <source>working_time_calc</source>
+        <target>Arbeitszeitberechnung</target>
+      </trans-unit>
+      <trans-unit id="wts002" resname="working_time_calc.enabled">
+        <source>working_time_calc.enabled</source>
+        <target>Alternative Arbeitszeitberechnung</target>
+      </trans-unit>
+      <trans-unit id="wts003" resname="working_time_calc.enabled.help">
+        <source>working_time_calc.enabled.help</source>
+        <target>Standard: Kimai summiert die Dauer aller Buchungen pro Tag (kann bei parallelen Tätigkeiten zu Doppelzählung führen). Alternativ: Berechnet Arbeitszeit als Zeitspanne von erster Startzeit bis letzter Endzeit des Tages.</target>
+      </trans-unit>
+      <trans-unit id="wts004" resname="working_time_calc.gap_tolerance">
+        <source>working_time_calc.gap_tolerance</source>
+        <target>Lücken-Toleranz (Minuten)</target>
+      </trans-unit>
+      <trans-unit id="wts005" resname="working_time_calc.gap_tolerance.help">
+        <source>working_time_calc.gap_tolerance.help</source>
+        <target>Kleine Lücken zwischen Zeiteinträgen werden ignoriert und die Einträge als zusammenhängend betrachtet. Standard: 3 Minuten.</target>
+      </trans-unit>
+      <trans-unit id="wts006" resname="working_time_calc.max_duration">
+        <source>working_time_calc.max_duration</source>
+        <target>Max. Aufgabendauer (Stunden)</target>
+      </trans-unit>
+      <trans-unit id="wts007" resname="working_time_calc.max_duration.help">
+        <source>working_time_calc.max_duration.help</source>
+        <target>Einzelne Zeiteinträge, die länger dauern, werden nicht in die Arbeitszeitberechnung einbezogen. Standard: 16 Stunden.</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/translations/messages.en.xlf
+++ b/translations/messages.en.xlf
@@ -2082,6 +2082,34 @@
         <source>count_as_expected_time_help</source>
         <target>When enabled, %type% will count as worked hours towards the expected daily hours. When disabled, the expected hours for these days will be set to 0. Both settings maintain a neutral balance but affect monthly totals differently.</target>
       </trans-unit>
+      <trans-unit id="wts001" resname="working_time_calc">
+        <source>working_time_calc</source>
+        <target>Working time calculation</target>
+      </trans-unit>
+      <trans-unit id="wts002" resname="working_time_calc.enabled">
+        <source>working_time_calc.enabled</source>
+        <target>Alternative working time calculation</target>
+      </trans-unit>
+      <trans-unit id="wts003" resname="working_time_calc.enabled.help">
+        <source>working_time_calc.enabled.help</source>
+        <target>Default: Kimai sums up the duration of all bookings per day (may cause double counting for parallel activities). Alternative: Calculates working time as time span from first start to last end of the day.</target>
+      </trans-unit>
+      <trans-unit id="wts004" resname="working_time_calc.gap_tolerance">
+        <source>working_time_calc.gap_tolerance</source>
+        <target>Gap tolerance (minutes)</target>
+      </trans-unit>
+      <trans-unit id="wts005" resname="working_time_calc.gap_tolerance.help">
+        <source>working_time_calc.gap_tolerance.help</source>
+        <target>Small gaps between time entries are ignored and entries are considered connected. Default: 3 minutes.</target>
+      </trans-unit>
+      <trans-unit id="wts006" resname="working_time_calc.max_duration">
+        <source>working_time_calc.max_duration</source>
+        <target>Max. task duration (hours)</target>
+      </trans-unit>
+      <trans-unit id="wts007" resname="working_time_calc.max_duration.help">
+        <source>working_time_calc.max_duration.help</source>
+        <target>Individual time entries exceeding this duration are excluded from working time calculation. Default: 16 hours.</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>


### PR DESCRIPTION
Alternative working time calculation that merges overlapping time entries into spans instead of summing durations (prevents double-counting).

- Add TimeSpanCalculator service to App\WorkingTime
- Add WorkingTimeSpanSubscriber for WorkingTimeYearEvent
- Add WorkingTimeSpanConfigurationSubscriber for system settings
- Add translations (de, en) for configuration options

## Description
A clear and concise description of what this pull request adds or changes.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] I verified that my code applies to the guidelines (`composer code-check`)
- [ ] I updated the documentation (see [here](https://github.com/kimai/www.kimai.org/tree/master/_documentation))
- [x] I agree that this code is used in Kimai (see [license](https://github.com/kimai/kimai/blob/main/LICENSE))
