### PR TITLE
add column summarization per customer

### DIFF
--- a/templates/reporting/report_by_user.html.twig
+++ b/templates/reporting/report_by_user.html.twig
@@ -17,5 +17,8 @@
         {% block column_classes_total -%}
             {% if column is weekend %} weekend{% endif %}
         {%- endblock %}
+        {% block column_classes_customer_total -%}
+            {% if column is weekend %} weekend{% endif %}
+        {%- endblock %}
     {% endembed %}
 {% endblock %}

--- a/templates/reporting/report_by_user_data.html.twig
+++ b/templates/reporting/report_by_user_data.html.twig
@@ -46,6 +46,23 @@
         {% elseif data.customer != totalCurrency %}
             {% set totalCurrency = null %}
         {% endif %}
+        {% set customerTotalsDuration = {} %}
+        {% set customerTotalsInternalRate = {} %}
+        {% set customerTotalsRate = {} %}
+        {% for column in period.dateTimes %}
+            {% set dateKey = column|report_date %}
+            {% set customerTotalsDuration = customerTotalsDuration|merge({(dateKey): 0}) %}
+            {% set customerTotalsInternalRate = customerTotalsInternalRate|merge({(dateKey): 0}) %}
+            {% set customerTotalsRate = customerTotalsRate|merge({(dateKey): 0}) %}
+        {% endfor %}
+        {% for project in data.projects %}
+            {% for column in project.data.data %}
+                {% set dateKey = column.date|report_date %}
+                {% set customerTotalsDuration = customerTotalsDuration|merge({(dateKey): (customerTotalsDuration[dateKey] + column.duration)}) %}
+                {% set customerTotalsInternalRate = customerTotalsInternalRate|merge({(dateKey): (customerTotalsInternalRate[dateKey] + column.internalRate)}) %}
+                {% set customerTotalsRate = customerTotalsRate|merge({(dateKey): (customerTotalsRate[dateKey] + column.rate)}) %}
+            {% endfor %}
+        {% endfor %}
         <tr class="summary">
             <td>{{ widgets.label_customer(data.customer) }}</td>
             <td class="text-center total">
@@ -59,7 +76,18 @@
                 {% endif %}
                 {% if with_links %}</a>{% endif %}
             </td>
-            <td colspan="{{ columns }}"></td>
+            {% for column in period.dateTimes %}
+                {% set dateKey = column|report_date %}
+                <td class="text-nowrap text-center day-total {% block column_classes_customer_total %}{% endblock %}">
+                    {% if dataType == 'rate' %}
+                        <strong>{{ customerTotalsRate[dateKey]|money(currency) }}</strong>
+                    {% elseif dataType == 'internalRate' %}
+                        <strong>{{ customerTotalsInternalRate[dateKey]|money(currency) }}</strong>
+                    {% else %}
+                        <strong>{{ customerTotalsDuration[dateKey]|duration(decimal) }}</strong>
+                    {% endif %}
+                </td>
+            {% endfor %}
         </tr>
         {% for project in data.projects %}
             {% set absoluteDuration = absoluteDuration + project.duration %}

--- a/templates/reporting/report_by_user_year.html.twig
+++ b/templates/reporting/report_by_user_year.html.twig
@@ -14,5 +14,6 @@
         {% block column_classes_project %}{% endblock %}
         {% block column_classes_activity %}{% endblock %}
         {% block column_classes_total %}{% endblock %}
+        {% block column_classes_customer_total %}{% endblock %}
     {% endembed %}
 {% endblock %}

--- a/templates/reporting/report_by_user_year_export.html.twig
+++ b/templates/reporting/report_by_user_year_export.html.twig
@@ -5,4 +5,5 @@
     {% block column_classes_project %}{% endblock %}
     {% block column_classes_activity %}{% endblock %}
     {% block column_classes_total %}{% endblock %}
+    {% block column_classes_customer_total %}{% endblock %}
 {% endembed %}


### PR DESCRIPTION
<img width="732" height="790" alt="grafik" src="https://github.com/user-attachments/assets/59c93945-9cc8-4de4-81af-889e7e0abf17" />
## Description
add column summarization per customer
feel free to adapt or make it optional; all changes where created via GH-Copilot-prompting...
I will use it to have daily working-times per customer (I have "pause/breaks" as separate customer which is a suitable workaround).

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] I verified that my code applies to the guidelines (`composer code-check`)
- [ ] I updated the documentation (see [here](https://github.com/kimai/www.kimai.org/tree/master/_documentation))
- [x] I agree that this code is used in Kimai (see [license](https://github.com/kimai/kimai/blob/main/LICENSE))
