### PR TITLE
preserve fixed rate on activity change (#5735)

### DIFF
--- a/src/Timesheet/Calculator/RateResetCalculator.php
+++ b/src/Timesheet/Calculator/RateResetCalculator.php
@@ -23,6 +23,13 @@ final class RateResetCalculator implements CalculatorInterface
             }
         }
 
+        // if the record already has a manually set rate (fixedRate or hourlyRate),
+        // preserve it when project/activity/user changes - the user explicitly set
+        // this rate before and chose not to change it (see GitHub issue #5735)
+        if ($record->getFixedRate() !== null || $record->getHourlyRate() !== null) {
+            return;
+        }
+
         // if no manual rate changed was applied:
         // check if a field changed, that is relevant for the rate calculation
         // reset all rates, because most users do not even see their rates and would not be able

--- a/tests/Timesheet/Calculator/RateResetCalculatorTest.php
+++ b/tests/Timesheet/Calculator/RateResetCalculatorTest.php
@@ -20,14 +20,17 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(RateResetCalculator::class)]
 class RateResetCalculatorTest extends TestCase
 {
-    public function testWithReset(): void
+    /**
+     * Tests that rates are reset when project/activity/user changes
+     * and no manual rate (fixedRate or hourlyRate) is set.
+     */
+    public function testWithResetWhenNoManualRatesSet(): void
     {
         $record = new Timesheet();
         $record->setRate(999.99);
-        $record->setHourlyRate(100);
-        $record->setFixedRate(123.45);
         $record->setInternalRate(98.76);
         $record->setBillableMode(Timesheet::BILLABLE_NO);
+        // Note: NOT setting fixedRate or hourlyRate - rates should be reset
 
         $user = new User();
         $user->setPreferences([
@@ -37,8 +40,8 @@ class RateResetCalculatorTest extends TestCase
         $record->setUser($user);
 
         self::assertEquals(999.99, $record->getRate());
-        self::assertEquals(100, $record->getHourlyRate());
-        self::assertEquals(123.45, $record->getFixedRate());
+        self::assertNull($record->getHourlyRate());
+        self::assertNull($record->getFixedRate());
         self::assertEquals(98.76, $record->getInternalRate());
         self::assertEquals(Timesheet::BILLABLE_NO, $record->getBillableMode());
 
@@ -51,5 +54,82 @@ class RateResetCalculatorTest extends TestCase
         self::assertNull($record->getFixedRate());
         self::assertNull($record->getInternalRate());
         self::assertEquals(Timesheet::BILLABLE_AUTOMATIC, $record->getBillableMode());
+    }
+
+    /**
+     * Tests that rates are preserved when project/activity/user changes
+     * but the record already has a fixedRate set (GitHub issue #5735).
+     */
+    public function testPreserveRatesWhenFixedRateIsSet(): void
+    {
+        $record = new Timesheet();
+        $record->setRate(80.00);
+        $record->setFixedRate(80.00);
+        $record->setInternalRate(50.00);
+        $record->setBillableMode(Timesheet::BILLABLE_YES);
+
+        $user = new User();
+        $record->setUser($user);
+
+        self::assertEquals(80.00, $record->getRate());
+        self::assertEquals(80.00, $record->getFixedRate());
+
+        $sut = new RateResetCalculator();
+        // Change project - rates should be preserved because fixedRate is set
+        $sut->calculate($record, ['project' => [0 => new Project(), 1 => new Project()]]);
+
+        // Rates should NOT be reset - fixedRate should be preserved
+        self::assertEquals(80.00, $record->getRate());
+        self::assertEquals(80.00, $record->getFixedRate());
+        self::assertEquals(50.00, $record->getInternalRate());
+        self::assertEquals(Timesheet::BILLABLE_YES, $record->getBillableMode());
+    }
+
+    /**
+     * Tests that rates are preserved when project/activity/user changes
+     * but the record already has an hourlyRate set.
+     */
+    public function testPreserveRatesWhenHourlyRateIsSet(): void
+    {
+        $record = new Timesheet();
+        $record->setRate(100.00);
+        $record->setHourlyRate(100.00);
+        $record->setInternalRate(75.00);
+        $record->setBillableMode(Timesheet::BILLABLE_YES);
+
+        $user = new User();
+        $record->setUser($user);
+
+        self::assertEquals(100.00, $record->getRate());
+        self::assertEquals(100.00, $record->getHourlyRate());
+
+        $sut = new RateResetCalculator();
+        // Change activity - rates should be preserved because hourlyRate is set
+        $sut->calculate($record, ['activity' => [0 => null, 1 => null]]);
+
+        // Rates should NOT be reset - hourlyRate should be preserved
+        self::assertEquals(100.00, $record->getRate());
+        self::assertEquals(100.00, $record->getHourlyRate());
+        self::assertEquals(75.00, $record->getInternalRate());
+        self::assertEquals(Timesheet::BILLABLE_YES, $record->getBillableMode());
+    }
+
+    /**
+     * Tests that rates are reset when rate field is in changeset
+     * (user explicitly modified it).
+     */
+    public function testNoResetWhenRateInChangeset(): void
+    {
+        $record = new Timesheet();
+        $record->setRate(999.99);
+        $record->setBillableMode(Timesheet::BILLABLE_NO);
+
+        $sut = new RateResetCalculator();
+        // Rate is in changeset - should return early, no reset
+        $sut->calculate($record, ['rate' => [0 => 50.00, 1 => 999.99]]);
+
+        // Rates should NOT be reset
+        self::assertEquals(999.99, $record->getRate());
+        self::assertEquals(Timesheet::BILLABLE_NO, $record->getBillableMode());
     }
 }


### PR DESCRIPTION
Fixes #5735

**Problem:** Fixed price removed when changing activity without modifying the rate field.

**Solution:** Preserve `fixedRate`/`hourlyRate` when already set on the record.

**Changes:**
- `RateResetCalculator.php`: Skip reset if manual rate exists
- `RateResetCalculatorTest.php`: Added tests for rate preservation