### PR TITLE
Feature: plugin test support

### DIFF
--- a/bin/test-plugins
+++ b/bin/test-plugins
@@ -1,0 +1,93 @@
+#!/usr/bin/env php
+<?php
+
+/*
+ * This file is part of the Kimai time-tracking app.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+/**
+ * Discovers and runs PHPUnit test suites for all installed Kimai plugins.
+ *
+ * Before each plugin suite, this script establishes a clean baseline:
+ * - Clears the test cache with all plugins loaded, so the Symfony
+ *   container is compiled correctly (APP_DEBUG=0 won't detect stale
+ *   containers from previous core test runs)
+ *
+ * Each plugin's bootstrap.php is responsible for its own schema needs
+ * (e.g. doctrine:schema:update for plugin-specific tables).
+ *
+ * Usage:
+ *   bin/test-plugins [phpunit-args]
+ *   bin/test-plugins --filter testSomething
+ *   bin/test-plugins --stop-on-failure
+ */
+
+$projectDir = dirname(__DIR__);
+$pluginsDir = $projectDir . '/var/plugins';
+$phpunit = $projectDir . '/vendor/bin/phpunit';
+$console = $projectDir . '/bin/console';
+
+if (!is_dir($pluginsDir)) {
+    echo "No plugins directory found.\n";
+    exit(0);
+}
+
+// Discover testable plugins: *Bundle with phpunit.xml and without .disabled
+$pluginNames = [];
+$testable = [];
+
+foreach (glob($pluginsDir . '/*Bundle', GLOB_ONLYDIR) ?: [] as $dir) {
+    $name = basename($dir);
+
+    if (file_exists($dir . '/.disabled')) {
+        continue;
+    }
+
+    $pluginNames[] = $name;
+
+    if (file_exists($dir . '/phpunit.xml') && is_dir($dir . '/Tests/')) {
+        $testable[] = ['name' => $name, 'config' => $dir . '/phpunit.xml', 'tests' => $dir . '/Tests/'];
+    }
+}
+
+if (count($testable) === 0) {
+    echo "No testable plugins found (need phpunit.xml + Tests/ directory).\n";
+    exit(0);
+}
+
+$pluginList = implode(',', $pluginNames);
+$extraArgs = array_slice($argv, 1);
+$extraArgsStr = implode(' ', array_map('escapeshellarg', $extraArgs));
+
+$exitCode = 0;
+
+foreach ($testable as $plugin) {
+    // Clean baseline: clear test cache with all plugins loaded so the
+    // Symfony container is compiled with the correct bundle registrations
+    passthru(sprintf(
+        'APP_ENV=test APP_DEBUG=0 LOAD_PLUGINS_IN_TEST=%s php %s cache:clear --no-warmup --env=test --quiet',
+        escapeshellarg($pluginList),
+        escapeshellarg($console)
+    ));
+
+    echo "\n=== Running tests for {$plugin['name']} ===\n\n";
+
+    $command = sprintf(
+        '%s -c %s %s %s',
+        escapeshellarg($phpunit),
+        escapeshellarg($plugin['config']),
+        escapeshellarg($plugin['tests']),
+        $extraArgsStr
+    );
+
+    passthru($command, $result);
+
+    if ($result !== 0) {
+        $exitCode = $result;
+    }
+}
+
+exit($exitCode);

--- a/bin/test-plugins
+++ b/bin/test-plugins
@@ -21,6 +21,7 @@
  *
  * Usage:
  *   bin/test-plugins [phpunit-args]
+ *   bin/test-plugins --plugin RemoteWorkBundle
  *   bin/test-plugins --filter testSomething
  *   bin/test-plugins --stop-on-failure
  */
@@ -33,6 +34,18 @@ $console = $projectDir . '/bin/console';
 if (!is_dir($pluginsDir)) {
     echo "No plugins directory found.\n";
     exit(0);
+}
+
+// Parse --plugin option (consume before passing remaining args to PHPUnit)
+$onlyPlugin = null;
+$extraArgs = [];
+
+for ($i = 1; $i < $argc; $i++) {
+    if ($argv[$i] === '--plugin' && isset($argv[$i + 1])) {
+        $onlyPlugin = $argv[++$i];
+    } else {
+        $extraArgs[] = $argv[$i];
+    }
 }
 
 // Discover testable plugins: *Bundle with phpunit.xml and without .disabled
@@ -53,13 +66,21 @@ foreach (glob($pluginsDir . '/*Bundle', GLOB_ONLYDIR) ?: [] as $dir) {
     }
 }
 
+if ($onlyPlugin !== null) {
+    $testable = array_values(array_filter($testable, fn ($p) => $p['name'] === $onlyPlugin));
+
+    if (count($testable) === 0) {
+        echo "Plugin '{$onlyPlugin}' not found or has no tests.\n";
+        exit(1);
+    }
+}
+
 if (count($testable) === 0) {
     echo "No testable plugins found (need phpunit.xml + Tests/ directory).\n";
     exit(0);
 }
 
 $pluginList = implode(',', $pluginNames);
-$extraArgs = array_slice($argv, 1);
 $extraArgsStr = implode(' ', array_map('escapeshellarg', $extraArgs));
 
 $exitCode = 0;

--- a/composer.json
+++ b/composer.json
@@ -189,6 +189,7 @@
         "tests": "vendor/bin/phpunit tests/",
         "tests-unit": "vendor/bin/phpunit --exclude-group integration tests/",
         "tests-integration": "vendor/bin/phpunit --group integration tests/",
+        "tests-plugins": "bin/test-plugins",
         "phpstan": [
             "@phpstan-src",
             "@phpstan-tests"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -21,6 +21,11 @@
     <env name="APP_ENV" value="test" force="true"/>
     <env name="APP_DEBUG" value="0" force="true"/>
     <env name="APP_SECRET" value="5a79a1c866efef9ca1800f971d689f3e" force="true"/>
+    <!--
+        DATABASE_URL: Default for CI/local standalone setup.
+        Without force="true", an existing DATABASE_URL environment variable
+        (e.g. from Docker container) takes precedence.
+    -->
     <env name="DATABASE_URL" value="mysql://kimai2_test:kimai2_test@127.0.0.1:3306/kimai2_test?charset=utf8mb4&amp;serverVersion=10.5.8-MariaDB"/>
     <env name="CORS_ALLOW_ORIGIN" value="^https?://localhost(:[0-9]+)?$"/>
     <env name="MAILER_URL" value="null://null"/>

--- a/src/Kernel.php
+++ b/src/Kernel.php
@@ -61,6 +61,18 @@ class Kernel extends BaseKernel
         }
 
         if ($this->environment === 'test') {
+            $loadPlugins = $_ENV['LOAD_PLUGINS_IN_TEST'] ?? $_SERVER['LOAD_PLUGINS_IN_TEST'] ?? '';
+            if ($loadPlugins === '') {
+                return;
+            }
+            $allowed = array_map('trim', explode(',', $loadPlugins));
+            foreach ($this->getBundleClasses() as $plugin) {
+                $name = (new \ReflectionClass($plugin))->getShortName();
+                if (\in_array($name, $allowed, true)) {
+                    yield $plugin;
+                }
+            }
+
             return;
         }
 

--- a/src/Kernel.php
+++ b/src/Kernel.php
@@ -62,6 +62,9 @@ class Kernel extends BaseKernel
 
         if ($this->environment === 'test') {
             $loadPlugins = $_ENV['LOAD_PLUGINS_IN_TEST'] ?? $_SERVER['LOAD_PLUGINS_IN_TEST'] ?? '';
+            if (!\is_string($loadPlugins)) {
+                return;
+            }
             if ($loadPlugins === '') {
                 return;
             }


### PR DESCRIPTION
## Summary

Adds infrastructure for testing Kimai plugins within the main Kimai test environment:

- **Selective plugin loading in test environment**: New `LOAD_PLUGINS_IN_TEST` env var in `Kernel::registerBundles()` controls which plugins are loaded during tests. Accepts a comma-separated list of bundle names (e.g. `RemoteWorkBundle,WorkContractBundle`). Without it, behavior is unchanged — no plugins are loaded in the `test` environment.
- **`bin/test-plugins` script**: Standalone PHP script that discovers all installed plugins with a `phpunit.xml` and `Tests/` directory, then runs PHPUnit for each one. Supports `--plugin <name>` to run a single plugin's tests. Extra CLI arguments are passed through (e.g. `bin/test-plugins --filter testSomething`). Disabled plugins (`.disabled` marker) are skipped.
- **`composer tests-plugins`**: Composer script entry pointing to `bin/test-plugins`, consistent with existing `composer tests`, `tests-unit`, and `tests-integration`.
- **`$_ENV`/`$_SERVER` compatibility**: Checks both `$_ENV` and `$_SERVER` for `LOAD_PLUGINS_IN_TEST`, since PHPUnit `<env force="true">` sets `$_ENV` while Docker/shell `env` sets `$_SERVER`.
- **`phpunit.xml.dist`**: Removed `force="true"` from `DATABASE_URL` so an existing environment variable (e.g. from a Docker container) takes precedence over the default.

## Two-level test architecture

The test infrastructure uses a two-level approach to separate central concerns from plugin-specific needs:

### Level 1: `bin/test-plugins` (central baseline)

Before each plugin suite, the script establishes a clean baseline:
- Clears the Symfony test cache with `APP_DEBUG=0` (matching PHPUnit's non-debug container) and all plugins loaded via `LOAD_PLUGINS_IN_TEST`
- This ensures the compiled container includes the correct bundle registrations, even after core tests (`composer tests`) have run with a different container configuration

### Level 2: Plugin `bootstrap.php` (plugin-specific)

Each plugin's bootstrap handles its own needs, e.g.:
- `doctrine:schema:update --force` to ensure plugin-specific tables exist (idempotent — creates missing tables after core test reset, no-op when current)
- Database initialization for CI/local environments (`BOOTSTRAP_RESET_DATABASE=true`)

This separation means `bin/test-plugins` doesn't need to know about plugin-specific database schemas, and plugins don't need to worry about cache state.

### Usage

```bash
# Run all plugin test suites
composer tests-plugins
bin/test-plugins

# Run a single plugin
composer tests-plugins -- --plugin RemoteWorkBundle
bin/test-plugins --plugin RemoteWorkBundle

# With PHPUnit arguments
bin/test-plugins --plugin RemoteWorkBundle --filter testSomething
bin/test-plugins --stop-on-failure
```

### Plugin phpunit.xml example

```xml
<phpunit bootstrap="Tests/bootstrap.php">
    <php>
        <env name="KERNEL_CLASS" value="App\Kernel" force="true"/>
        <env name="LOAD_PLUGINS_IN_TEST" value="MyPlugin,OtherPlugin" force="true"/>
        <env name="DATABASE_URL" value="mysql://test:test@127.0.0.1:3306/kimai_test?..."/>
    </php>
</phpunit>
```

## Test plan

- [x] `bin/test-plugins` discovers and runs plugin test suites
- [x] `composer tests-plugins` invokes `bin/test-plugins`
- [x] `--plugin <name>` runs only a single plugin's test suite
- [x] Extra PHPUnit arguments are passed through correctly
- [x] Plugins without `phpunit.xml` or `Tests/` directory are skipped
- [x] Disabled plugins (`.disabled`) are skipped
- [x] Cache is cleared with `APP_DEBUG=0` before each suite (prevents stale non-debug container)
- [x] Plugin bootstrap recovers plugin tables after core test reset
- [x] Works both locally and inside Docker containers

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] I verified that my code applies to the guidelines (`composer code-check`)
- [ ] I updated the documentation (see [here](https://github.com/kimai/www.kimai.org/tree/master/_documentation))
- [x] I agree that this code is used in Kimai (see [license](https://github.com/kimai/kimai/blob/main/LICENSE))
