### PR TITLE
[3.0] Feature/plugin test support

### DIFF
--- a/bin/test-plugins
+++ b/bin/test-plugins
@@ -1,0 +1,93 @@
+#!/usr/bin/env php
+<?php
+
+/*
+ * This file is part of the Kimai time-tracking app.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+/**
+ * Discovers and runs PHPUnit test suites for all installed Kimai plugins.
+ *
+ * Before each plugin suite, this script establishes a clean baseline:
+ * - Clears the test cache with all plugins loaded, so the Symfony
+ *   container is compiled correctly (APP_DEBUG=0 won't detect stale
+ *   containers from previous core test runs)
+ *
+ * Each plugin's bootstrap.php is responsible for its own schema needs
+ * (e.g. doctrine:schema:update for plugin-specific tables).
+ *
+ * Usage:
+ *   bin/test-plugins [phpunit-args]
+ *   bin/test-plugins --filter testSomething
+ *   bin/test-plugins --stop-on-failure
+ */
+
+$projectDir = dirname(__DIR__);
+$pluginsDir = $projectDir . '/var/plugins';
+$phpunit = $projectDir . '/vendor/bin/phpunit';
+$console = $projectDir . '/bin/console';
+
+if (!is_dir($pluginsDir)) {
+    echo "No plugins directory found.\n";
+    exit(0);
+}
+
+// Discover testable plugins: *Bundle with phpunit.xml and without .disabled
+$pluginNames = [];
+$testable = [];
+
+foreach (glob($pluginsDir . '/*Bundle', GLOB_ONLYDIR) ?: [] as $dir) {
+    $name = basename($dir);
+
+    if (file_exists($dir . '/.disabled')) {
+        continue;
+    }
+
+    $pluginNames[] = $name;
+
+    if (file_exists($dir . '/phpunit.xml') && is_dir($dir . '/Tests/')) {
+        $testable[] = ['name' => $name, 'config' => $dir . '/phpunit.xml', 'tests' => $dir . '/Tests/'];
+    }
+}
+
+if (count($testable) === 0) {
+    echo "No testable plugins found (need phpunit.xml + Tests/ directory).\n";
+    exit(0);
+}
+
+$pluginList = implode(',', $pluginNames);
+$extraArgs = array_slice($argv, 1);
+$extraArgsStr = implode(' ', array_map('escapeshellarg', $extraArgs));
+
+$exitCode = 0;
+
+foreach ($testable as $plugin) {
+    // Clean baseline: clear test cache with all plugins loaded so the
+    // Symfony container is compiled with the correct bundle registrations
+    passthru(sprintf(
+        'APP_ENV=test APP_DEBUG=0 LOAD_PLUGINS_IN_TEST=%s php %s cache:clear --no-warmup --env=test --quiet',
+        escapeshellarg($pluginList),
+        escapeshellarg($console)
+    ));
+
+    echo "\n=== Running tests for {$plugin['name']} ===\n\n";
+
+    $command = sprintf(
+        '%s -c %s %s %s',
+        escapeshellarg($phpunit),
+        escapeshellarg($plugin['config']),
+        escapeshellarg($plugin['tests']),
+        $extraArgsStr
+    );
+
+    passthru($command, $result);
+
+    if ($result !== 0) {
+        $exitCode = $result;
+    }
+}
+
+exit($exitCode);

--- a/bin/test-plugins
+++ b/bin/test-plugins
@@ -21,6 +21,7 @@
  *
  * Usage:
  *   bin/test-plugins [phpunit-args]
+ *   bin/test-plugins --plugin RemoteWorkBundle
  *   bin/test-plugins --filter testSomething
  *   bin/test-plugins --stop-on-failure
  */
@@ -33,6 +34,18 @@ $console = $projectDir . '/bin/console';
 if (!is_dir($pluginsDir)) {
     echo "No plugins directory found.\n";
     exit(0);
+}
+
+// Parse --plugin option (consume before passing remaining args to PHPUnit)
+$onlyPlugin = null;
+$extraArgs = [];
+
+for ($i = 1; $i < $argc; $i++) {
+    if ($argv[$i] === '--plugin' && isset($argv[$i + 1])) {
+        $onlyPlugin = $argv[++$i];
+    } else {
+        $extraArgs[] = $argv[$i];
+    }
 }
 
 // Discover testable plugins: *Bundle with phpunit.xml and without .disabled
@@ -53,13 +66,21 @@ foreach (glob($pluginsDir . '/*Bundle', GLOB_ONLYDIR) ?: [] as $dir) {
     }
 }
 
+if ($onlyPlugin !== null) {
+    $testable = array_values(array_filter($testable, fn ($p) => $p['name'] === $onlyPlugin));
+
+    if (count($testable) === 0) {
+        echo "Plugin '{$onlyPlugin}' not found or has no tests.\n";
+        exit(1);
+    }
+}
+
 if (count($testable) === 0) {
     echo "No testable plugins found (need phpunit.xml + Tests/ directory).\n";
     exit(0);
 }
 
 $pluginList = implode(',', $pluginNames);
-$extraArgs = array_slice($argv, 1);
 $extraArgsStr = implode(' ', array_map('escapeshellarg', $extraArgs));
 
 $exitCode = 0;

--- a/bin/test-plugins
+++ b/bin/test-plugins
@@ -86,11 +86,27 @@ $extraArgsStr = implode(' ', array_map('escapeshellarg', $extraArgs));
 $exitCode = 0;
 
 foreach ($testable as $plugin) {
-    // Clean baseline: clear test cache with all plugins loaded so the
-    // Symfony container is compiled with the correct bundle registrations
+    // Compile the container with exactly the bundle set this suite's phpunit.xml
+    // registers (its LOAD_PLUGINS_IN_TEST). Compiling with all plugins instead
+    // would wire another plugin's subscribers into the container while its routes
+    // stay absent from the test kernel's router — breaking full-page (HTML) renders.
+    // Falls back to all discovered plugins when the suite declares nothing.
+    $loadPlugins = $pluginList;
+    $suiteXml = @simplexml_load_file($plugin['config']);
+    if ($suiteXml !== false) {
+        foreach ($suiteXml->php->env ?? [] as $env) {
+            if ((string) $env['name'] === 'LOAD_PLUGINS_IN_TEST') {
+                $loadPlugins = (string) $env['value'];
+                break;
+            }
+        }
+    }
+
+    // Clean baseline: clear the test cache so the container is compiled with the
+    // bundle set the test kernel will register.
     passthru(sprintf(
         'APP_ENV=test APP_DEBUG=0 LOAD_PLUGINS_IN_TEST=%s php %s cache:clear --no-warmup --env=test --quiet',
-        escapeshellarg($pluginList),
+        escapeshellarg($loadPlugins),
         escapeshellarg($console)
     ));
 

--- a/composer.json
+++ b/composer.json
@@ -193,6 +193,7 @@
         "tests": "vendor/bin/phpunit tests/",
         "tests-unit": "vendor/bin/phpunit --exclude-group integration tests/",
         "tests-integration": "vendor/bin/phpunit --group integration tests/",
+        "tests-plugins": "bin/test-plugins",
         "phpstan": [
             "@phpstan-src",
             "@phpstan-tests"

--- a/composer.json
+++ b/composer.json
@@ -201,6 +201,7 @@
         "tests": "vendor/bin/phpunit tests/",
         "tests-unit": "vendor/bin/phpunit --exclude-group integration tests/",
         "tests-integration": "vendor/bin/phpunit --group integration tests/",
+        "tests-plugins": "bin/test-plugins",
         "phpstan": [
             "@phpstan-src",
             "@phpstan-tests"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,12 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
-<!-- https://phpunit.readthedocs.io/en/latest/configuration.html -->
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
          backupGlobals="false"
          colors="true"
-         failOnNotice="true"
-         failOnWarning="true"
          bootstrap="tests/bootstrap.php"
          cacheDirectory="var/cache/phpunit/"
          displayDetailsOnTestsThatTriggerDeprecations="true"
@@ -14,86 +10,64 @@
          displayDetailsOnTestsThatTriggerNotices="true"
          displayDetailsOnTestsThatTriggerWarnings="true"
          displayDetailsOnPhpunitDeprecations="true">
-    <php>
-        <ini name="display_errors" value="1" />
-        <ini name="error_reporting" value="-1"/>
-        <ini name="max_execution_time" value="-1"/>
-        <ini name="date.timezone" value="UTC"/>
-        <ini name="intl.default_locale" value="en"/>
-        <ini name="date.timezone" value="Europe/Vienna"/>
-        <env name="KERNEL_CLASS" value="App\Kernel" force="true"/>
-        <env name="SYMFONY_DEPRECATIONS_HELPER" value="weak"/>
-        <server name="SHELL_VERBOSITY" value="-1" />
-        <env name="APP_DEBUG" value="0" force="true"/>
-        <env name="DATABASE_URL" value="mysql://kimai2_test:kimai2_test@127.0.0.1:3306/kimai2_test?charset=utf8mb4&amp;serverVersion=10.11.15-MariaDB"/>
-        <!-- ###+ nelmio/cors-bundle ### -->
-        <env name="CORS_ALLOW_ORIGIN" value="'^https?://(localhost|127\.0\.0\.1)(:[0-9]+)?$'"/>
-        <!-- ###- nelmio/cors-bundle ### -->
-        <!--
-            REINSTALL THE TEST DATABASE, eg. AFTER CHANGING STRUCTURE!
+  <php>
+    <ini name="error_reporting" value="-1"/>
+    <ini name="max_execution_time" value="-1"/>
+    <ini name="date.timezone" value="UTC"/>
+    <ini name="intl.default_locale" value="en"/>
+    <ini name="date.timezone" value="Europe/Vienna"/>
+    <env name="KERNEL_CLASS" value="App\Kernel" force="true"/>
+    <env name="SYMFONY_DEPRECATIONS_HELPER" value="weak"/>
+    <env name="APP_ENV" value="test" force="true"/>
+    <env name="APP_DEBUG" value="0" force="true"/>
+    <env name="APP_SECRET" value="5a79a1c866efef9ca1800f971d689f3e" force="true"/>
+    <!--
+        DATABASE_URL: Default for CI/local standalone setup.
+        Without force="true", an existing DATABASE_URL environment variable
+        (e.g. from Docker container) takes precedence.
+    -->
+    <env name="DATABASE_URL" value="mysql://kimai2_test:kimai2_test@127.0.0.1:3306/kimai2_test?charset=utf8mb4&amp;serverVersion=10.5.8-MariaDB"/>
+    <env name="CORS_ALLOW_ORIGIN" value="^https?://localhost(:[0-9]+)?$"/>
+    <env name="MAILER_URL" value="null://null"/>
+    <env name="MAILER_FROM" value="kimai@example.com"/>
+    <!--
+        REINSTALL THE TEST DATABASE, eg. AFTER CHANGING STRUCTURE!
 
-            - change to "true"
-            - composer tests
-            - change back to "false"
+        - change to "true"
+        - composer tests
+        - change back to "false"
 
-            CREATE DATABASE IF NOT EXISTS `kimai2_test`;
-            CREATE USER IF NOT EXISTS `kimai2_test`@127.0.0.1;
-            ALTER USER `kimai2_test`@127.0.0.1 IDENTIFIED BY "kimai2_test";
-            GRANT execute,select,insert,update,delete,create,alter,drop,index,references ON `kimai2_test`.* TO kimai2_test@127.0.0.1;
-        -->
-        <env name="BOOTSTRAP_RESET_DATABASE" value="true"/>
-
-        <!-- ###+ symfony/framework-bundle ### -->
-        <env name="APP_ENV" value="test" force="true"/>
-        <env name="APP_SECRET" value="5a79a1c866efef9ca1800f971d689f3e" force="true"/>
-        <env name="APP_SHARE_DIR" value="var/share"/>
-        <!-- ###- symfony/framework-bundle ### -->
-        <!-- ###+ symfony/mailer ### -->
-        <env name="MAILER_URL" value="null://null"/>
-        <env name="MAILER_FROM" value="kimai@example.com"/>
-        <!-- ###- symfony/mailer ### -->
-
-        <!-- ###+ symfony/routing ### -->
-        <!-- Configure how to generate URLs in non-HTTP contexts, such as CLI commands. -->
-        <!-- See https://symfony.com/doc/current/routing.html#generating-urls-in-commands -->
-        <env name="DEFAULT_URI" value="http://localhost"/>
-        <!-- ###- symfony/routing ### -->
-
-        <!-- ###+ symfony/messenger ### -->
-        <!-- Choose one of the transports below -->
-        <!-- MESSENGER_TRANSPORT_DSN=amqp://guest:guest@localhost:5672/%2f/messages -->
-        <!-- MESSENGER_TRANSPORT_DSN=redis://localhost:6379/messages -->
-        <env name="MESSENGER_TRANSPORT_DSN" value="doctrine://default?auto_setup=0"/>
-        <!-- ###- symfony/messenger ### -->
-    </php>
-    <testsuites>
-        <testsuite name="Kimai">
-            <directory>tests/</directory>
-        </testsuite>
-    </testsuites>
-    <extensions>
-        <bootstrap class="Symfony\Bridge\PhpUnit\SymfonyExtension">
-            <parameter name="clock-mock-namespaces" value="App" />
-            <parameter name="dns-mock-namespaces" value="App" />
-        </bootstrap>
-        <bootstrap class="DAMA\DoctrineTestBundle\PHPUnit\PHPUnitExtension"/>
-    </extensions>
-    <source ignoreSuppressionOfDeprecations="true" restrictNotices="true" restrictWarnings="true">
-        <include>
-            <directory suffix=".php">src/</directory>
-            <directory suffix=".php">templates/</directory>
-        </include>
-        <exclude>
-            <directory suffix=".php">migrations/</directory>
-            <directory suffix=".php">assets/</directory>
-            <directory suffix=".php">bin/</directory>
-            <directory suffix=".php">config/</directory>
-            <directory suffix=".php">node_modules/</directory>
-            <directory suffix=".php">public/</directory>
-            <directory suffix=".php">tests/</directory>
-            <directory suffix=".php">translations/</directory>
-            <directory suffix=".php">var/</directory>
-            <directory suffix=".php">vendor/</directory>
-        </exclude>
-    </source>
+        CREATE DATABASE IF NOT EXISTS `kimai2_test`;
+        CREATE USER IF NOT EXISTS `kimai2_test`@127.0.0.1;
+        ALTER USER `kimai2_test`@127.0.0.1 IDENTIFIED BY "kimai2_test";
+        GRANT execute,select,insert,update,delete,create,alter,drop,index,references ON `kimai2_test`.* TO kimai2_test@127.0.0.1;
+    -->
+    <env name="BOOTSTRAP_RESET_DATABASE" value="true"/>
+  </php>
+  <testsuites>
+    <testsuite name="Kimai">
+      <directory>tests/</directory>
+    </testsuite>
+  </testsuites>
+  <extensions>
+    <bootstrap class="DAMA\DoctrineTestBundle\PHPUnit\PHPUnitExtension"/>
+  </extensions>
+  <source>
+    <include>
+      <directory suffix=".php">src/</directory>
+      <directory suffix=".php">templates/</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">migrations/</directory>
+      <directory suffix=".php">assets/</directory>
+      <directory suffix=".php">bin/</directory>
+      <directory suffix=".php">config/</directory>
+      <directory suffix=".php">node_modules/</directory>
+      <directory suffix=".php">public/</directory>
+      <directory suffix=".php">tests/</directory>
+      <directory suffix=".php">translations/</directory>
+      <directory suffix=".php">var/</directory>
+      <directory suffix=".php">vendor/</directory>
+    </exclude>
+  </source>
 </phpunit>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,8 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
+
+<!-- https://phpunit.readthedocs.io/en/latest/configuration.html -->
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
          backupGlobals="false"
          colors="true"
+         failOnNotice="true"
+         failOnWarning="true"
          bootstrap="tests/bootstrap.php"
          cacheDirectory="var/cache/phpunit/"
          displayDetailsOnTestsThatTriggerDeprecations="true"
@@ -10,64 +14,86 @@
          displayDetailsOnTestsThatTriggerNotices="true"
          displayDetailsOnTestsThatTriggerWarnings="true"
          displayDetailsOnPhpunitDeprecations="true">
-  <php>
-    <ini name="error_reporting" value="-1"/>
-    <ini name="max_execution_time" value="-1"/>
-    <ini name="date.timezone" value="UTC"/>
-    <ini name="intl.default_locale" value="en"/>
-    <ini name="date.timezone" value="Europe/Vienna"/>
-    <env name="KERNEL_CLASS" value="App\Kernel" force="true"/>
-    <env name="SYMFONY_DEPRECATIONS_HELPER" value="weak"/>
-    <env name="APP_ENV" value="test" force="true"/>
-    <env name="APP_DEBUG" value="0" force="true"/>
-    <env name="APP_SECRET" value="5a79a1c866efef9ca1800f971d689f3e" force="true"/>
-    <!--
-        DATABASE_URL: Default for CI/local standalone setup.
-        Without force="true", an existing DATABASE_URL environment variable
-        (e.g. from Docker container) takes precedence.
-    -->
-    <env name="DATABASE_URL" value="mysql://kimai2_test:kimai2_test@127.0.0.1:3306/kimai2_test?charset=utf8mb4&amp;serverVersion=10.5.8-MariaDB"/>
-    <env name="CORS_ALLOW_ORIGIN" value="^https?://localhost(:[0-9]+)?$"/>
-    <env name="MAILER_URL" value="null://null"/>
-    <env name="MAILER_FROM" value="kimai@example.com"/>
-    <!--
-        REINSTALL THE TEST DATABASE, eg. AFTER CHANGING STRUCTURE!
+    <php>
+        <ini name="display_errors" value="1" />
+        <ini name="error_reporting" value="-1"/>
+        <ini name="max_execution_time" value="-1"/>
+        <ini name="date.timezone" value="UTC"/>
+        <ini name="intl.default_locale" value="en"/>
+        <ini name="date.timezone" value="Europe/Vienna"/>
+        <env name="KERNEL_CLASS" value="App\Kernel" force="true"/>
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="weak"/>
+        <server name="SHELL_VERBOSITY" value="-1" />
+        <env name="APP_DEBUG" value="0" force="true"/>
+        <env name="DATABASE_URL" value="mysql://kimai2_test:kimai2_test@127.0.0.1:3306/kimai2_test?charset=utf8mb4&amp;serverVersion=10.11.15-MariaDB"/>
+        <!-- ###+ nelmio/cors-bundle ### -->
+        <env name="CORS_ALLOW_ORIGIN" value="'^https?://(localhost|127\.0\.0\.1)(:[0-9]+)?$'"/>
+        <!-- ###- nelmio/cors-bundle ### -->
+        <!--
+            REINSTALL THE TEST DATABASE, eg. AFTER CHANGING STRUCTURE!
 
-        - change to "true"
-        - composer tests
-        - change back to "false"
+            - change to "true"
+            - composer tests
+            - change back to "false"
 
-        CREATE DATABASE IF NOT EXISTS `kimai2_test`;
-        CREATE USER IF NOT EXISTS `kimai2_test`@127.0.0.1;
-        ALTER USER `kimai2_test`@127.0.0.1 IDENTIFIED BY "kimai2_test";
-        GRANT execute,select,insert,update,delete,create,alter,drop,index,references ON `kimai2_test`.* TO kimai2_test@127.0.0.1;
-    -->
-    <env name="BOOTSTRAP_RESET_DATABASE" value="true"/>
-  </php>
-  <testsuites>
-    <testsuite name="Kimai">
-      <directory>tests/</directory>
-    </testsuite>
-  </testsuites>
-  <extensions>
-    <bootstrap class="DAMA\DoctrineTestBundle\PHPUnit\PHPUnitExtension"/>
-  </extensions>
-  <source>
-    <include>
-      <directory suffix=".php">src/</directory>
-      <directory suffix=".php">templates/</directory>
-    </include>
-    <exclude>
-      <directory suffix=".php">migrations/</directory>
-      <directory suffix=".php">assets/</directory>
-      <directory suffix=".php">bin/</directory>
-      <directory suffix=".php">config/</directory>
-      <directory suffix=".php">node_modules/</directory>
-      <directory suffix=".php">public/</directory>
-      <directory suffix=".php">tests/</directory>
-      <directory suffix=".php">translations/</directory>
-      <directory suffix=".php">var/</directory>
-      <directory suffix=".php">vendor/</directory>
-    </exclude>
-  </source>
+            CREATE DATABASE IF NOT EXISTS `kimai2_test`;
+            CREATE USER IF NOT EXISTS `kimai2_test`@127.0.0.1;
+            ALTER USER `kimai2_test`@127.0.0.1 IDENTIFIED BY "kimai2_test";
+            GRANT execute,select,insert,update,delete,create,alter,drop,index,references ON `kimai2_test`.* TO kimai2_test@127.0.0.1;
+        -->
+        <env name="BOOTSTRAP_RESET_DATABASE" value="true"/>
+
+        <!-- ###+ symfony/framework-bundle ### -->
+        <env name="APP_ENV" value="test" force="true"/>
+        <env name="APP_SECRET" value="5a79a1c866efef9ca1800f971d689f3e" force="true"/>
+        <env name="APP_SHARE_DIR" value="var/share"/>
+        <!-- ###- symfony/framework-bundle ### -->
+        <!-- ###+ symfony/mailer ### -->
+        <env name="MAILER_URL" value="null://null"/>
+        <env name="MAILER_FROM" value="kimai@example.com"/>
+        <!-- ###- symfony/mailer ### -->
+
+        <!-- ###+ symfony/routing ### -->
+        <!-- Configure how to generate URLs in non-HTTP contexts, such as CLI commands. -->
+        <!-- See https://symfony.com/doc/current/routing.html#generating-urls-in-commands -->
+        <env name="DEFAULT_URI" value="http://localhost"/>
+        <!-- ###- symfony/routing ### -->
+
+        <!-- ###+ symfony/messenger ### -->
+        <!-- Choose one of the transports below -->
+        <!-- MESSENGER_TRANSPORT_DSN=amqp://guest:guest@localhost:5672/%2f/messages -->
+        <!-- MESSENGER_TRANSPORT_DSN=redis://localhost:6379/messages -->
+        <env name="MESSENGER_TRANSPORT_DSN" value="doctrine://default?auto_setup=0"/>
+        <!-- ###- symfony/messenger ### -->
+    </php>
+    <testsuites>
+        <testsuite name="Kimai">
+            <directory>tests/</directory>
+        </testsuite>
+    </testsuites>
+    <extensions>
+        <bootstrap class="Symfony\Bridge\PhpUnit\SymfonyExtension">
+            <parameter name="clock-mock-namespaces" value="App" />
+            <parameter name="dns-mock-namespaces" value="App" />
+        </bootstrap>
+        <bootstrap class="DAMA\DoctrineTestBundle\PHPUnit\PHPUnitExtension"/>
+    </extensions>
+    <source ignoreSuppressionOfDeprecations="true" restrictNotices="true" restrictWarnings="true">
+        <include>
+            <directory suffix=".php">src/</directory>
+            <directory suffix=".php">templates/</directory>
+        </include>
+        <exclude>
+            <directory suffix=".php">migrations/</directory>
+            <directory suffix=".php">assets/</directory>
+            <directory suffix=".php">bin/</directory>
+            <directory suffix=".php">config/</directory>
+            <directory suffix=".php">node_modules/</directory>
+            <directory suffix=".php">public/</directory>
+            <directory suffix=".php">tests/</directory>
+            <directory suffix=".php">translations/</directory>
+            <directory suffix=".php">var/</directory>
+            <directory suffix=".php">vendor/</directory>
+        </exclude>
+    </source>
 </phpunit>

--- a/src/Kernel.php
+++ b/src/Kernel.php
@@ -68,6 +68,18 @@ class Kernel extends BaseKernel
         }
 
         if ($this->environment === 'test') {
+            $loadPlugins = $_ENV['LOAD_PLUGINS_IN_TEST'] ?? $_SERVER['LOAD_PLUGINS_IN_TEST'] ?? '';
+            if ($loadPlugins === '') {
+                return;
+            }
+            $allowed = array_map('trim', explode(',', $loadPlugins));
+            foreach ($this->getBundleClasses() as $plugin) {
+                $name = (new \ReflectionClass($plugin))->getShortName();
+                if (\in_array($name, $allowed, true)) {
+                    yield $plugin;
+                }
+            }
+
             return;
         }
 

--- a/src/Kernel.php
+++ b/src/Kernel.php
@@ -69,6 +69,9 @@ class Kernel extends BaseKernel
 
         if ($this->environment === 'test') {
             $loadPlugins = $_ENV['LOAD_PLUGINS_IN_TEST'] ?? $_SERVER['LOAD_PLUGINS_IN_TEST'] ?? '';
+            if (!\is_string($loadPlugins)) {
+                return;
+            }
             if ($loadPlugins === '') {
                 return;
             }

--- a/src/Kernel.php
+++ b/src/Kernel.php
@@ -75,6 +75,18 @@ class Kernel extends BaseKernel
         }
 
         if ($this->environment === 'test') {
+            $loadPlugins = $_ENV['LOAD_PLUGINS_IN_TEST'] ?? $_SERVER['LOAD_PLUGINS_IN_TEST'] ?? '';
+            if ($loadPlugins === '') {
+                return;
+            }
+            $allowed = array_map('trim', explode(',', $loadPlugins));
+            foreach ($this->getBundleClasses() as $plugin) {
+                $name = (new \ReflectionClass($plugin))->getShortName();
+                if (\in_array($name, $allowed, true)) {
+                    yield $plugin;
+                }
+            }
+
             return;
         }
 

--- a/src/Kernel.php
+++ b/src/Kernel.php
@@ -76,6 +76,9 @@ class Kernel extends BaseKernel
 
         if ($this->environment === 'test') {
             $loadPlugins = $_ENV['LOAD_PLUGINS_IN_TEST'] ?? $_SERVER['LOAD_PLUGINS_IN_TEST'] ?? '';
+            if (!\is_string($loadPlugins)) {
+                return;
+            }
             if ($loadPlugins === '') {
                 return;
             }


### PR DESCRIPTION
## Summary

Adds infrastructure for testing Kimai plugins within the main Kimai test environment:

- **Selective plugin loading in test environment**: New `LOAD_PLUGINS_IN_TEST` env var in `Kernel::registerBundles()` controls which plugins are loaded during tests. Accepts a comma-separated list of bundle names (e.g. `RemoteWorkBundle,WorkContractBundle`). Without it, behavior is unchanged — no plugins are loaded in the `test` environment.
- **`bin/test-plugins` script**: Standalone PHP script that discovers all installed plugins with a `phpunit.xml` and `Tests/` directory, then runs PHPUnit for each one. Supports `--plugin <name>` to run a single plugin's tests. Extra CLI arguments are passed through (e.g. `bin/test-plugins --filter testSomething`). Disabled plugins (`.disabled` marker) are skipped.
- **`composer tests-plugins`**: Composer script entry pointing to `bin/test-plugins`, consistent with existing `composer tests`, `tests-unit`, and `tests-integration`.
- **`$_ENV`/`$_SERVER` compatibility**: Checks both `$_ENV` and `$_SERVER` for `LOAD_PLUGINS_IN_TEST`, since PHPUnit `<env force="true">` sets `$_ENV` while Docker/shell `env` sets `$_SERVER`.
- **`phpunit.xml.dist`**: Removed `force="true"` from `DATABASE_URL` so an existing environment variable (e.g. from a Docker container) takes precedence over the default.

## Two-level test architecture

The test infrastructure uses a two-level approach to separate central concerns from plugin-specific needs:

### Level 1: `bin/test-plugins` (central baseline)

Before each plugin suite, the script establishes a clean baseline:
- Clears the Symfony test cache with `APP_DEBUG=0` (matching PHPUnit's non-debug container) and all plugins loaded via `LOAD_PLUGINS_IN_TEST`
- This ensures the compiled container includes the correct bundle registrations, even after core tests (`composer tests`) have run with a different container configuration

### Level 2: Plugin `bootstrap.php` (plugin-specific)

Each plugin's bootstrap handles its own needs, e.g.:
- `doctrine:schema:update --force` to ensure plugin-specific tables exist (idempotent — creates missing tables after core test reset, no-op when current)
- Database initialization for CI/local environments (`BOOTSTRAP_RESET_DATABASE=true`)

This separation means `bin/test-plugins` doesn't need to know about plugin-specific database schemas, and plugins don't need to worry about cache state.

### Usage

```bash
# Run all plugin test suites
composer tests-plugins
bin/test-plugins

# Run a single plugin
composer tests-plugins -- --plugin RemoteWorkBundle
bin/test-plugins --plugin RemoteWorkBundle

# With PHPUnit arguments
bin/test-plugins --plugin RemoteWorkBundle --filter testSomething
bin/test-plugins --stop-on-failure
```

### Plugin phpunit.xml example

```xml
<phpunit bootstrap="Tests/bootstrap.php">
    <php>
        <env name="KERNEL_CLASS" value="App\Kernel" force="true"/>
        <env name="LOAD_PLUGINS_IN_TEST" value="MyPlugin,OtherPlugin" force="true"/>
        <env name="DATABASE_URL" value="mysql://test:test@127.0.0.1:3306/kimai_test?..."/>
    </php>
</phpunit>
```

## Test plan

- [x] `bin/test-plugins` discovers and runs plugin test suites
- [x] `composer tests-plugins` invokes `bin/test-plugins`
- [x] `--plugin <name>` runs only a single plugin's test suite
- [x] Extra PHPUnit arguments are passed through correctly
- [x] Plugins without `phpunit.xml` or `Tests/` directory are skipped
- [x] Disabled plugins (`.disabled`) are skipped
- [x] Cache is cleared with `APP_DEBUG=0` before each suite (prevents stale non-debug container)
- [x] Plugin bootstrap recovers plugin tables after core test reset
- [x] Works both locally and inside Docker containers
## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] I verified that my code applies to the guidelines (`composer code-check`)
- [ ] I updated the documentation (see [here](https://github.com/kimai/www.kimai.org/tree/master/_documentation))
- [x] I agree that this code is used in Kimai (see [license](https://github.com/kimai/kimai/blob/main/LICENSE))
