### PR TITLE
Add missing icons for absence sub-types

### DIFF
--- a/config/packages/tabler.yaml
+++ b/config/packages/tabler.yaml
@@ -97,6 +97,7 @@ tabler:
         off: fas fa-toggle-off
         on: fas fa-toggle-on
         other: fas fa-file-alt
+        parental: fas fa-baby-carriage
         password: fas fa-key
         pause: fas fa-pause
         pause-small: far fa-pause-circle
@@ -123,6 +124,7 @@ tabler:
         search: fas fa-search
         settings: fas fa-cog
         sickness: fas fa-prescription-bottle-medical
+        sickness_child: fas fa-prescription-bottle-medical
         shop: fas fa-shopping-cart
         spinner: fas fa-spinner
         start: fas fa-play
@@ -137,6 +139,7 @@ tabler:
         time-off: fas fa-couch
         trash: far fa-trash-alt
         unlocked: fas fa-unlock-alt
+        unpaid_vacation: fas fa-umbrella-beach
         upload: fas fa-upload
         user: fas fa-user
         users: fas fa-user-friends


### PR DESCRIPTION
- Add icon mappings for `sickness_child`, `parental`, and `unpaid_vacation` absence sub-types
- These types are registered by WorkContractBundle as DayAddon types in the working time overview
- Without icon mappings, the `|icon` Twig filter falls through to using the type name as CSS class, resulting in no visible icon

## Icons

| Type | Icon | Same as |
|------|------|---------|
| `sickness_child` | `fas fa-prescription-bottle-medical` | `sickness` |
| `parental` | `fas fa-baby-carriage` | (new) |
| `unpaid_vacation` | `fas fa-umbrella-beach` | `holiday` |

## Test plan

- [ ] Create a `sickness_child` absence in WorkContractBundle
- [ ] Verify the working time overview shows the medical icon for that day
- [ ] Create `parental` and `unpaid_vacation` absences
- [ ] Verify icons are displayed correctly in the working time overview

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] I verified that my code applies to the guidelines (`composer code-check`)
- [ ] I updated the documentation (see [here](https://github.com/kimai/www.kimai.org/tree/master/_documentation))
- [x] I agree that this code is used in Kimai (see [license](https://github.com/kimai/kimai/blob/main/LICENSE))
