### PR TITLE
Fix off-by-one in stopActiveEntries when starting new timesheet

### DIFF
--- a/src/Timesheet/TimesheetService.php
+++ b/src/Timesheet/TimesheetService.php
@@ -301,7 +301,8 @@ final class TimesheetService
         }
 
         $activeEntries = array_reverse($activeEntries);
-        $needsStop = \count($activeEntries) - $hardLimit;
+        // +1 because the new timesheet is not yet persisted and not in $activeEntries
+        $needsStop = \count($activeEntries) - $hardLimit + 1;
         $counter = 0;
 
         foreach ($activeEntries as $activeEntry) {

--- a/tests/Timesheet/TimesheetServiceTest.php
+++ b/tests/Timesheet/TimesheetServiceTest.php
@@ -138,6 +138,28 @@ class TimesheetServiceTest extends TestCase
         $sut->saveTimesheet($newTimesheet);
     }
 
+    public function testSaveNewTimesheetStopsOldestWhenAtHardLimit(): void
+    {
+        $authorizationChecker = $this->createMock(AuthorizationCheckerInterface::class);
+        $authorizationChecker->expects($this->once())->method('isGranted')->willReturn(true);
+
+        $activeEntry = $this->createMock(Timesheet::class);
+        $activeEntry->method('getId')->willReturn(1);
+        $activeEntry->method('getBegin')->willReturn(new \DateTime());
+        $activeEntry->expects($this->once())->method('setBegin');
+        $activeEntry->expects($this->once())->method('setEnd');
+
+        $newTimesheet = new Timesheet();
+
+        // hard_limit=1, one active entry already running → must be stopped
+        $repository = $this->createMock(TimesheetRepository::class);
+        $repository->method('getActiveEntries')->willReturn([$activeEntry]);
+
+        $sut = $this->getSut($authorizationChecker, null, null, $repository);
+
+        $sut->saveTimesheet($newTimesheet);
+    }
+
     public function testSaveNewTimesheetFixesTimezone(): void
     {
         $user = new User();


### PR DESCRIPTION
## Summary

`stopActiveEntries()` has an off-by-one error that allows more concurrent timesheets than `hard_limit` permits.

The method is called **before** the new timesheet is persisted, so `getActiveEntries()` does not include the upcoming entry. The current calculation `count($activeEntries) - $hardLimit` therefore underestimates by one — it checks whether there are *too many* entries, but doesn't account for the one about to be added.

**Example with `hard_limit = 3`:**
- 3 entries already running
- User starts a 4th via "Restart recent activity"
- `needsStop = 3 - 3 = 0` → nothing stopped
- New entry saved → **4 active entries** (exceeds limit)

**Fix:** `needsStop = count($activeEntries) - $hardLimit + 1`

This makes room for the incoming entry. The existing `$timesheet->getId() !== $activeEntry->getId()` guard still correctly skips the new (unpersisted) entry if it somehow appears in the list.

With `hard_limit = 1` (the default), the bug is less visible because most UI flows implicitly stop the previous entry through other mechanisms. It becomes clearly reproducible with `hard_limit > 1` when using "Restart one of your recent activities".

## Test plan

- [x] New unit test `testSaveNewTimesheetStopsOldestWhenAtHardLimit` — verifies that starting a new timesheet with one already running at `hard_limit = 1` stops the existing entry
- [x] Existing test `testSaveNewTimesheetStopsActiveRecords` still passes
- [x] Manual test: set `hard_limit = 3`, start 3 timesheets, restart a recent activity → oldest is stopped, count stays at 3
- [ ] 
## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] I verified that my code applies to the guidelines (`composer code-check`)
- [ ] I updated the documentation (see [here](https://github.com/kimai/www.kimai.org/tree/master/_documentation))
- [x] I agree that this code is used in Kimai (see [license](https://github.com/kimai/kimai/blob/main/LICENSE))
