### PR TITLE
[BUGFIX] Fix flaky datetime tests

### DIFF
--- a/tests/Customer/CustomerServiceTest.php
+++ b/tests/Customer/CustomerServiceTest.php
@@ -143,7 +143,7 @@ class CustomerServiceTest extends TestCase
     }
 
     #[DataProvider('getTestData')]
-    public function testCustomerNumber(string $format, int|string $expected): void
+    public function testCustomerNumber(string $format, int|string|callable $expected): void
     {
         $configuration = SystemConfigurationFactory::createStub([
             'defaults' => [
@@ -161,62 +161,57 @@ class CustomerServiceTest extends TestCase
         $sut = $this->getSut(null, null, $configuration);
         $customer = $sut->createNewCustomer('Test');
 
+        if (\is_callable($expected)) {
+            $expected = $expected();
+        }
+
         self::assertEquals((string) $expected, $customer->getNumber());
     }
 
     /**
-     * @return array<int, array<int, string|\DateTime|int>>
+     * @return array<int, array<int, string|int|callable>>
      */
     public static function getTestData(): array
     {
-        $dateTime = new \DateTime();
-
-        $yearLong = (int) $dateTime->format('Y');
-        $yearShort = (int) $dateTime->format('y');
-        $monthLong = $dateTime->format('m');
-        $monthShort = (int) $dateTime->format('n');
-        $dayLong = $dateTime->format('d');
-        $dayShort = (int) $dateTime->format('j');
-
         return [
             // simple tests for single calls
             ['{cc,1}', '2'],
             ['{cc,2}', '02'],
             ['{cc,3}', '002'],
             ['{cc,4}', '0002'],
-            ['{Y}', $yearLong],
-            ['{y}', $yearShort],
-            ['{M}', $monthLong],
-            ['{m}', $monthShort],
-            ['{D}', $dayLong],
-            ['{d}', $dayShort],
+            ['{Y}', function () { return (int) (new \DateTime())->format('Y'); }],
+            ['{y}', function () { return (int) (new \DateTime())->format('y'); }],
+            ['{M}', function () { return (new \DateTime())->format('m'); }],
+            ['{m}', function () { return (int) (new \DateTime())->format('n'); }],
+            ['{D}', function () { return (new \DateTime())->format('d'); }],
+            ['{d}', function () { return (int) (new \DateTime())->format('j'); }],
             // number formatting (not testing the lower case versions, as the tests might break depending on the date)
-            ['{Y,6}', '00' . $yearLong],
-            ['{M,3}', '0' . $monthLong],
-            ['{D,3}', '0' . $dayLong],
+            ['{Y,6}', function () { return '00' . (int) (new \DateTime())->format('Y'); }],
+            ['{M,3}', function () { return '0' . (new \DateTime())->format('m'); }],
+            ['{D,3}', function () { return '0' . (new \DateTime())->format('d'); }],
             // increment dates
-            ['{YY}', $yearLong + 1],
-            ['{YY+1}', $yearLong + 1],
-            ['{YY+2}', $yearLong + 2],
-            ['{YY+3}', $yearLong + 3],
-            ['{YY-1}', $yearLong - 1],
-            ['{YY-2}', $yearLong - 2],
-            ['{YY-3}', $yearLong - 3],
-            ['{yy}', $yearShort + 1],
-            ['{yy+1}', $yearShort + 1],
-            ['{yy+2}', $yearShort + 2],
-            ['{yy+3}', $yearShort + 3],
-            ['{yy-1}', $yearShort - 1],
-            ['{yy-2}', $yearShort - 2],
-            ['{yy-3}', $yearShort - 3],
-            ['{MM}', $monthShort + 1], // cast to int removes leading zero
-            ['{MM+1}', $monthShort + 1], // cast to int removes leading zero
-            ['{MM+2}', $monthShort + 2], // cast to int removes leading zero
-            ['{MM+3}', $monthShort + 3], // cast to int removes leading zero
-            ['{DD}', $dayShort + 1], // cast to int removes leading zero
-            ['{DD+1}', $dayShort + 1], // cast to int removes leading zero
-            ['{DD+2}', $dayShort + 2], // cast to int removes leading zero
-            ['{DD+3}', $dayShort + 3], // cast to int removes leading zero
+            ['{YY}', function () { return (int) (new \DateTime())->format('Y') + 1; }],
+            ['{YY+1}', function () { return (int) (new \DateTime())->format('Y') + 1; }],
+            ['{YY+2}', function () { return (int) (new \DateTime())->format('Y') + 2; }],
+            ['{YY+3}', function () { return (int) (new \DateTime())->format('Y') + 3; }],
+            ['{YY-1}', function () { return (int) (new \DateTime())->format('Y') - 1; }],
+            ['{YY-2}', function () { return (int) (new \DateTime())->format('Y') - 2; }],
+            ['{YY-3}', function () { return (int) (new \DateTime())->format('Y') - 3; }],
+            ['{yy}', function () { return (int) (new \DateTime())->format('y') + 1; }],
+            ['{yy+1}', function () { return (int) (new \DateTime())->format('y') + 1; }],
+            ['{yy+2}', function () { return (int) (new \DateTime())->format('y') + 2; }],
+            ['{yy+3}', function () { return (int) (new \DateTime())->format('y') + 3; }],
+            ['{yy-1}', function () { return (int) (new \DateTime())->format('y') - 1; }],
+            ['{yy-2}', function () { return (int) (new \DateTime())->format('y') - 2; }],
+            ['{yy-3}', function () { return (int) (new \DateTime())->format('y') - 3; }],
+            ['{MM}', function () { return (int) (new \DateTime())->format('n') + 1; }], // cast to int removes leading zero
+            ['{MM+1}', function () { return (int) (new \DateTime())->format('n') + 1; }], // cast to int removes leading zero
+            ['{MM+2}', function () { return (int) (new \DateTime())->format('n') + 2; }], // cast to int removes leading zero
+            ['{MM+3}', function () { return (int) (new \DateTime())->format('n') + 3; }], // cast to int removes leading zero
+            ['{DD}', function () { return (int) (new \DateTime())->format('j') + 1; }], // cast to int removes leading zero
+            ['{DD+1}', function () { return (int) (new \DateTime())->format('j') + 1; }], // cast to int removes leading zero
+            ['{DD+2}', function () { return (int) (new \DateTime())->format('j') + 2; }], // cast to int removes leading zero
+            ['{DD+3}', function () { return (int) (new \DateTime())->format('j') + 3; }], // cast to int removes leading zero
         ];
     }
 }

--- a/tests/Project/ProjectServiceTest.php
+++ b/tests/Project/ProjectServiceTest.php
@@ -173,7 +173,7 @@ class ProjectServiceTest extends TestCase
     }
 
     #[DataProvider('getTestData')]
-    public function testProjectNumber(string $format, int|string $expected): void
+    public function testProjectNumber(string $format, int|string|callable $expected): void
     {
         $configuration = SystemConfigurationFactory::createStub([
             'project' => [
@@ -185,62 +185,57 @@ class ProjectServiceTest extends TestCase
         $sut = $this->getSut(null, null, $configuration);
         $project = $sut->createNewProject();
 
+        if (\is_callable($expected)) {
+            $expected = $expected();
+        }
+
         self::assertEquals((string) $expected, $project->getNumber());
     }
 
     /**
-     * @return array<int, array<int, string|\DateTime|int>>
+     * @return array<int, array<int, string|int|callable>>
      */
     public static function getTestData(): array
     {
-        $dateTime = new \DateTime();
-
-        $yearLong = (int) $dateTime->format('Y');
-        $yearShort = (int) $dateTime->format('y');
-        $monthLong = $dateTime->format('m');
-        $monthShort = (int) $dateTime->format('n');
-        $dayLong = $dateTime->format('d');
-        $dayShort = (int) $dateTime->format('j');
-
         return [
             // simple tests for single calls
             ['{pc,1}', '2'],
             ['{pc,2}', '02'],
             ['{pc,3}', '002'],
             ['{pc,4}', '0002'],
-            ['{Y}', $yearLong],
-            ['{y}', $yearShort],
-            ['{M}', $monthLong],
-            ['{m}', $monthShort],
-            ['{D}', $dayLong],
-            ['{d}', $dayShort],
+            ['{Y}', function () { return (int) (new \DateTime())->format('Y'); }],
+            ['{y}', function () { return (int) (new \DateTime())->format('y'); }],
+            ['{M}', function () { return (new \DateTime())->format('m'); }],
+            ['{m}', function () { return (int) (new \DateTime())->format('n'); }],
+            ['{D}', function () { return (new \DateTime())->format('d'); }],
+            ['{d}', function () { return (int) (new \DateTime())->format('j'); }],
             // number formatting (not testing the lower case versions, as the tests might break depending on the date)
-            ['{Y,6}', '00' . $yearLong],
-            ['{M,3}', '0' . $monthLong],
-            ['{D,3}', '0' . $dayLong],
+            ['{Y,6}', function () { return '00' . (int) (new \DateTime())->format('Y'); }],
+            ['{M,3}', function () { return '0' . (new \DateTime())->format('m'); }],
+            ['{D,3}', function () { return '0' . (new \DateTime())->format('d'); }],
             // increment dates
-            ['{YY}', $yearLong + 1],
-            ['{YY+1}', $yearLong + 1],
-            ['{YY+2}', $yearLong + 2],
-            ['{YY+3}', $yearLong + 3],
-            ['{YY-1}', $yearLong - 1],
-            ['{YY-2}', $yearLong - 2],
-            ['{YY-3}', $yearLong - 3],
-            ['{yy}', $yearShort + 1],
-            ['{yy+1}', $yearShort + 1],
-            ['{yy+2}', $yearShort + 2],
-            ['{yy+3}', $yearShort + 3],
-            ['{yy-1}', $yearShort - 1],
-            ['{yy-2}', $yearShort - 2],
-            ['{yy-3}', $yearShort - 3],
-            ['{MM}', $monthShort + 1], // cast to int removes leading zero
-            ['{MM+1}', $monthShort + 1], // cast to int removes leading zero
-            ['{MM+2}', $monthShort + 2], // cast to int removes leading zero
-            ['{MM+3}', $monthShort + 3], // cast to int removes leading zero
-            ['{DD}', $dayShort + 1], // cast to int removes leading zero
-            ['{DD+1}', $dayShort + 1], // cast to int removes leading zero
-            ['{DD+2}', $dayShort + 2], // cast to int removes leading zero
-            ['{DD+3}', $dayShort + 3], // cast to int removes leading zero
+            ['{YY}', function () { return (int) (new \DateTime())->format('Y') + 1; }],
+            ['{YY+1}', function () { return (int) (new \DateTime())->format('Y') + 1; }],
+            ['{YY+2}', function () { return (int) (new \DateTime())->format('Y') + 2; }],
+            ['{YY+3}', function () { return (int) (new \DateTime())->format('Y') + 3; }],
+            ['{YY-1}', function () { return (int) (new \DateTime())->format('Y') - 1; }],
+            ['{YY-2}', function () { return (int) (new \DateTime())->format('Y') - 2; }],
+            ['{YY-3}', function () { return (int) (new \DateTime())->format('Y') - 3; }],
+            ['{yy}', function () { return (int) (new \DateTime())->format('y') + 1; }],
+            ['{yy+1}', function () { return (int) (new \DateTime())->format('y') + 1; }],
+            ['{yy+2}', function () { return (int) (new \DateTime())->format('y') + 2; }],
+            ['{yy+3}', function () { return (int) (new \DateTime())->format('y') + 3; }],
+            ['{yy-1}', function () { return (int) (new \DateTime())->format('y') - 1; }],
+            ['{yy-2}', function () { return (int) (new \DateTime())->format('y') - 2; }],
+            ['{yy-3}', function () { return (int) (new \DateTime())->format('y') - 3; }],
+            ['{MM}', function () { return (int) (new \DateTime())->format('n') + 1; }], // cast to int removes leading zero
+            ['{MM+1}', function () { return (int) (new \DateTime())->format('n') + 1; }], // cast to int removes leading zero
+            ['{MM+2}', function () { return (int) (new \DateTime())->format('n') + 2; }], // cast to int removes leading zero
+            ['{MM+3}', function () { return (int) (new \DateTime())->format('n') + 3; }], // cast to int removes leading zero
+            ['{DD}', function () { return (int) (new \DateTime())->format('j') + 1; }], // cast to int removes leading zero
+            ['{DD+1}', function () { return (int) (new \DateTime())->format('j') + 1; }], // cast to int removes leading zero
+            ['{DD+2}', function () { return (int) (new \DateTime())->format('j') + 2; }], // cast to int removes leading zero
+            ['{DD+3}', function () { return (int) (new \DateTime())->format('j') + 3; }], // cast to int removes leading zero
         ];
     }
 }


### PR DESCRIPTION
## Description
The tests testProjectNumber in tests/Project/ProjectServiceTest.php and testCustomerNumber in tests/Customer/CustomerServiceTest.php were flaky because they used a PHPUnit data provider (getTestData) that calculated "Expected" date values (like current day or year) at the start of the test suite execution.

The Service methods (calculateNextProjectNumber and calculateNextCustomerNumber) calculated the "Actual" values at runtime when the test method executed.

This caused two issues:

1. Timezone mismatch: If the data provider ran in a context with a different default timezone than the test execution (or if date_default_timezone_get() changed between them), the calculated days could
differ (e.g., "06" vs "05").

2. Midnight boundary: If the test suite started before midnight and the test ran after midnight, the dates would differ.

The tests are fixed by refactoring getTestData to return a callable (closure) for any date-dependent expected value. The test methods now execute this closure to calculate the expected value at the same time the service calculates the actual value, ensuring they match.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] I verified that my code applies to the guidelines (`composer code-check`)
- [x] I agree that this code is used in Kimai (see [license](https://github.com/kimai/kimai/blob/main/LICENSE))
