### PR TITLE
feat: add Saturday as first day of week option

### DIFF
--- a/src/Command/InvoiceCreateCommand.php
+++ b/src/Command/InvoiceCreateCommand.php
@@ -120,7 +120,7 @@ final class InvoiceCreateCommand extends Command
         }
 
         $timezone = new \DateTimeZone($timezone);
-        $dateFactory = new DateTimeFactory($timezone, $user->isFirstDayOfWeekSunday());
+        $dateFactory = new DateTimeFactory($timezone, $user->getFirstDayOfWeek());
 
         if (!empty($input->getOption('start')) && empty($input->getOption('end'))) {
             $io->error('You need to supply a end date if a start date was given');

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -478,6 +478,11 @@ class User implements UserInterface, EquatableInterface, ThemeUserInterface, Pas
         return $this->getFirstDayOfWeek() === 'sunday';
     }
 
+    public function isFirstDayOfWeekSaturday(): bool
+    {
+        return $this->getFirstDayOfWeek() === 'saturday';
+    }
+
     public function getFirstDayOfWeek(): string
     {
         return $this->getPreferenceValue(UserPreference::FIRST_WEEKDAY, User::DEFAULT_FIRST_WEEKDAY, false);

--- a/src/Form/Type/FirstWeekDayType.php
+++ b/src/Form/Type/FirstWeekDayType.php
@@ -22,7 +22,8 @@ final class FirstWeekDayType extends AbstractType
     {
         $choices = [
             'Monday' => 'monday',
-            'Sunday' => 'sunday'
+            'Sunday' => 'sunday',
+            'Saturday' => 'saturday',
         ];
 
         $resolver->setDefaults([

--- a/src/Timesheet/DateTimeFactory.php
+++ b/src/Timesheet/DateTimeFactory.php
@@ -17,20 +17,20 @@ use DateTimeZone;
 final class DateTimeFactory
 {
     private DateTimeZone $timezone;
-    private bool $startOnSunday = false;
+    private string $firstDayOfWeek = 'monday';
 
     public static function createByUser(User $user): self
     {
-        return new DateTimeFactory(new \DateTimeZone($user->getTimezone()), $user->isFirstDayOfWeekSunday());
+        return new DateTimeFactory(new \DateTimeZone($user->getTimezone()), $user->getFirstDayOfWeek());
     }
 
-    public function __construct(?DateTimeZone $timezone = null, bool $startOnSunday = false)
+    public function __construct(?DateTimeZone $timezone = null, string $firstDayOfWeek = 'monday')
     {
         if (null === $timezone) {
             $timezone = new \DateTimeZone(date_default_timezone_get());
         }
         $this->timezone = $timezone;
-        $this->startOnSunday = $startOnSunday;
+        $this->firstDayOfWeek = $firstDayOfWeek;
     }
 
     public function getTimezone(): DateTimeZone
@@ -95,13 +95,19 @@ final class DateTimeFactory
     public function getStartOfWeek(DateTimeInterface|string|null $date = null): DateTime
     {
         $date = $this->getDate($date);
-        $firstDay = 1;
+        $firstDay = match ($this->firstDayOfWeek) {
+            'sunday' => 7,
+            'saturday' => 6,
+            default => 1,
+        };
 
-        if ($this->startOnSunday) {
-            $firstDay = 7;
-
+        if ($this->firstDayOfWeek === 'sunday') {
             // if today = sunday => increase week by one
             if ($date->format('N') !== '7') {
+                $date = $date->modify('-1 week');
+            }
+        } elseif ($this->firstDayOfWeek === 'saturday') {
+            if ((int) $date->format('N') < 6) {
                 $date = $date->modify('-1 week');
             }
         }
@@ -112,13 +118,19 @@ final class DateTimeFactory
     public function getEndOfWeek(DateTimeInterface|string|null $date = null): DateTime
     {
         $date = $this->getDate($date);
-        $lastDay = 7;
+        $lastDay = match ($this->firstDayOfWeek) {
+            'sunday' => 6,
+            'saturday' => 5,
+            default => 7,
+        };
 
-        if ($this->startOnSunday) {
-            $lastDay = 6;
-
+        if ($this->firstDayOfWeek === 'sunday') {
             // only change when today is not sunday
             if ($date->format('N') === '7') {
+                $date = $date->modify('+1 week');
+            }
+        } elseif ($this->firstDayOfWeek === 'saturday') {
+            if ((int) $date->format('N') >= 6) {
                 $date = $date->modify('+1 week');
             }
         }

--- a/src/Timesheet/DateTimeFactory.php
+++ b/src/Timesheet/DateTimeFactory.php
@@ -24,8 +24,13 @@ final class DateTimeFactory
         return new DateTimeFactory(new \DateTimeZone($user->getTimezone()), $user->getFirstDayOfWeek());
     }
 
-    public function __construct(?DateTimeZone $timezone = null, string $firstDayOfWeek = 'monday')
+    public function __construct(?DateTimeZone $timezone = null, bool|string $firstDayOfWeek = 'monday')
     {
+        if (\is_bool($firstDayOfWeek)) {
+            @trigger_error('Passing a boolean as first day of week is deprecated, pass "sunday" or "monday" instead.', E_USER_DEPRECATED);
+            $firstDayOfWeek = $firstDayOfWeek ? 'sunday' : 'monday';
+        }
+
         if (null === $timezone) {
             $timezone = new \DateTimeZone(date_default_timezone_get());
         }

--- a/tests/Timesheet/DateTimeFactoryTest.php
+++ b/tests/Timesheet/DateTimeFactoryTest.php
@@ -21,13 +21,13 @@ class DateTimeFactoryTest extends TestCase
 {
     public const TEST_TIMEZONE = 'Europe/London';
 
-    protected static function createDateTimeFactory(?string $timezone = null, bool $sunday = false): DateTimeFactory
+    protected static function createDateTimeFactory(?string $timezone = null, bool|string $firstDayOfWeek = 'monday'): DateTimeFactory
     {
         if (null === $timezone) {
-            return new DateTimeFactory(null, $sunday);
+            return new DateTimeFactory(null, $firstDayOfWeek);
         }
 
-        return new DateTimeFactory(new DateTimeZone($timezone), $sunday);
+        return new DateTimeFactory(new DateTimeZone($timezone), $firstDayOfWeek);
     }
 
     public function testGetTimezone(): void
@@ -112,8 +112,8 @@ class DateTimeFactoryTest extends TestCase
     public static function getStartOfWeekData()
     {
         yield [self::createDateTimeFactory(self::TEST_TIMEZONE), 'Monday', 23, 1];
-        yield [self::createDateTimeFactory(self::TEST_TIMEZONE, false), 'Monday', 23, 1];
-        yield [self::createDateTimeFactory(self::TEST_TIMEZONE, true), 'Sunday', 22, 7];
+        yield [self::createDateTimeFactory(self::TEST_TIMEZONE, 'sunday'), 'Sunday', 22, 7];
+        yield [self::createDateTimeFactory(self::TEST_TIMEZONE, 'saturday'), 'Saturday', 21, 6];
     }
 
     #[DataProvider('getStartOfWeekData')]
@@ -133,6 +133,11 @@ class DateTimeFactoryTest extends TestCase
         self::assertEquals($expected->format('Y'), $dateTime->format('Y'));
         self::assertEquals(self::TEST_TIMEZONE, $dateTime->getTimezone()->getName());
 
+        if ($day === 6) {
+            self::assertSame('2018-07-28 00:00:00', $sut->getStartOfWeek('2018-07-28')->format('Y-m-d H:i:s'));
+            self::assertSame('2018-08-03 23:59:59', $sut->getEndOfWeek('2018-07-28')->format('Y-m-d H:i:s'));
+        }
+
         $dateTime = $sut->getStartOfWeek();
 
         self::assertEquals(0, $dateTime->format('H'));
@@ -147,8 +152,8 @@ class DateTimeFactoryTest extends TestCase
     public static function getEndOfWeekData()
     {
         yield [self::createDateTimeFactory(self::TEST_TIMEZONE), 'Sunday', 29, 7];
-        yield [self::createDateTimeFactory(self::TEST_TIMEZONE, false), 'Sunday', 29, 7];
-        yield [self::createDateTimeFactory(self::TEST_TIMEZONE, true), 'Saturday', 28, 6];
+        yield [self::createDateTimeFactory(self::TEST_TIMEZONE, 'sunday'), 'Saturday', 28, 6];
+        yield [self::createDateTimeFactory(self::TEST_TIMEZONE, 'saturday'), 'Friday', 27, 5];
     }
 
     #[DataProvider('getEndOfWeekData')]
@@ -177,6 +182,27 @@ class DateTimeFactoryTest extends TestCase
         self::assertEquals($dayName, $dateTime->format('l'));
         // month and year can be different when the week started at the end of the month
         self::assertEquals(self::TEST_TIMEZONE, $dateTime->getTimezone()->getName());
+    }
+
+    public static function getBooleanFirstDayOfWeekData(): iterable
+    {
+        return [[true, 'Sunday'], [false, 'Monday']];
+    }
+
+    #[DataProvider('getBooleanFirstDayOfWeekData')]
+    public function testBooleanFirstDayOfWeekIsDeprecated(bool $firstDayOfWeek, string $expected): void
+    {
+        $deprecation = null;
+        set_error_handler(static function (int $type, string $message) use (&$deprecation): bool {
+            $deprecation = $message;
+
+            return true;
+        }, E_USER_DEPRECATED);
+        $sut = self::createDateTimeFactory(self::TEST_TIMEZONE, $firstDayOfWeek);
+        restore_error_handler();
+
+        self::assertSame('Passing a boolean as first day of week is deprecated, pass "sunday" or "monday" instead.', $deprecation);
+        self::assertSame($expected, $sut->getStartOfWeek('2018-07-26')->format('l'));
     }
 
     public function testCreateDateTime(): void


### PR DESCRIPTION
## Summary

Adds Saturday as an option for the first day of the week, alongside the existing Monday and Sunday options. Useful for regions where the work week starts on Saturday.

## Changes

- `src/Form/Type/FirstWeekDayType.php`: Added `'Saturday' => 'saturday'` to the choices array
- `src/Timesheet/DateTimeFactory.php`: Refactored from `bool $startOnSunday` to `string $firstDayOfWeek` with `match` expressions for Monday/Sunday/Saturday week boundary calculations
- `src/Entity/User.php`: Added `isFirstDayOfWeekSaturday()` method, kept `isFirstDayOfWeekSunday()` for backward compatibility
- `src/Command/InvoiceCreateCommand.php`: Updated to pass `$user->getFirstDayOfWeek()` instead of `$user->isFirstDayOfWeekSunday()`

## Backward compatibility

The `isFirstDayOfWeekSunday()` method is preserved. The `DateTimeFactory` constructor now accepts a string (`'monday'`, `'sunday'`, `'saturday'`) instead of a boolean, but the default behavior (`'monday'`) matches the previous default (`false`).

Fixes #4017

This contribution was developed with AI assistance (Codex).