### PR TITLE
New API endpoint to create user API tokens

### DIFF
--- a/config/packages/nelmio_api_doc.yaml
+++ b/config/packages/nelmio_api_doc.yaml
@@ -36,6 +36,8 @@ nelmio_api_doc:
             - { alias: UserPreference,              type: App\Entity\UserPreference,                groups: [Default, User_Entity] }
             - { alias: UserEntity,                  type: App\Entity\User,                          groups: [Default, Entity, User, User_Entity] }
             - { alias: UserCollection,              type: App\Entity\User,                          groups: [Default, Collection, User] }
+            - { alias: AccessTokenCreateForm,       type: App\Form\API\AccessTokenApiCreateForm,    groups: [Default, Entity, AccessToken] }
+            - { alias: AccessTokenEntity,           type: App\Entity\AccessToken,                   groups: [Default, Entity, AccessToken] }
             - { alias: TeamEditForm,                type: App\Form\API\TeamApiEditForm,             groups: [Default, Entity, Team, Team_Entity] }
             - { alias: Team,                        type: App\Entity\Team,                          groups: [Default, Entity, Team, Team_Entity] }
             - { alias: TeamCollection,              type: App\Entity\Team,                          groups: [Default, Collection, Team] }

--- a/src/API/UserController.php
+++ b/src/API/UserController.php
@@ -202,6 +202,69 @@ final class UserController extends BaseApiController
     }
 
     /**
+     * Create API token
+     *
+     * Creates a new API token for the given user. The plain token is only visible in this response.
+     */
+    #[OA\Post(description: 'Creates a new API token for the given user and returns it. The plain token is only visible in this response.')]
+    #[OA\RequestBody(required: true, content: new OA\JsonContent(
+        required: ['name'],
+        properties: [
+            new OA\Property(property: 'name', type: 'string', description: 'A name to identify this token', example: 'My API token'),
+            new OA\Property(property: 'expiresAt', type: 'string', format: 'date-time', description: 'Optional expiration date', example: '2027-01-01T00:00:00+00:00'),
+        ]
+    ))]
+    #[OA\Response(response: 200, description: 'Returns the created API token including the plain text token value.', content: new OA\JsonContent(
+        properties: [
+            new OA\Property(property: 'id', type: 'integer'),
+            new OA\Property(property: 'name', type: 'string'),
+            new OA\Property(property: 'token', type: 'string', description: 'The plain text token — store it now, it cannot be retrieved later'),
+            new OA\Property(property: 'expiresAt', type: 'string', format: 'date-time', nullable: true),
+        ]
+    ))]
+    #[OA\Parameter(name: 'id', in: 'path', description: 'User ID to create the token for', required: true)]
+    #[Route(methods: ['POST'], path: '/{id}/api-token', name: 'post_api_token', requirements: ['id' => '\d+'])]
+    public function postApiToken(User $profile, Request $request, AccessTokenRepository $accessTokenRepository): Response
+    {
+        $user = $this->getUser();
+        if (!$this->isGranted('api-token', $user)) {
+            throw $this->createAccessDeniedException('User has no access to API tokens');
+        }
+
+        if (!$this->isGranted('api-token', $profile)) {
+            throw $this->createAccessDeniedException('You are not allowed to create API tokens for this user');
+        }
+
+        $name = $request->request->get('name');
+        if (!\is_string($name) || trim($name) === '') {
+            throw new BadRequestHttpException('Missing required parameter "name"');
+        }
+
+        $accessToken = AccessToken::createForUser($profile);
+        $accessToken->setName(trim($name));
+
+        $expiresAt = $request->request->get('expiresAt');
+        if (\is_string($expiresAt) && $expiresAt !== '') {
+            try {
+                $accessToken->setExpiresAt(new \DateTimeImmutable($expiresAt));
+            } catch (\Exception) {
+                throw new BadRequestHttpException('Invalid date format for "expiresAt"');
+            }
+        }
+
+        $accessTokenRepository->saveAccessToken($accessToken);
+
+        $view = new View([
+            'id' => $accessToken->getId(),
+            'name' => $accessToken->getName(),
+            'token' => $accessToken->getToken(),
+            'expiresAt' => $accessToken->getExpiresAt()?->format(\DateTimeInterface::ATOM),
+        ], Response::HTTP_OK);
+
+        return $this->viewHandler->handle($view);
+    }
+
+    /**
      * Delete API token
      *
      * This ONLY works if the given API token exists and belongs to the current user

--- a/src/API/UserController.php
+++ b/src/API/UserController.php
@@ -223,18 +223,10 @@ final class UserController extends BaseApiController
         ]
     ))]
     #[OA\Parameter(name: 'id', in: 'path', description: 'User ID to create the token for', required: true)]
+    #[IsGranted('api-token', 'profile')]
     #[Route(methods: ['POST'], path: '/{id}/api-token', name: 'post_api_token', requirements: ['id' => '\d+'])]
     public function postApiToken(User $profile, Request $request, AccessTokenRepository $accessTokenRepository): Response
     {
-        $user = $this->getUser();
-        if (!$this->isGranted('api-token', $user)) {
-            throw $this->createAccessDeniedException('User has no access to API tokens');
-        }
-
-        if (!$this->isGranted('api-token', $profile)) {
-            throw $this->createAccessDeniedException('You are not allowed to create API tokens for this user');
-        }
-
         $name = $request->request->get('name');
         if (!\is_string($name) || trim($name) === '') {
             throw new BadRequestHttpException('Missing required parameter "name"');

--- a/src/API/UserController.php
+++ b/src/API/UserController.php
@@ -240,7 +240,7 @@ final class UserController extends BaseApiController
             throw new BadRequestHttpException('Missing required parameter "name"');
         }
 
-        $accessToken = AccessToken::createForUser($profile);
+        $accessToken = new AccessToken($profile);
         $accessToken->setName(trim($name));
 
         $expiresAt = $request->request->get('expiresAt');

--- a/src/API/UserController.php
+++ b/src/API/UserController.php
@@ -13,6 +13,7 @@ use App\Entity\AccessToken;
 use App\Entity\User;
 use App\Entity\UserPreference;
 use App\Event\PrepareUserEvent;
+use App\Form\API\AccessTokenApiCreateForm;
 use App\Form\API\UserApiCreateForm;
 use App\Form\API\UserApiEditForm;
 use App\Repository\AccessTokenRepository;
@@ -203,55 +204,30 @@ final class UserController extends BaseApiController
 
     /**
      * Create API token
-     *
-     * Creates a new API token for the given user. The plain token is only visible in this response.
      */
-    #[OA\Post(description: 'Creates a new API token for the given user and returns it. The plain token is only visible in this response.')]
-    #[OA\RequestBody(required: true, content: new OA\JsonContent(
-        required: ['name'],
-        properties: [
-            new OA\Property(property: 'name', type: 'string', description: 'A name to identify this token', example: 'My API token'),
-            new OA\Property(property: 'expiresAt', type: 'string', format: 'date-time', description: 'Optional expiration date', example: '2027-01-01T00:00:00+00:00'),
-        ]
-    ))]
-    #[OA\Response(response: 200, description: 'Returns the created API token including the plain text token value.', content: new OA\JsonContent(
-        properties: [
-            new OA\Property(property: 'id', type: 'integer'),
-            new OA\Property(property: 'name', type: 'string'),
-            new OA\Property(property: 'token', type: 'string', description: 'The plain text token — store it now, it cannot be retrieved later'),
-            new OA\Property(property: 'expiresAt', type: 'string', format: 'date-time', nullable: true),
-        ]
-    ))]
-    #[OA\Parameter(name: 'id', in: 'path', description: 'User ID to create the token for', required: true)]
     #[IsGranted('api-token', 'profile')]
+    #[OA\Post(description: 'Creates a new API token and returns it afterwards', responses: [new OA\Response(response: 200, description: 'Returns the new created API token', content: new OA\JsonContent(ref: '#/components/schemas/AccessTokenEntity'))])]
+    #[OA\RequestBody(required: true, content: new OA\JsonContent(ref: '#/components/schemas/AccessTokenCreateForm'))]
+    #[OA\Parameter(name: 'id', in: 'path', description: 'User ID to create the token for', required: true)]
     #[Route(methods: ['POST'], path: '/{id}/api-token', name: 'post_api_token', requirements: ['id' => '\d+'])]
     public function postApiToken(User $profile, Request $request, AccessTokenRepository $accessTokenRepository): Response
     {
-        $name = $request->request->get('name');
-        if (!\is_string($name) || trim($name) === '') {
-            throw new BadRequestHttpException('Missing required parameter "name"');
-        }
-
         $accessToken = new AccessToken($profile);
-        $accessToken->setName(trim($name));
 
-        $expiresAt = $request->request->get('expiresAt');
-        if (\is_string($expiresAt) && $expiresAt !== '') {
-            try {
-                $accessToken->setExpiresAt(new \DateTimeImmutable($expiresAt));
-            } catch (\Exception) {
-                throw new BadRequestHttpException('Invalid date format for "expiresAt"');
-            }
+        $form = $this->createForm(AccessTokenApiCreateForm::class, $accessToken);
+        $form->submit($request->request->all());
+
+        if ($form->isValid()) {
+            $accessTokenRepository->saveAccessToken($accessToken);
+
+            $view = new View($accessToken, Response::HTTP_OK);
+            $view->getContext()->setGroups(self::GROUPS_ENTITY);
+
+            return $this->viewHandler->handle($view);
         }
 
-        $accessTokenRepository->saveAccessToken($accessToken);
-
-        $view = new View([
-            'id' => $accessToken->getId(),
-            'name' => $accessToken->getName(),
-            'token' => $accessToken->getToken(),
-            'expiresAt' => $accessToken->getExpiresAt()?->format(\DateTimeInterface::ATOM),
-        ], Response::HTTP_OK);
+        $view = new View($form);
+        $view->getContext()->setGroups(self::GROUPS_FORM);
 
         return $this->viewHandler->handle($view);
     }

--- a/src/Controller/ProfileController.php
+++ b/src/Controller/ProfileController.php
@@ -181,7 +181,7 @@ final class ProfileController extends AbstractController
         AccessTokenRepository $accessTokenRepository
     ): Response
     {
-        $accessToken = new AccessToken($profile, substr(bin2hex(random_bytes(100)), 0, 25));
+        $accessToken = AccessToken::createForUser($profile);
 
         $form = $this->createForm(AccessTokenForm::class, $accessToken, [
             'action' => $this->generateUrl('user_profile_access_token', ['username' => $profile->getUserIdentifier()]),

--- a/src/Controller/ProfileController.php
+++ b/src/Controller/ProfileController.php
@@ -181,7 +181,7 @@ final class ProfileController extends AbstractController
         AccessTokenRepository $accessTokenRepository
     ): Response
     {
-        $accessToken = AccessToken::createForUser($profile);
+        $accessToken = new AccessToken($profile);
 
         $form = $this->createForm(AccessTokenForm::class, $accessToken, [
             'action' => $this->generateUrl('user_profile_access_token', ['username' => $profile->getUserIdentifier()]),

--- a/src/Entity/AccessToken.php
+++ b/src/Entity/AccessToken.php
@@ -49,6 +49,11 @@ class AccessToken
         $this->token = $token;
     }
 
+    public static function createForUser(User $user): self
+    {
+        return new self($user, substr(bin2hex(random_bytes(100)), 0, 25));
+    }
+
     public function getId(): ?int
     {
         return $this->id;

--- a/src/Entity/AccessToken.php
+++ b/src/Entity/AccessToken.php
@@ -43,15 +43,10 @@ class AccessToken
     #[ORM\Column(name: 'expires_at', type: Types::DATETIME_IMMUTABLE, nullable: true)]
     private ?\DateTimeImmutable $expiresAt = null;
 
-    public function __construct(User $user, string $token)
+    public function __construct(User $user, ?string $token = null)
     {
         $this->user = $user;
-        $this->token = $token;
-    }
-
-    public static function createForUser(User $user): self
-    {
-        return new self($user, substr(bin2hex(random_bytes(100)), 0, 25));
+        $this->token = $token ?? substr(bin2hex(random_bytes(100)), 0, 25);
     }
 
     public function getId(): ?int

--- a/src/Entity/AccessToken.php
+++ b/src/Entity/AccessToken.php
@@ -12,6 +12,7 @@ namespace App\Entity;
 use App\Repository\AccessTokenRepository;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
+use JMS\Serializer\Annotation as Serializer;
 use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
 use Symfony\Component\Validator\Constraints as Assert;
 
@@ -20,11 +21,14 @@ use Symfony\Component\Validator\Constraints as Assert;
 #[ORM\UniqueConstraint(columns: ['token'])]
 #[ORM\ChangeTrackingPolicy('DEFERRED_EXPLICIT')]
 #[UniqueEntity(fields: ['token'])]
+#[Serializer\ExclusionPolicy('all')]
 class AccessToken
 {
     #[ORM\Column(name: 'id', type: Types::INTEGER)]
     #[ORM\Id]
     #[ORM\GeneratedValue(strategy: 'IDENTITY')]
+    #[Serializer\Expose]
+    #[Serializer\Groups(['Default'])]
     private ?int $id = null;
     #[ORM\ManyToOne(targetEntity: User::class)]
     #[ORM\JoinColumn(nullable: false, onDelete: 'CASCADE')]
@@ -33,14 +37,20 @@ class AccessToken
     #[ORM\Column(name: 'token', type: Types::STRING, length: 100, nullable: false)]
     #[Assert\NotBlank]
     #[Assert\Length(min: 2, max: 100)]
+    #[Serializer\Expose]
+    #[Serializer\Groups(['Default'])]
     private string $token;
     #[ORM\Column(name: 'name', type: Types::STRING, length: 50, nullable: false)]
     #[Assert\NotBlank]
     #[Assert\Length(min: 2, max: 50)]
+    #[Serializer\Expose]
+    #[Serializer\Groups(['Default'])]
     private ?string $name = null;
     #[ORM\Column(name: 'last_usage', type: Types::DATETIME_IMMUTABLE, nullable: true)]
     private ?\DateTimeImmutable $lastUsage = null;
     #[ORM\Column(name: 'expires_at', type: Types::DATETIME_IMMUTABLE, nullable: true)]
+    #[Serializer\Expose]
+    #[Serializer\Groups(['Default'])]
     private ?\DateTimeImmutable $expiresAt = null;
 
     public function __construct(User $user, ?string $token = null)

--- a/src/Form/API/AccessTokenApiCreateForm.php
+++ b/src/Form/API/AccessTokenApiCreateForm.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of the Kimai time-tracking app.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Form\API;
+
+use App\Entity\AccessToken;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Validator\Constraints\GreaterThan;
+
+final class AccessTokenApiCreateForm extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder
+            ->add('name', TextType::class, [
+                'required' => true,
+            ])
+            ->add('expiresAt', DateTimeApiType::class, [
+                'required' => false,
+                'constraints' => [
+                    new GreaterThan($options['min_date']),
+                ],
+            ])
+        ;
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'data_class' => AccessToken::class,
+            'csrf_protection' => false,
+            'min_date' => new \DateTimeImmutable('today 00:00:00'),
+        ]);
+        $resolver->setAllowedTypes('min_date', [\DateTimeInterface::class]);
+    }
+}

--- a/tests/API/APIControllerBaseTestCase.php
+++ b/tests/API/APIControllerBaseTestCase.php
@@ -344,6 +344,14 @@ abstract class APIControllerBaseTestCase extends AbstractControllerBaseTestCase
                     'visible' => 'bool',
                 ];
 
+            case 'AccessTokenEntity':
+                return [
+                    'id' => 'int',
+                    'name' => 'string',
+                    'token' => 'string',
+                    'expiresAt' => '@datetime',
+                ];
+
                 // embedded meta data
             case 'UserPreference':
                 return [

--- a/tests/API/ApiDocControllerTest.php
+++ b/tests/API/ApiDocControllerTest.php
@@ -107,6 +107,7 @@ class ApiDocControllerTest extends AbstractControllerBaseTestCase
             '/api/users',
             '/api/users/{id}',
             '/api/users/me',
+            '/api/users/{id}/api-token',
             '/api/users/api-token/{id}',
             '/api/users/{id}/preferences',
         ];

--- a/tests/API/UserControllerTest.php
+++ b/tests/API/UserControllerTest.php
@@ -341,6 +341,107 @@ class UserControllerTest extends APIControllerBaseTestCase
         $this->assertApiCallValidationError($response, ['email', 'language', 'timezone', 'roles'], true);
     }
 
+    // ------------------------------------- [API TOKEN] -------------------------------------
+
+    public function testPostApiTokenIsSecure(): void
+    {
+        $this->assertRequestIsSecured(self::createClient(), '/api/users/1/api-token', 'POST');
+    }
+
+    public function testPostApiToken(): void
+    {
+        $client = $this->getClientForAuthenticatedUser(User::ROLE_SUPER_ADMIN);
+        $this->request($client, '/api/users/6/api-token', 'POST', [], (string) json_encode(['name' => 'My API token']));
+        self::assertTrue($client->getResponse()->isSuccessful());
+
+        $content = $client->getResponse()->getContent();
+        self::assertIsString($content);
+        $result = json_decode($content, true);
+
+        self::assertIsArray($result);
+        self::assertArrayHasKey('id', $result);
+        self::assertArrayHasKey('name', $result);
+        self::assertArrayHasKey('token', $result);
+        self::assertArrayHasKey('expiresAt', $result);
+        self::assertEquals('My API token', $result['name']);
+        self::assertNotEmpty($result['token']);
+        self::assertNull($result['expiresAt']);
+    }
+
+    public function testPostApiTokenWithExpiresAt(): void
+    {
+        $client = $this->getClientForAuthenticatedUser(User::ROLE_SUPER_ADMIN);
+        $data = [
+            'name' => 'Expiring token',
+            'expiresAt' => '2099-01-01T00:00:00+00:00',
+        ];
+        $this->request($client, '/api/users/6/api-token', 'POST', [], (string) json_encode($data));
+        self::assertTrue($client->getResponse()->isSuccessful());
+
+        $content = $client->getResponse()->getContent();
+        self::assertIsString($content);
+        $result = json_decode($content, true);
+
+        self::assertIsArray($result);
+        self::assertEquals('Expiring token', $result['name']);
+        self::assertNotEmpty($result['token']);
+        self::assertEquals('2099-01-01T00:00:00+00:00', $result['expiresAt']);
+    }
+
+    public function testPostApiTokenTrimsName(): void
+    {
+        $client = $this->getClientForAuthenticatedUser(User::ROLE_SUPER_ADMIN);
+        $this->request($client, '/api/users/6/api-token', 'POST', [], (string) json_encode(['name' => '  Trimmed  ']));
+        self::assertTrue($client->getResponse()->isSuccessful());
+
+        $content = $client->getResponse()->getContent();
+        self::assertIsString($content);
+        $result = json_decode($content, true);
+
+        self::assertIsArray($result);
+        self::assertEquals('Trimmed', $result['name']);
+    }
+
+    public function testPostApiTokenWithMissingName(): void
+    {
+        $client = $this->getClientForAuthenticatedUser(User::ROLE_SUPER_ADMIN);
+        $this->assertBadRequest($client, '/api/users/6/api-token', 'POST');
+    }
+
+    public function testPostApiTokenWithEmptyName(): void
+    {
+        $client = $this->getClientForAuthenticatedUser(User::ROLE_SUPER_ADMIN);
+        $this->assertExceptionForMethod($client, '/api/users/6/api-token', 'POST', ['name' => '   '], [
+            'code' => Response::HTTP_BAD_REQUEST,
+            'message' => 'Bad Request',
+        ]);
+    }
+
+    public function testPostApiTokenWithInvalidExpiresAt(): void
+    {
+        $client = $this->getClientForAuthenticatedUser(User::ROLE_SUPER_ADMIN);
+        $this->assertExceptionForMethod($client, '/api/users/6/api-token', 'POST', [
+            'name' => 'foo',
+            'expiresAt' => 'not-a-date',
+        ], [
+            'code' => Response::HTTP_BAD_REQUEST,
+            'message' => 'Bad Request',
+        ]);
+    }
+
+    public function testPostApiTokenForUnknownUser(): void
+    {
+        $client = $this->getClientForAuthenticatedUser(User::ROLE_SUPER_ADMIN);
+        $this->assertEntityNotFoundForPost($client, '/api/users/255/api-token', ['name' => 'foo']);
+    }
+
+    public function testPostApiTokenForOtherUserIsDeniedToRegularUser(): void
+    {
+        $client = $this->getClientForAuthenticatedUser(User::ROLE_USER);
+        $this->request($client, '/api/users/6/api-token', 'POST', [], (string) json_encode(['name' => 'foo']));
+        $this->assertApiResponseAccessDenied($client->getResponse());
+    }
+
     // ------------------------------------- [USER PREFERENCES] -------------------------------------
 
     public function testUpdateUserPreferenceThrowsNotFound(): void

--- a/tests/API/UserControllerTest.php
+++ b/tests/API/UserControllerTest.php
@@ -359,10 +359,8 @@ class UserControllerTest extends APIControllerBaseTestCase
         $result = json_decode($content, true);
 
         self::assertIsArray($result);
-        self::assertArrayHasKey('id', $result);
-        self::assertArrayHasKey('name', $result);
-        self::assertArrayHasKey('token', $result);
-        self::assertArrayHasKey('expiresAt', $result);
+        self::assertApiResponseTypeStructure('AccessTokenEntity', $result);
+        self::assertNotEmpty($result['id']);
         self::assertEquals('My API token', $result['name']);
         self::assertNotEmpty($result['token']);
         self::assertNull($result['expiresAt']);
@@ -373,7 +371,7 @@ class UserControllerTest extends APIControllerBaseTestCase
         $client = $this->getClientForAuthenticatedUser(User::ROLE_SUPER_ADMIN);
         $data = [
             'name' => 'Expiring token',
-            'expiresAt' => '2099-01-01T00:00:00+00:00',
+            'expiresAt' => '2099-01-01T00:00:00',
         ];
         $this->request($client, '/api/users/6/api-token', 'POST', [], (string) json_encode($data));
         self::assertTrue($client->getResponse()->isSuccessful());
@@ -383,50 +381,20 @@ class UserControllerTest extends APIControllerBaseTestCase
         $result = json_decode($content, true);
 
         self::assertIsArray($result);
+        self::assertApiResponseTypeStructure('AccessTokenEntity', $result);
         self::assertEquals('Expiring token', $result['name']);
         self::assertNotEmpty($result['token']);
-        self::assertEquals('2099-01-01T00:00:00+00:00', $result['expiresAt']);
+        self::assertEquals((new \DateTime('2099-01-01T00:00:00'))->format('Y-m-d\TH:i:sO'), $result['expiresAt']);
     }
 
-    public function testPostApiTokenTrimsName(): void
+    public function testPostApiTokenWithValidationErrors(): void
     {
         $client = $this->getClientForAuthenticatedUser(User::ROLE_SUPER_ADMIN);
-        $this->request($client, '/api/users/6/api-token', 'POST', [], (string) json_encode(['name' => '  Trimmed  ']));
-        self::assertTrue($client->getResponse()->isSuccessful());
-
-        $content = $client->getResponse()->getContent();
-        self::assertIsString($content);
-        $result = json_decode($content, true);
-
-        self::assertIsArray($result);
-        self::assertEquals('Trimmed', $result['name']);
-    }
-
-    public function testPostApiTokenWithMissingName(): void
-    {
-        $client = $this->getClientForAuthenticatedUser(User::ROLE_SUPER_ADMIN);
-        $this->assertBadRequest($client, '/api/users/6/api-token', 'POST');
-    }
-
-    public function testPostApiTokenWithEmptyName(): void
-    {
-        $client = $this->getClientForAuthenticatedUser(User::ROLE_SUPER_ADMIN);
-        $this->assertExceptionForMethod($client, '/api/users/6/api-token', 'POST', ['name' => '   '], [
-            'code' => Response::HTTP_BAD_REQUEST,
-            'message' => 'Bad Request',
-        ]);
-    }
-
-    public function testPostApiTokenWithInvalidExpiresAt(): void
-    {
-        $client = $this->getClientForAuthenticatedUser(User::ROLE_SUPER_ADMIN);
-        $this->assertExceptionForMethod($client, '/api/users/6/api-token', 'POST', [
-            'name' => 'foo',
-            'expiresAt' => 'not-a-date',
-        ], [
-            'code' => Response::HTTP_BAD_REQUEST,
-            'message' => 'Bad Request',
-        ]);
+        $this->request($client, '/api/users/6/api-token', 'POST', [], (string) json_encode([
+            'name' => '',
+            'expiresAt' => '2000-01-01T00:00:00',
+        ]));
+        $this->assertApiCallValidationError($client->getResponse(), ['name', 'expiresAt']);
     }
 
     public function testPostApiTokenForUnknownUser(): void


### PR DESCRIPTION
## Description
Adds a new API endpoint `POST /api/users/{id}/api-token` that creates a new `AccessToken` for the given user and returns the plain token in the response. This is the missing counterpart of the existing `DELETE /api/users/api-token/{id}`.

Currently the only way to obtain an `AccessToken` is via the web UI. This blocks any automated provisioning flow that needs to create a Kimai user and immediately get a usable Bearer token for that user — for example, a SaaS integration that creates one Kimai user per customer. The legacy `plainApiToken` field on `POST /api/users` only populates the deprecated `users.api_token` column used by the `X-AUTH-USER`/`X-AUTH-TOKEN` headers, which is not interchangeable with `Authorization: Bearer …`.

To guarantee that tokens generated via the API and via the web UI always follow the same algorithm, the random-token generation has been extracted into a new factory method `AccessToken::createForUser(User $user): self`. Both `ProfileController::createAccessToken` and the new `UserController::postApiToken` now use this single source of truth. The `AccessToken` constructor signature `(User $user, string $token)` is left unchanged so that fixtures and `ResetTestCommand`, which need predictable tokens, keep working as-is.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] I verified that my code applies to the guidelines (`composer code-check`)
- [x] I updated the documentation (OpenAPI annotations are included in the controller; happy to open a follow-up PR on www.kimai.org if maintainers want a manual mention)
- [x] I agree that this code is used in Kimai (see [license](https://github.com/kimai/kimai/blob/main/LICENSE))
