### PR TITLE
Run console (and thus php) as the correct user during entrypoint.sh

### DIFF
--- a/.docker/entrypoint.sh
+++ b/.docker/entrypoint.sh
@@ -55,8 +55,9 @@ function handleStartup() {
     pwconv
   fi
 
+  PHP_RUN_USER=$(id -nu "$USER_ID")
   if [ -e /use_apache ]; then
-    export APACHE_RUN_USER=$(id -nu "$USER_ID")
+    export APACHE_RUN_USER=$PHP_RUN_USER
     # This doesn't _exactly_ run as the specified GID, it runs as the GID of the specified user but WTF
     export APACHE_RUN_GROUP=$(id -ng "$USER_ID")
     export APACHE_PID_FILE=/var/run/apache2/apache2.pid
@@ -73,11 +74,15 @@ function handleStartup() {
   fi
 }
 
+function console() {
+	su -s /bin/bash -c "/opt/kimai/bin/console $*" "$PHP_RUN_USER"
+}
+
 function prepareKimai() {
   # These are idempotent, so we can run them on every start-up
-  /opt/kimai/bin/console -n kimai:install
+  console -n kimai:install
   if [ ! -z "$ADMINPASS" ] && [ ! -a "$ADMINMAIL" ]; then
-    /opt/kimai/bin/console kimai:user:create admin "$ADMINMAIL" ROLE_SUPER_ADMIN "$ADMINPASS"
+    console kimai:user:create admin "$ADMINMAIL" ROLE_SUPER_ADMIN "$ADMINPASS"
   fi
   echo "$KIMAI" > /opt/kimai/var/installed
   echo "Kimai is ready"
@@ -85,7 +90,7 @@ function prepareKimai() {
 
 function runServer() {
   # Just while I'm fixing things
-  /opt/kimai/bin/console kimai:reload --env="$APP_ENV"
+  console kimai:reload --env="$APP_ENV"
   chown -R $USER_ID:$GROUP_ID /opt/kimai/var
   if [ -e /use_apache ]; then
     exec /usr/sbin/apache2 -D FOREGROUND


### PR DESCRIPTION
## Description
This makes the kimai container compatible with rootless setups such as podman & docker rootless. Without this change the container would just keep getting permission errors during rebuilding of the cache etc.

Note that running the container in rootless podman/docker it's still a bit messy, as you have to start the user as root, but then assign the host user to 33, but at least it works.

For example this is my podman quadlet.

```systemd
Environment=USER_ID=33
Environment=GROUP_ID=33
UserNS=keep-id:uid=33,gid=33,size=2000
User=0
```


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] I verified that my code applies to the guidelines (`composer code-check`)
- [ ] I updated the documentation (see [here](https://github.com/kimai/www.kimai.org/tree/master/_documentation))
- [x] I agree that this code is used in Kimai (see [license](https://github.com/kimai/kimai/blob/main/LICENSE))
