### PR TITLE
fix checking for correct formatter in durationDecimal

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -3646,11 +3646,6 @@ parameters:
             path: src/Utils/JavascriptFormatConverter.php
 
         -
-            message: "#^Cannot call method format\\(\\) on NumberFormatter\\|null\\.$#"
-            count: 1
-            path: src/Utils/LocaleFormatter.php
-
-        -
             message: "#^Cannot call method getTimestamp\\(\\) on DateTime\\|null\\.$#"
             count: 1
             path: src/Utils/LocaleFormatter.php

--- a/src/Utils/LocaleFormatter.php
+++ b/src/Utils/LocaleFormatter.php
@@ -75,7 +75,7 @@ final class LocaleFormatter
      */
     public function durationDecimal(Timesheet|int|string|null $duration): string
     {
-        if (null === $this->numberFormatter) {
+        if (null === $this->decimalFormatter) {
             $this->decimalFormatter = new NumberFormatter($this->locale, NumberFormatter::DECIMAL);
             $this->decimalFormatter->setAttribute(NumberFormatter::FRACTION_DIGITS, 2);
         }


### PR DESCRIPTION
## Description

`LocaleFormatter::durationDecimal()` guarded the lazy initialization of `$this->decimalFormatter` with the wrong property (`$this->numberFormatter` instead of `$this->decimalFormatter`). If `amount()` was called before `durationDecimal()` on the same formatter instance, `$this->numberFormatter` would already be set, the guard would pass, `$this->decimalFormatter` would never be initialized, and the subsequent `->format()` call would fail on null.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] I verified that my code applies to the guidelines (`composer code-check`)
- [ ] I updated the documentation (see [here](https://github.com/kimai/www.kimai.org/tree/master/_documentation))
- [x] I agree that this code is used in Kimai (see [license](https://github.com/kimai/kimai/blob/main/LICENSE))
