### PR TITLE
fix formatting locale reset after embedded controller sub-requests

### DIFF
--- a/src/EventSubscriber/UserEnvironmentSubscriber.php
+++ b/src/EventSubscriber/UserEnvironmentSubscriber.php
@@ -12,6 +12,7 @@ namespace App\EventSubscriber;
 use App\Entity\User;
 use App\Twig\LocaleFormatExtensions;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\FinishRequestEvent;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
@@ -19,6 +20,8 @@ use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 
 final class UserEnvironmentSubscriber implements EventSubscriberInterface
 {
+    private ?string $userLocale = null;
+
     public function __construct(
         private readonly TokenStorageInterface $tokenStorage,
         private readonly AuthorizationCheckerInterface $auth,
@@ -31,7 +34,25 @@ final class UserEnvironmentSubscriber implements EventSubscriberInterface
     {
         return [
             KernelEvents::REQUEST => ['prepareEnvironment', -100],
+            KernelEvents::FINISH_REQUEST => ['restoreLocale', -20],
         ];
+    }
+
+    public function restoreLocale(FinishRequestEvent $event): void
+    {
+        if ($event->isMainRequest()) {
+            return;
+        }
+
+        if ($this->userLocale === null) {
+            return;
+        }
+
+        // LocaleSwitcher (called by LocaleAwareListener) overwrites \Locale::getDefault() with the URL
+        // locale during sub-requests. Restore both the PHP default and the Twig formatter locale to
+        // the user's formatting locale that was saved during the main request.
+        \Locale::setDefault($this->userLocale);
+        $this->localeFormatExtensions->setLocale($this->userLocale);
     }
 
     public function prepareEnvironment(RequestEvent $event): void
@@ -55,6 +76,7 @@ final class UserEnvironmentSubscriber implements EventSubscriberInterface
         }
 
         // the locale is primarily used for formatting values, so we depend on the user locale if available
+        $this->userLocale = $locale;
         \Locale::setDefault($locale);
         $this->localeFormatExtensions->setLocale($locale);
     }


### PR DESCRIPTION
## Description

Pages that contain embedded controllers rendered via `render(controller(...))` (e.g. the project details page with its activities sub-request) lose the user's formatting locale mid-render. Symfony's `LocaleAwareListener` and `LocaleSwitcher` reset all `LocaleAwareInterface` services, including `LocaleFormatExtensions`, to the URL locale during the sub-request, and `UserEnvironmentSubscriber` already skipped sub-requests without restoring afterwards. Everything rendered after the sub-request in the same template (dates, durations, money amounts) used the wrong locale for the rest of the page.

Fixed by saving the user's formatting locale in `prepareEnvironment()` and subscribing to `KernelEvents::FINISH_REQUEST` at priority `-20` (after `LocaleAwareListener` at `-15`) to restore both `\Locale::setDefault()` and `LocaleFormatExtensions::setLocale()` to the saved value after each sub-request.

This affects any user whose formatting locale differs from their URL locale, i.e., regional variants like de_AT, fr_CH, en_GB, etc.


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] I verified that my code applies to the guidelines (`composer code-check`)
- [ ] I updated the documentation (see [here](https://github.com/kimai/www.kimai.org/tree/master/_documentation))
- [x] I agree that this code is used in Kimai (see [license](https://github.com/kimai/kimai/blob/main/LICENSE))
