### PR TITLE
Impersonate user

### DIFF
--- a/config/packages/kimai.yaml
+++ b/config/packages/kimai.yaml
@@ -106,9 +106,8 @@ kimai:
             LOCKDOWN: ['lockdown_grace_timesheet','lockdown_override_timesheet']
             REPORTING: ['view_reporting','view_other_reporting','project_reporting','customer_reporting']
             EVERYONE: ['api_access','hours_own_profile']
-            # permissions which are deactivated, as these features are hidden for now
-            # brave users can try to activate them and be surprised what happens
-            REGISTER_BETA: []
+            # permissions that exist, but are not assigned by default to anyone
+            NO_ONE: ['impersonate_user']
         # mapping a "role name" to an array of "set names"
         maps:
             ROLE_USER: ['TIMESHEET','PROFILE', 'EVERYONE']

--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -76,6 +76,11 @@ security:
                 lifetime: 900
                 max_uses: 3
 
+            switch_user:
+                role: impersonate_user
+                parameter: _see_kimai_as
+                target_route: homepage
+
     access_decision_manager:
         # only grants access if there is no voter denying access
         strategy: unanimous

--- a/src/Controller/PermissionController.php
+++ b/src/Controller/PermissionController.php
@@ -165,6 +165,11 @@ final class PermissionController extends AbstractController
             'manager' => $this->manager,
             'system_roles' => $roleService->getSystemRoles(),
             'always_apply_superadmin' => array_keys(RolePermissionManager::SUPER_ADMIN_PERMISSIONS),
+            'deactivated' => [
+                User::ROLE_USER => ['impersonate_user'],
+                User::ROLE_TEAMLEAD => ['impersonate_user'],
+                User::ROLE_ADMIN => ['impersonate_user'],
+            ],
         ]);
     }
 
@@ -239,6 +244,10 @@ final class PermissionController extends AbstractController
 
         if (!$this->manager->isRegisteredPermission($name)) {
             throw $this->createNotFoundException('Unknown permission: ' . $name);
+        }
+
+        if ($name === 'impersonate_user' && $role->getName() !== User::ROLE_SUPER_ADMIN) {
+            throw $this->createAccessDeniedException(\sprintf('Impersonation cannot be activated for role "%s"', $role->getName()));
         }
 
         if (false === $value && $role->getName() === User::ROLE_SUPER_ADMIN && \array_key_exists($name, RolePermissionManager::SUPER_ADMIN_PERMISSIONS)) {

--- a/src/Voter/ImpersonateVoter.php
+++ b/src/Voter/ImpersonateVoter.php
@@ -1,0 +1,59 @@
+<?php
+
+/*
+ * This file is part of the Kimai time-tracking app.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Voter;
+
+use App\Entity\User;
+use App\Security\RolePermissionManager;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authorization\Voter\Voter;
+
+/**
+ * A voter to check if the current user can impersonate other users.
+ *
+ * @extends Voter<string, null>
+ */
+final class ImpersonateVoter extends Voter
+{
+    public function __construct(private readonly RolePermissionManager $permissionManager)
+    {
+    }
+
+    public function supportsAttribute(string $attribute): bool
+    {
+        return $attribute === 'impersonate_user';
+    }
+
+    public function supportsType(string $subjectType): bool
+    {
+        return str_contains($subjectType, User::class);
+    }
+
+    protected function supports(string $attribute, mixed $subject): bool
+    {
+        return $subject instanceof User && $this->supportsAttribute($attribute);
+    }
+
+    protected function voteOnAttribute(string $attribute, mixed $subject, TokenInterface $token): bool
+    {
+        $user = $token->getUser();
+
+        // if the user is anonymous or if the subject is not a user, do not grant access
+        if (!$user instanceof User || !$subject instanceof User) {
+            return false;
+        }
+
+        // never ever might any other user use impersonation
+        if (!$user->isSuperAdmin()) {
+            return false;
+        }
+
+        return $this->permissionManager->hasRolePermission($user, 'impersonate_user');
+    }
+}

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -193,6 +193,25 @@
 {% endblock %}
 
 {% block page_header %}
+    {% if is_granted('IS_IMPERSONATOR') %}
+        <div class="container-fluid p-2">
+            <div class="alert alert-danger mb-0" role="alert">
+                <div class="alert-icon">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="icon alert-icon icon-2">
+                        <path d="M3 12a9 9 0 1 0 18 0a9 9 0 0 0 -18 0"></path>
+                        <path d="M12 8v4"></path>
+                        <path d="M12 16h.01"></path>
+                    </svg>
+                </div>
+                <div>
+                    <div class="alert-heading">You are watching Kimai as <strong>{{ app.user.alias }}</strong>.</div>
+                    <div class="alert-description">
+                        <a class="alert-action" href="{{ impersonation_exit_path(path('homepage')) }}">Exit impersonation</a>
+                    </div>
+                </div>
+            </div>
+        </div>
+    {% endif %}
     {%- if page_setup is defined -%}
         {%- if page_setup.actionName is not null or page_setup.hasSearchForm() -%}
             {{ parent() }}

--- a/templates/permission/permissions.html.twig
+++ b/templates/permission/permissions.html.twig
@@ -76,8 +76,10 @@
                     {% for role in roles %}
                         {% set value = manager.permission(role.name, permission) %}
                         <td class="{{ tables.data_table_column_class(tableName, columns, role.name) }}">
-                            {# see RolePermissionManager for this special case #}
-                            {% if role.name == 'ROLE_SUPER_ADMIN' and permission in always_apply_superadmin %}
+                            {% if deactivated[role.name] is defined and permission in deactivated[role.name] %}
+                                &ndash;
+                            {% elseif role.name == 'ROLE_SUPER_ADMIN' and permission in always_apply_superadmin %}
+                                {# see RolePermissionManager for this special case #}
                                 {% if value %}
                                     {{ widgets.label('yes'|trans, 'warning') }}
                                 {% else %}

--- a/templates/user/layout.html.twig
+++ b/templates/user/layout.html.twig
@@ -25,6 +25,9 @@
                             </div>
                             <div class="col-auto text-end mt-2 mt-sm-1" id="profile-buttons">
                                 {% from '@theme/components/buttons.html.twig' import link_button %}
+                                {% if is_granted('impersonate_user', user) %}
+                                    {{ link_button('impersonate'|trans, impersonation_path(user.userIdentifier), 'fas fa-user-secret', 'default') }}
+                                {% endif %}
                                 {% if app.user == user %}
                                 {{ link_button('notifications'|trans, 'javascript:notificationStatus()', 'fas fa-bell', 'default') }}
                                 {% endif %}

--- a/tests/Voter/ImpersonateVoterTest.php
+++ b/tests/Voter/ImpersonateVoterTest.php
@@ -1,0 +1,77 @@
+<?php
+
+/*
+ * This file is part of the Kimai time-tracking app.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Tests\Voter;
+
+use App\Entity\User;
+use App\Voter\ImpersonateVoter;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
+
+#[CoversClass(ImpersonateVoter::class)]
+class ImpersonateVoterTest extends AbstractVoterTestCase
+{
+    #[DataProvider('getVoteData')]
+    public function testVote(User $authenticatedUser, mixed $subject, string $attribute, int $result): void
+    {
+        $token = new UsernamePasswordToken($authenticatedUser, 'bar', $authenticatedUser->getRoles());
+        $sut = new ImpersonateVoter($this->getRolePermissionManager([
+            User::ROLE_ADMIN => ['impersonate_user'],
+            User::ROLE_SUPER_ADMIN => ['impersonate_user'],
+        ], true));
+
+        self::assertEquals($result, $sut->vote($token, $subject, [$attribute]));
+    }
+
+    public static function getVoteData(): iterable
+    {
+        $plainUser = self::getUser(1, User::ROLE_USER);
+        $admin = self::getUser(2, User::ROLE_ADMIN);
+        $superAdmin = self::getUser(3, User::ROLE_SUPER_ADMIN);
+        $target = self::getUser(4, User::ROLE_USER);
+
+        $granted = VoterInterface::ACCESS_GRANTED;
+        yield [$superAdmin, $target, 'impersonate_user', $granted];
+
+        $denied = VoterInterface::ACCESS_DENIED;
+        yield [$plainUser, $target, 'impersonate_user', $denied];
+        yield [$admin, $target, 'impersonate_user', $denied];
+
+        $abstain = VoterInterface::ACCESS_ABSTAIN;
+        yield [$superAdmin, null, 'impersonate_user', $abstain];
+        yield [$superAdmin, new \stdClass(), 'impersonate_user', $abstain];
+        yield [$superAdmin, $target, 'view', $abstain];
+        yield [$superAdmin, new \stdClass(), 'view', $abstain];
+    }
+
+    public function testVoteDeniesMissingAuthenticatedUser(): void
+    {
+        $target = self::getUser(2, User::ROLE_USER);
+        $token = $this->createMock(TokenInterface::class);
+        $token->method('getUser')->willReturn(null);
+        $sut = new ImpersonateVoter($this->getRolePermissionManager([
+            User::ROLE_SUPER_ADMIN => ['impersonate_user'],
+        ], true));
+
+        self::assertEquals(VoterInterface::ACCESS_DENIED, $sut->vote($token, $target, ['impersonate_user']));
+    }
+
+    public function testVoteDeniesSuperAdminWithoutPermission(): void
+    {
+        $superAdmin = self::getUser(1, User::ROLE_SUPER_ADMIN);
+        $target = self::getUser(2, User::ROLE_USER);
+        $token = new UsernamePasswordToken($superAdmin, 'bar', $superAdmin->getRoles());
+        $sut = new ImpersonateVoter($this->getRolePermissionManager([], true));
+
+        self::assertEquals(VoterInterface::ACCESS_DENIED, $sut->vote($token, $target, ['impersonate_user']));
+    }
+}


### PR DESCRIPTION
## Description

This feature can only ever be activated by Super-Admins and only if the new permission `impersonate_user` is explicitly activated in the roles screen.

This feature is meant to help testing new environments, especially teams, permissions and roles.

**TODO:**
- [ ] do not allow to impersonate other Super-Admin
- [ ] write audit log
- [ ] prevent self-impersonation
- [ ] prevent impersonation of disabled users (fails already, but hide button)
- [ ] use constant instead of hardcoded `impersonate_user`
- [ ] what about 2FA? config/packages/scheb_2fa.yaml misses SwitchUserToken

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] I verified that my code applies to the guidelines (`composer code-check`)
- [ ] I updated the documentation (see [here](https://github.com/kimai/www.kimai.org/tree/master/_documentation))
- [ ] I agree that this code is used in Kimai (see [license](https://github.com/kimai/kimai/blob/main/LICENSE))
