### PR TITLE
fix adding an empty space in the delete modals

### DIFF
--- a/templates/activity/delete.html.twig
+++ b/templates/activity/delete.html.twig
@@ -6,7 +6,7 @@
         '%duration%': stats.duration|duration
     } %}
     {{ include(kimai_context.modalRequest ? 'default/_form_delete_modal.html.twig' : 'default/_form_delete.html.twig', {
-        'message': ("delete_warning.short_stats"|trans(params) ~ "admin_entity.delete_confirm"|trans),
+        'message': ("delete_warning.short_stats"|trans(params) ~ " " ~ "admin_entity.delete_confirm"|trans),
         'form': form,
         'delete_item_name': activity.name,
         'used': (stats.counter > 0),

--- a/templates/customer/delete.html.twig
+++ b/templates/customer/delete.html.twig
@@ -6,7 +6,7 @@
         '%duration%': stats.duration|duration
     } %}
     {{ include(kimai_context.modalRequest ? 'default/_form_delete_modal.html.twig' : 'default/_form_delete.html.twig', {
-        'message': ("delete_warning.short_stats"|trans(params) ~ "admin_entity.delete_confirm"|trans),
+        'message': ("delete_warning.short_stats"|trans(params) ~ " " ~ "admin_entity.delete_confirm"|trans),
         'form': form,
         'delete_item_name': customer.name,
         'used': (stats.counter > 0),

--- a/templates/project/delete.html.twig
+++ b/templates/project/delete.html.twig
@@ -6,7 +6,7 @@
         '%duration%': stats.duration|duration
     } %}
     {{ include(kimai_context.modalRequest ? 'default/_form_delete_modal.html.twig' : 'default/_form_delete.html.twig', {
-        'message': ("delete_warning.short_stats"|trans(params) ~ "admin_entity.delete_confirm"|trans),
+        'message': ("delete_warning.short_stats"|trans(params) ~ " " ~ "admin_entity.delete_confirm"|trans),
         'form': form,
         'delete_item_name': project.name,
         'used': (stats.counter > 0),

--- a/templates/user/delete.html.twig
+++ b/templates/user/delete.html.twig
@@ -11,7 +11,7 @@
     } %}
 
     {{ include(kimai_context.modalRequest ? 'default/_form_delete_modal.html.twig' : 'default/_form_delete.html.twig', {
-        'message': ("delete_warning.short_stats"|trans(params) ~ "admin_entity.delete_confirm"|trans),
+        'message': ("delete_warning.short_stats"|trans(params) ~ " " ~ "admin_entity.delete_confirm"|trans),
         'form': form,
         'delete_item_name': user.displayName,
         'used': inUse,


### PR DESCRIPTION
## Description
Currently, there is a space missing in the message when trying to delete an activity/user/project:
<img width="812" height="425" alt="image" src="https://github.com/user-attachments/assets/36f8adf9-e61f-473f-a778-8af35a37dc00" />

With this patch, we get a space:
<img width="772" height="385" alt="image" src="https://github.com/user-attachments/assets/52401ba3-d6af-47cb-8fab-105707d51def" />

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] I verified that my code applies to the guidelines (`composer code-check`)
- [ ] I updated the documentation (see [here](https://github.com/kimai/www.kimai.org/tree/master/_documentation))
- [x] I agree that this code is used in Kimai (see [license](https://github.com/kimai/kimai/blob/main/LICENSE))
