### PR TITLE
Improve whitespace handling in Search term parser

### DIFF
--- a/src/Repository/Search/SearchHelper.php
+++ b/src/Repository/Search/SearchHelper.php
@@ -51,6 +51,7 @@ final class SearchHelper
             $i = 0;
             $c = 0;
             $j = 0;
+            $k = 0;
             foreach ($searchTerm->getParts() as $part) {
                 // we do NOT search for unspecific/global terms as of now, because it is not clear if the user wants that
                 if (($metaName = $part->getField()) === null) {
@@ -61,7 +62,7 @@ final class SearchHelper
                 $metaValue = $part->getTerm();
                 $paramName = 'metaName' . $i++;
                 $paramValue = 'metaValue' . $c++;
-                $subqueryName = 'metaNotExists' . $metaName;
+                $subqueryName = 'metaNotExists' . $k++;
                 $field = $alias . '.value';
 
                 $and = $qb->expr()->andX();

--- a/src/Utils/SearchTerm.php
+++ b/src/Utils/SearchTerm.php
@@ -21,7 +21,10 @@ final class SearchTerm
     public function __construct(string $searchTerm)
     {
         $this->originalTerm = $searchTerm;
-        $terms = explode(' ', $searchTerm);
+        $terms = preg_split('/\s+/', trim($searchTerm), -1, PREG_SPLIT_NO_EMPTY);
+        if (!\is_array($terms)) {
+            $terms = [];
+        }
         $finalTerm = [];
 
         foreach ($terms as $term) {

--- a/tests/Repository/Search/SearchHelperTest.php
+++ b/tests/Repository/Search/SearchHelperTest.php
@@ -23,6 +23,7 @@ use Doctrine\ORM\Query\Expr\Orx;
 use Doctrine\ORM\Query\Parameter;
 use Doctrine\ORM\QueryBuilder;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 #[CoversClass(SearchHelper::class)]
@@ -197,5 +198,58 @@ class SearchHelperTest extends TestCase
         $sut = new SearchHelper($configuration);
 
         $sut->addSearchTerm($qb, $query);
+    }
+
+    public static function provideMaliciousMetaFieldPayloads(): array
+    {
+        $exploitPayload = "metaNotExists1\tFROM\tApp\\Entity\\User\tmetaNotExists1\tWHERE\tmetaNotExists1.id=1)--";
+
+        return [
+            'dot and parenthesis characters' => ['x.y:~ x):""', ['x.y', 'x)']],
+            'tab and comment injection payloads' => [$exploitPayload . ':~ ' . $exploitPayload . ':""', ['metaNotExists1.id=1)--', 'metaNotExists1.id=1)--']],
+        ];
+    }
+
+    /**
+     * // Regression test for GHSA-9cxw-hp3c-637x
+     */
+    #[DataProvider('provideMaliciousMetaFieldPayloads')]
+    public function testMaliciousMetaFieldNamesCannotInfluenceSubqueryDql(string $term, array $expectedMetaNames): void
+    {
+        $em = $this->createMock(EntityManagerInterface::class);
+        $em->method('getExpressionBuilder')->willReturn(new Expr());
+        $qb = new QueryBuilder($em);
+        $qb->from(Timesheet::class, 'testFoo');
+
+        $query = new BaseQuery();
+        $query->setSearchTerm(new SearchTerm($term));
+        $configuration = new SearchConfiguration(['bar'], 'MetaFieldClass', 'metaFieldName');
+        $configuration->setEntityFieldName('entityFieldName');
+
+        $sut = new SearchHelper($configuration);
+
+        $sut->addSearchTerm($qb, $query);
+
+        $wherePart = $qb->getDQLPart('where');
+        self::assertInstanceOf(Andx::class, $wherePart);
+        $where = (string) $wherePart;
+
+        self::assertStringContainsString('metaNotExists0', $where);
+        self::assertStringContainsString('metaNotExists1', $where);
+        self::assertStringNotContainsString('App\\Entity\\User', $where);
+        self::assertStringNotContainsString('--', $where);
+        self::assertStringNotContainsString("\tFROM\t", $where);
+
+        $metaNames = [];
+        /** @var Parameter $parameter */
+        foreach ($qb->getParameters() as $parameter) {
+            if (str_starts_with($parameter->getName(), 'metaName')) {
+                $metaNames[] = $parameter->getValue();
+            }
+        }
+
+        self::assertCount(2, $metaNames);
+        self::assertEquals($expectedMetaNames[0], $metaNames[0]);
+        self::assertEquals($expectedMetaNames[1], $metaNames[1]);
     }
 }

--- a/tests/Utils/SearchTermTest.php
+++ b/tests/Utils/SearchTermTest.php
@@ -170,4 +170,39 @@ class SearchTermTest extends TestCase
             self::assertEquals($expected[2], $part->isExcluded());
         }
     }
+
+    public function testWhitespaceIsNormalizedWhenTokenizing(): void
+    {
+        $sut = new SearchTerm(" \tfoo\tbar:baz\nhello  world\t ");
+
+        self::assertTrue($sut->hasSearchTerm());
+        self::assertEquals('foo hello world', $sut->getSearchTerm());
+        self::assertEquals(['bar' => 'baz'], $sut->getSearchFields());
+        self::assertEquals(" \tfoo\tbar:baz\nhello  world\t ", $sut->getOriginalSearch());
+        self::assertCount(4, $sut->getParts());
+
+        $expectedParts = [
+            ['foo', null, false],
+            ['baz', 'bar', false],
+            ['hello', null, false],
+            ['world', null, false],
+        ];
+        $i = 0;
+        foreach ($sut->getParts() as $part) {
+            $expected = $expectedParts[$i++];
+            self::assertEquals($expected[0], $part->getTerm());
+            self::assertEquals($expected[1], $part->getField());
+            self::assertEquals($expected[2], $part->isExcluded());
+        }
+    }
+
+    public function testWhitespaceOnlySearchTermCreatesNoParts(): void
+    {
+        $sut = new SearchTerm(" \t \n ");
+
+        self::assertFalse($sut->hasSearchTerm());
+        self::assertEquals('', $sut->getSearchTerm());
+        self::assertEquals([], $sut->getSearchFields());
+        self::assertCount(0, $sut->getParts());
+    }
 }


### PR DESCRIPTION
## Description

Do not explode by ` ` but on all whitespace character.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] I verified that my code applies to the guidelines (`composer code-check`)
- [ ] I updated the documentation (see [here](https://github.com/kimai/www.kimai.org/tree/master/_documentation))
- [x] I agree that this code is used in Kimai (see [license](https://github.com/kimai/kimai/blob/main/LICENSE))
