### PR TITLE
Allow searching projects by their customer name in select dropdowns

### DIFF
--- a/assets/js/forms/KimaiFormSelect.js
+++ b/assets/js/forms/KimaiFormSelect.js
@@ -84,6 +84,26 @@ export default class KimaiFormSelect extends KimaiFormTomselectPlugin {
             // TODO make this value configurable with a data attribute
             maxOptions: 500,
             sortField:[{field: '$order'}, {field: '$score'}],
+            // also match options by their optgroup label (e.g. find a project by its
+            // customer name). TomSelect only searches the option text by default, and
+            // an option's "optgroup" property holds the group id, not its label, so we
+            // resolve the label from the optgroups registry inside a custom score.
+            score: function(search) {
+                const scoreFn = this.getScoreFunction(search);
+                const needle = search.trim().toLowerCase();
+                const labelField = this.settings.optgroupLabelField;
+                return (item) => {
+                    let score = scoreFn(item);
+                    if (score === 0 && needle !== '' && item.optgroup !== undefined) {
+                        const optgroup = this.optgroups[item.optgroup];
+                        const label = optgroup !== undefined ? (optgroup[labelField] ?? '') : '';
+                        if (label.toString().toLowerCase().indexOf(needle) !== -1) {
+                            score = 1;
+                        }
+                    }
+                    return score;
+                };
+            },
             // required so it works in table.responsive, but requires z-index 1056, because bootstrap modal would otherwise hide it
             dropdownParent: 'body',
             onOptionAdd: (value) => {


### PR DESCRIPTION
TomSelect searches only the option text by default, so projects grouped by customer could no longer be found by typing the customer name — a regression from Kimai 1.x. Add a custom score that
  also matches an option's optgroup label (the customer/parent name).

Fixes #5910

  ## Description
  
  Projects in the dropdown are grouped by customer via `<optgroup>`, but TomSelect
  only searches the option **text** by default, so typing a **customer** name
  returned "No results" — a regression from Kimai 1.x.

  Added a custom `score` in `assets/js/forms/KimaiFormSelect.js` that also matches
  an option's optgroup **label** (the customer/parent name), resolved via
  `this.optgroups[item.optgroup]`. The default search is untouched, and this helps
  every grouped select (projects by customer, activities by project).

  Note: the `searchField: ['text', 'optgroup']` approach doesn't work here — on
  the bundled TomSelect (2.5.2) that field holds the optgroup **id**, not its label.

  JS-only change; `pnpm run lint` (eslint) passes for the changed file. Verified
  manually with demo data: customer search now finds projects, project-name search
  is unchanged, and nonsense input still returns no results (no false positives).

  ## Types of changes
  - [x] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to change)

  ## Checklist
  - [x] I verified that my code applies to the guidelines (`composer code-check`)
  - [ ] I updated the documentation (see [here](https://github.com/kimai/www.kimai.org/tree/master/_documentation))
  - [x] I agree that this code is used in Kimai (see [license](https://github.com/kimai/kimai/blob/main/LICENSE))

**Before:**
<img width="1100" height="800" alt="bug-customer-no-results" src="https://github.com/user-attachments/assets/c8f3626e-abd6-4bb2-a33a-d295cabffe8f" />

**After:**
<img width="1100" height="800" alt="fixed-customer-search" src="https://github.com/user-attachments/assets/23622783-1816-444f-8a3d-c3c6fed32dd5" />

