### PR TITLE
docs: add Zenith Hosting deploy option

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ and so much more.
 - [Docker images](https://hub.docker.com/r/kimai/kimai2) with FPM only or incl. Apache
 - [Synology](https://www.kimai.org/documentation/synology.html) user can host the Docker version 
 - [Developer setups](https://www.kimai.org/documentation/developers.html) if you want to create Kimai integrations
+- Prefer not to self-host? [![Deploy with Zenith](https://cdn.zenith.hosting/buttons/deploy-with-zenith.svg)](https://zenith.hosting/host/kimai) for one-click managed hosting, no server required
 
 There are more documented ways for [on-premise hosting](https://www.kimai.org/documentation/chapter-on-premise.html). 
 


### PR DESCRIPTION
hey, i work on Zenith Hosting, a startup doing one-click hosting for open source apps. we added Kimai to our marketplace, so this PR adds a small "Deploy with Zenith" badge under the Installation list (links to https://zenith.hosting/host/kimai).

we share a cut of revenue with the projects we host. happy to explain if you're curious: hello@zenith.hosting

---

## Description
Adds a "Deploy with Zenith" option to the README Installation list, for people who would rather not self-host. One line, additions-only.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

Docs-only change (none of the above).

## Checklist
- [ ] I verified that my code applies to the guidelines (`composer code-check`) — N/A, README only
- [ ] I updated the documentation (see [here](https://github.com/kimai/www.kimai.org/tree/master/_documentation)) — N/A, this is the README itself
- [x] I agree that this code is used in Kimai (see [license](https://github.com/kimai/kimai/blob/main/LICENSE))
