### PR TITLE
feat(oidc): implement OIDC login attributes and provider

### DIFF
--- a/config/packages/scheb_2fa.yaml
+++ b/config/packages/scheb_2fa.yaml
@@ -4,6 +4,7 @@ scheb_two_factor:
         - Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken
         - Symfony\Component\Security\Http\Authenticator\Token\PostAuthenticationToken
         - App\Saml\SamlToken
+        - App\Oidc\OidcToken
 
     totp:
         enabled: true

--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -40,6 +40,7 @@ security:
 
             custom_authenticators:
                 - App\Saml\SamlAuthenticator
+                - App\Oidc\OidcAuthenticator
 
             remember_me:
                 name: KIMAI_REMEMBER

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -125,6 +125,18 @@ services:
             $configuration: '@App\Configuration\SamlConfigurationInterface'
 
     # ================================================================================
+    # OIDC Services
+    # ================================================================================
+    App\Oidc\OidcProvider:
+        arguments:
+            $userProvider: '@security.user.provider.concrete.kimai_internal'
+            $configuration: '@App\Configuration\OidcConfigurationInterface'
+
+    App\Oidc\OidcClient:
+        arguments:
+            $cache: '@cache.app'
+
+    # ================================================================================
     # REPOSITORIES
     # ================================================================================
 

--- a/src/Configuration/OidcConfiguration.php
+++ b/src/Configuration/OidcConfiguration.php
@@ -1,0 +1,92 @@
+<?php
+
+/*
+ * This file is part of the Kimai time-tracking app.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Configuration;
+
+final class OidcConfiguration implements OidcConfigurationInterface
+{
+    public function __construct(private readonly SystemConfiguration $configuration)
+    {
+    }
+
+    public function isActivated(): bool
+    {
+        return $this->configuration->isOidcActive();
+    }
+
+    public function getTitle(): string
+    {
+        return $this->configuration->getOidcTitle();
+    }
+
+    public function getProvider(): ?string
+    {
+        return $this->configuration->getOidcProvider();
+    }
+
+    public function getClientId(): string
+    {
+        return $this->configuration->getOidcClientId();
+    }
+
+    public function getClientSecret(): string
+    {
+        return $this->configuration->getOidcClientSecret();
+    }
+
+    public function getIssuer(): ?string
+    {
+        return $this->configuration->getOidcIssuer();
+    }
+
+    public function getAuthorizationUrl(): ?string
+    {
+        return $this->configuration->getOidcAuthorizationUrl();
+    }
+
+    public function getTokenUrl(): ?string
+    {
+        return $this->configuration->getOidcTokenUrl();
+    }
+
+    public function getUserInfoUrl(): ?string
+    {
+        return $this->configuration->getOidcUserInfoUrl();
+    }
+
+    public function getScopes(): array
+    {
+        return $this->configuration->getOidcScopes();
+    }
+
+    public function getUsernameClaim(): string
+    {
+        return $this->configuration->getOidcUsernameClaim();
+    }
+
+    public function getAttributeMapping(): array
+    {
+        return $this->configuration->getOidcAttributeMapping();
+    }
+
+    public function getRolesClaim(): ?string
+    {
+        return $this->configuration->getOidcRolesClaim();
+    }
+
+    public function getRolesMapping(): array
+    {
+        return $this->configuration->getOidcRolesMapping();
+    }
+
+    public function isRolesResetOnLogin(): bool
+    {
+        return $this->configuration->isOidcRolesResetOnLogin();
+    }
+}

--- a/src/Configuration/OidcConfigurationInterface.php
+++ b/src/Configuration/OidcConfigurationInterface.php
@@ -1,0 +1,89 @@
+<?php
+
+/*
+ * This file is part of the Kimai time-tracking app.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Configuration;
+
+interface OidcConfigurationInterface
+{
+    /**
+     * Whether OIDC login is activated.
+     */
+    public function isActivated(): bool;
+
+    /**
+     * Returns the title that is exclusively used in the frontend.
+     * Currently, used to display the button in the login screen.
+     */
+    public function getTitle(): string;
+
+    /**
+     * Returns the provider name that is exclusively used in the frontend.
+     * Currently, used to display an icon in the login screen.
+     */
+    public function getProvider(): ?string;
+
+    /**
+     * The OAuth2 / OIDC client ID registered at the identity provider.
+     */
+    public function getClientId(): string;
+
+    /**
+     * The OAuth2 / OIDC client secret registered at the identity provider.
+     */
+    public function getClientSecret(): string;
+
+    /**
+     * The issuer / base URL used to discover the OIDC endpoints via
+     * "{issuer}/.well-known/openid-configuration". Can be empty when all
+     * endpoints below are configured explicitly.
+     */
+    public function getIssuer(): ?string;
+
+    public function getAuthorizationUrl(): ?string;
+
+    public function getTokenUrl(): ?string;
+
+    public function getUserInfoUrl(): ?string;
+
+    /**
+     * The scopes requested during login (e.g. "openid profile email").
+     *
+     * @return array<int, string>
+     */
+    public function getScopes(): array;
+
+    /**
+     * The claim that is used as the unique Kimai user identifier.
+     */
+    public function getUsernameClaim(): string;
+
+    /**
+     * Mapping of OIDC claims to Kimai user properties.
+     *
+     * @return array<int, array{oidc: string, kimai: string}>
+     */
+    public function getAttributeMapping(): array;
+
+    /**
+     * The claim that contains the user roles / groups.
+     */
+    public function getRolesClaim(): ?string;
+
+    /**
+     * Mapping of OIDC role/group values to Kimai roles.
+     *
+     * @return array<int, array{oidc: string, kimai: string}>
+     */
+    public function getRolesMapping(): array;
+
+    /**
+     * Whether the roles are reset on every login.
+     */
+    public function isRolesResetOnLogin(): bool;
+}

--- a/src/Configuration/SystemConfiguration.php
+++ b/src/Configuration/SystemConfiguration.php
@@ -158,8 +158,8 @@ final class SystemConfiguration
             return true;
         }
 
-        // if SAML is active, the login form can be deactivated
-        if (!$this->isSamlActive()) {
+        // if SAML or OIDC is active, the login form can be deactivated
+        if (!$this->isSamlActive() && !$this->isOidcActive()) {
             return true;
         }
 
@@ -251,6 +251,130 @@ final class SystemConfiguration
         }
 
         return (string) $attr;
+    }
+
+    public function isOidcActive(): bool
+    {
+        return (bool) $this->find('oidc.activate');
+    }
+
+    public function getOidcTitle(): string
+    {
+        return (string) $this->find('oidc.title');
+    }
+
+    public function getOidcProvider(): ?string
+    {
+        $provider = $this->find('oidc.provider');
+        if (empty($provider)) {
+            return null;
+        }
+
+        return (string) $provider;
+    }
+
+    public function getOidcClientId(): string
+    {
+        return (string) $this->find('oidc.client_id');
+    }
+
+    public function getOidcClientSecret(): string
+    {
+        return (string) $this->find('oidc.client_secret');
+    }
+
+    public function getOidcIssuer(): ?string
+    {
+        $issuer = $this->find('oidc.issuer');
+        if (empty($issuer)) {
+            return null;
+        }
+
+        return (string) $issuer;
+    }
+
+    public function getOidcAuthorizationUrl(): ?string
+    {
+        $url = $this->find('oidc.authorization_url');
+        if (empty($url)) {
+            return null;
+        }
+
+        return (string) $url;
+    }
+
+    public function getOidcTokenUrl(): ?string
+    {
+        $url = $this->find('oidc.token_url');
+        if (empty($url)) {
+            return null;
+        }
+
+        return (string) $url;
+    }
+
+    public function getOidcUserInfoUrl(): ?string
+    {
+        $url = $this->find('oidc.userinfo_url');
+        if (empty($url)) {
+            return null;
+        }
+
+        return (string) $url;
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    public function getOidcScopes(): array
+    {
+        $scopes = $this->find('oidc.scopes');
+        if (empty($scopes)) {
+            return ['openid', 'profile', 'email'];
+        }
+
+        return array_values(array_filter(array_map('trim', explode(' ', (string) $scopes))));
+    }
+
+    public function getOidcUsernameClaim(): string
+    {
+        $claim = $this->find('oidc.username_claim');
+        if (empty($claim)) {
+            return 'preferred_username';
+        }
+
+        return (string) $claim;
+    }
+
+    /**
+     * @return array<int, array{oidc: string, kimai: string}>
+     */
+    public function getOidcAttributeMapping(): array
+    {
+        return $this->findArray('oidc.mapping');
+    }
+
+    public function getOidcRolesClaim(): ?string
+    {
+        $claim = $this->find('oidc.roles.claim');
+        if (empty($claim)) {
+            return null;
+        }
+
+        return (string) $claim;
+    }
+
+    /**
+     * @return array<int, array{oidc: string, kimai: string}>
+     */
+    public function getOidcRolesMapping(): array
+    {
+        return $this->findArray('oidc.roles.mapping');
+    }
+
+    public function isOidcRolesResetOnLogin(): bool
+    {
+        return (bool) $this->find('oidc.roles.resetOnLogin');
     }
 
     public function isLdapActive(): bool

--- a/src/Controller/Auth/OidcController.php
+++ b/src/Controller/Auth/OidcController.php
@@ -1,0 +1,64 @@
+<?php
+
+/*
+ * This file is part of the Kimai time-tracking app.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Controller\Auth;
+
+use App\Configuration\OidcConfigurationInterface;
+use App\Oidc\OidcAuthenticator;
+use App\Oidc\OidcClient;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+
+#[Route(path: '/oidc')]
+final class OidcController extends AbstractController
+{
+    public function __construct(
+        private readonly OidcClient $oidcClient,
+        private readonly OidcConfigurationInterface $configuration,
+    ) {
+    }
+
+    #[Route(path: '/login', name: 'oidc_login')]
+    public function loginAction(Request $request): Response
+    {
+        if (!$this->configuration->isActivated()) {
+            throw $this->createNotFoundException('OIDC deactivated');
+        }
+
+        $state = bin2hex(random_bytes(32));
+        $nonce = bin2hex(random_bytes(32));
+        $codeVerifier = bin2hex(random_bytes(32));
+
+        $session = $request->getSession();
+        $session->set(OidcAuthenticator::SESSION_STATE, $state);
+        $session->set(OidcAuthenticator::SESSION_NONCE, $nonce);
+        $session->set(OidcAuthenticator::SESSION_PKCE, $codeVerifier);
+
+        $redirectUri = $this->generateUrl('oidc_callback', [], UrlGeneratorInterface::ABSOLUTE_URL);
+
+        $url = $this->oidcClient->getAuthorizationUrl($redirectUri, $state, $nonce, $codeVerifier);
+
+        return new RedirectResponse($url);
+    }
+
+    #[Route(path: '/callback', name: 'oidc_callback')]
+    public function callbackAction(): Response
+    {
+        if (!$this->configuration->isActivated()) {
+            throw $this->createNotFoundException('OIDC deactivated');
+        }
+
+        // this route is intercepted by the OidcAuthenticator configured in the firewall
+        throw new \RuntimeException('You must configure the check path to be handled by the firewall.');
+    }
+}

--- a/src/Controller/Security/SecurityController.php
+++ b/src/Controller/Security/SecurityController.php
@@ -9,6 +9,7 @@
 
 namespace App\Controller\Security;
 
+use App\Configuration\OidcConfigurationInterface;
 use App\Configuration\SamlConfigurationInterface;
 use App\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Response;
@@ -18,7 +19,7 @@ use Symfony\Component\Security\Http\Authentication\AuthenticationUtils;
 
 final class SecurityController extends AbstractController
 {
-    public function __construct(private CsrfTokenManagerInterface $tokenManager, private SamlConfigurationInterface $samlConfiguration)
+    public function __construct(private CsrfTokenManagerInterface $tokenManager, private SamlConfigurationInterface $samlConfiguration, private OidcConfigurationInterface $oidcConfiguration)
     {
     }
 
@@ -45,6 +46,7 @@ final class SecurityController extends AbstractController
             'error' => $error,
             'csrf_token' => $csrfToken,
             'saml_config' => $this->samlConfiguration,
+            'oidc_config' => $this->oidcConfiguration,
         ]);
     }
 

--- a/src/Controller/SystemConfigurationController.php
+++ b/src/Controller/SystemConfigurationController.php
@@ -287,7 +287,7 @@ final class SystemConfigurationController extends AbstractController
             $authentication->getConfigurationByName('user.registration')?->setEnabled(false);
         }
 
-        if (!$this->systemConfiguration->isSamlActive()) {
+        if (!$this->systemConfiguration->isSamlActive() && !$this->systemConfiguration->isOidcActive()) {
             $authentication->getConfigurationByName('user.login')?->setEnabled(false);
         }
 

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -55,6 +55,7 @@ final class Configuration implements ConfigurationInterface
                 ->append($this->getPermissionsNode())
                 ->append($this->getLdapNode())
                 ->append($this->getSamlNode())
+                ->append($this->getOidcNode())
                 ->append($this->getQuickEntryNode())
                 ->append($this->getActivityNode())
                 ->append($this->getProjectNode())
@@ -1034,6 +1035,115 @@ final class Configuration implements ConfigurationInterface
                     return !$found;
                 })
                 ->thenInvalid('You need to configure a SAML mapping for the email attribute.')
+            ->end()
+        ;
+
+        return $node;
+    }
+
+    private function getOidcNode(): ArrayNodeDefinition
+    {
+        $builder = new TreeBuilder('oidc');
+        /** @var ArrayNodeDefinition $node */
+        $node = $builder->getRootNode();
+
+        $node
+            ->addDefaultsIfNotSet()
+            ->children()
+                ->booleanNode('activate')
+                    ->defaultFalse()
+                ->end()
+                ->scalarNode('title')
+                    ->defaultValue('Login with SSO')
+                ->end()
+                ->scalarNode('provider')
+                    ->defaultValue('openid')
+                ->end()
+                ->scalarNode('client_id')
+                    ->defaultNull()
+                ->end()
+                ->scalarNode('client_secret')
+                    ->defaultNull()
+                ->end()
+                ->scalarNode('issuer')
+                    ->defaultNull()
+                ->end()
+                ->scalarNode('authorization_url')
+                    ->defaultNull()
+                ->end()
+                ->scalarNode('token_url')
+                    ->defaultNull()
+                ->end()
+                ->scalarNode('userinfo_url')
+                    ->defaultNull()
+                ->end()
+                ->scalarNode('scopes')
+                    ->defaultValue('openid profile email')
+                ->end()
+                ->scalarNode('username_claim')
+                    ->defaultValue('preferred_username')
+                ->end()
+                ->arrayNode('roles')
+                    ->addDefaultsIfNotSet()
+                    ->children()
+                        ->booleanNode('resetOnLogin')
+                            ->defaultTrue()
+                        ->end()
+                        ->scalarNode('claim')
+                            ->defaultNull()
+                        ->end()
+                        ->arrayNode('mapping')
+                            ->defaultValue([])
+                            ->arrayPrototype()
+                                ->children()
+                                    ->scalarNode('oidc')->isRequired()->cannotBeEmpty()->end()
+                                    ->scalarNode('kimai')->isRequired()->cannotBeEmpty()->end()
+                                ->end()
+                            ->end()
+                        ->end()
+                    ->end()
+                ->end()
+                ->arrayNode('mapping')
+                    ->defaultValue([])
+                    ->arrayPrototype()
+                        ->children()
+                            ->scalarNode('oidc')->isRequired()->cannotBeEmpty()->end()
+                            ->scalarNode('kimai')
+                                ->isRequired()
+                                ->cannotBeEmpty()
+                                ->validate()
+                                    ->ifTrue(function ($v) {
+                                        return \in_array(strtolower($v), ['username', 'useridentifier'], true);
+                                    })
+                                    ->thenInvalid('You cannot configure "username" and "userIdentifier" for OIDC attribute mapping.')
+                                ->end()
+                            ->end()
+                        ->end()
+                    ->end()
+                ->end()
+            ->end()
+            ->validate()
+                ->ifTrue(static function ($v) {
+                    if (true !== $v['activate']) {
+                        return false;
+                    }
+
+                    return empty($v['client_id']) || empty($v['client_secret']);
+                })
+                ->thenInvalid('You need to configure "oidc.client_id" and "oidc.client_secret" when OIDC is activated.')
+            ->end()
+            ->validate()
+                ->ifTrue(static function ($v) {
+                    if (true !== $v['activate']) {
+                        return false;
+                    }
+
+                    // either the issuer (for discovery) or explicit endpoints must be set
+                    $hasExplicit = !empty($v['authorization_url']) && !empty($v['token_url']) && !empty($v['userinfo_url']);
+
+                    return empty($v['issuer']) && !$hasExplicit;
+                })
+                ->thenInvalid('You need to configure "oidc.issuer" or the explicit "oidc.authorization_url", "oidc.token_url" and "oidc.userinfo_url" endpoints.')
             ->end()
         ;
 

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -63,6 +63,7 @@ class User implements UserInterface, EquatableInterface, ThemeUserInterface, Pas
     public const AUTH_INTERNAL = 'kimai';
     public const AUTH_LDAP = 'ldap';
     public const AUTH_SAML = 'saml';
+    public const AUTH_OIDC = 'oidc';
 
     public const WIZARDS = ['intro', 'profile'];
 
@@ -856,6 +857,11 @@ class User implements UserInterface, EquatableInterface, ThemeUserInterface, Pas
     public function isSamlUser(): bool
     {
         return $this->auth === self::AUTH_SAML;
+    }
+
+    public function isOidcUser(): bool
+    {
+        return $this->auth === self::AUTH_OIDC;
     }
 
     public function isLdapUser(): bool

--- a/src/Oidc/OidcAuthenticator.php
+++ b/src/Oidc/OidcAuthenticator.php
@@ -1,0 +1,157 @@
+<?php
+
+/*
+ * This file is part of the Kimai time-tracking app.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Oidc;
+
+use App\Configuration\OidcConfigurationInterface;
+use App\Oidc\Security\OidcAuthenticationFailureHandler;
+use App\Oidc\Security\OidcAuthenticationSuccessHandler;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Exception\AuthenticationException;
+use Symfony\Component\Security\Http\Authenticator\AbstractAuthenticator;
+use Symfony\Component\Security\Http\Authenticator\Passport\Badge\RememberMeBadge;
+use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
+use Symfony\Component\Security\Http\Authenticator\Passport\Passport;
+use Symfony\Component\Security\Http\Authenticator\Passport\SelfValidatingPassport;
+use Symfony\Component\Security\Http\HttpUtils;
+
+/**
+ * @final
+ */
+class OidcAuthenticator extends AbstractAuthenticator
+{
+    public const CHECK_ROUTE = 'oidc_callback';
+    public const SESSION_STATE = '_oidc_state';
+    public const SESSION_NONCE = '_oidc_nonce';
+    public const SESSION_PKCE = '_oidc_pkce_verifier';
+
+    public function __construct(
+        private readonly HttpUtils $httpUtils,
+        private readonly OidcAuthenticationSuccessHandler $successHandler,
+        private readonly OidcAuthenticationFailureHandler $failureHandler,
+        private readonly OidcClient $oidcClient,
+        private readonly OidcProvider $oidcProvider,
+        private readonly OidcConfigurationInterface $configuration,
+        private readonly UrlGeneratorInterface $urlGenerator,
+        private readonly LoggerInterface $logger
+    ) {
+    }
+
+    public function supports(Request $request): bool
+    {
+        if (!$this->configuration->isActivated()) {
+            return false;
+        }
+
+        if (!$request->isMethod(Request::METHOD_GET)) {
+            return false;
+        }
+
+        if (!$this->httpUtils->checkRequestPath($request, self::CHECK_ROUTE)) {
+            return false;
+        }
+
+        return $request->query->has('code') || $request->query->has('error');
+    }
+
+    public function authenticate(Request $request): Passport
+    {
+        $session = $request->getSession();
+
+        $expectedState = $session->get(self::SESSION_STATE);
+        $session->remove(self::SESSION_STATE);
+        $nonce = $session->get(self::SESSION_NONCE);
+        $session->remove(self::SESSION_NONCE);
+        $codeVerifier = $session->get(self::SESSION_PKCE);
+        $session->remove(self::SESSION_PKCE);
+
+        // the IdP redirected back with an error (e.g. the user cancelled the login)
+        if ($request->query->has('error')) {
+            $error = (string) $request->query->get('error');
+            $this->logger->warning('OIDC login failed at the identity provider: ' . $error);
+            throw new AuthenticationException('OIDC login failed: ' . $error);
+        }
+
+        $givenState = $request->query->get('state');
+
+        // CSRF protection: the state must match the value stored before the redirect
+        if (!\is_string($expectedState) || $expectedState === '' || !hash_equals($expectedState, (string) $givenState)) {
+            $this->logger->critical('OIDC login failed: state mismatch.');
+            throw new AuthenticationException('OIDC state mismatch.');
+        }
+
+        if (!\is_string($nonce) || $nonce === '') {
+            throw new AuthenticationException('OIDC nonce is missing.');
+        }
+
+        if (!\is_string($codeVerifier) || $codeVerifier === '') {
+            throw new AuthenticationException('OIDC PKCE code verifier is missing.');
+        }
+
+        $code = (string) $request->query->get('code');
+        $redirectUri = $this->urlGenerator->generate(self::CHECK_ROUTE, [], UrlGeneratorInterface::ABSOLUTE_URL);
+
+        $claims = $this->oidcClient->fetchUserClaims($code, $redirectUri, $nonce, $codeVerifier);
+
+        $usernameClaim = $this->configuration->getUsernameClaim();
+        if (!\array_key_exists($usernameClaim, $claims)) {
+            $message = \sprintf('Claim "%s" not found in OIDC response.', $usernameClaim);
+            $this->logger->critical($message);
+            throw new AuthenticationException($message);
+        }
+
+        $identifier = $claims[$usernameClaim];
+        if (\is_array($identifier)) {
+            $identifier = $identifier[0] ?? null;
+        }
+        if (!\is_string($identifier) || $identifier === '') {
+            throw new AuthenticationException(\sprintf('Claim "%s" did not contain a valid user identifier.', $usernameClaim));
+        }
+
+        $loginAttributes = new OidcLoginAttributes();
+        $loginAttributes->setAttributes($claims);
+        $loginAttributes->setUserIdentifier($identifier);
+
+        return new SelfValidatingPassport(
+            new UserBadge($identifier, function () use ($loginAttributes) {
+                return $this->oidcProvider->findUser($loginAttributes);
+            }),
+            [new RememberMeBadge(), new OidcBadge($loginAttributes)]
+        );
+    }
+
+    public function createToken(Passport $passport, string $firewallName): TokenInterface
+    {
+        $user = $passport->getUser();
+
+        $token = new OidcToken($user, $firewallName, $user->getRoles());
+
+        foreach ($passport->getBadges() as $badge) {
+            if ($badge instanceof OidcBadge) {
+                $token->setAttributes($badge->getOidcLoginAttributes()->getAttributes());
+            }
+        }
+
+        return $token;
+    }
+
+    public function onAuthenticationSuccess(Request $request, TokenInterface $token, string $firewallName): ?Response
+    {
+        return $this->successHandler->onAuthenticationSuccess($request, $token);
+    }
+
+    public function onAuthenticationFailure(Request $request, AuthenticationException $exception): Response
+    {
+        return $this->failureHandler->onAuthenticationFailure($request, $exception);
+    }
+}

--- a/src/Oidc/OidcBadge.php
+++ b/src/Oidc/OidcBadge.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the Kimai time-tracking app.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Oidc;
+
+use Symfony\Component\Security\Http\Authenticator\Passport\Badge\BadgeInterface;
+
+final class OidcBadge implements BadgeInterface
+{
+    public function __construct(private readonly OidcLoginAttributes $attributes)
+    {
+    }
+
+    public function getOidcLoginAttributes(): OidcLoginAttributes
+    {
+        return $this->attributes;
+    }
+
+    public function isResolved(): bool
+    {
+        return true;
+    }
+}

--- a/src/Oidc/OidcClient.php
+++ b/src/Oidc/OidcClient.php
@@ -201,8 +201,11 @@ class OidcClient
         }
 
         $issuer = $this->configuration->getIssuer();
-        if ($issuer !== null && $issuer !== '' && isset($payload['iss']) && rtrim((string) $payload['iss'], '/') !== rtrim($issuer, '/')) {
-            throw new AuthenticationException('OIDC ID token issuer mismatch.');
+        if ($issuer !== null && $issuer !== '' && isset($payload['iss'])) {
+            $tokenIssuer = $payload['iss'];
+            if (!\is_string($tokenIssuer) || rtrim($tokenIssuer, '/') !== rtrim($issuer, '/')) {
+                throw new AuthenticationException('OIDC ID token issuer mismatch.');
+            }
         }
 
         if (isset($payload['aud'])) {
@@ -223,7 +226,7 @@ class OidcClient
     }
 
     /**
-     * @return array<string, mixed>
+     * @return array<array-key, mixed>
      */
     private function decodeSegment(string $segment): array
     {
@@ -237,7 +240,6 @@ class OidcClient
             throw new AuthenticationException('OIDC ID token payload is invalid.');
         }
 
-        /** @var array<string, mixed> $data */
         return $data;
     }
 

--- a/src/Oidc/OidcClient.php
+++ b/src/Oidc/OidcClient.php
@@ -1,0 +1,306 @@
+<?php
+
+/*
+ * This file is part of the Kimai time-tracking app.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Oidc;
+
+use App\Configuration\OidcConfigurationInterface;
+use Psr\Cache\CacheItemPoolInterface;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Security\Core\Exception\AuthenticationException;
+use Symfony\Contracts\HttpClient\Exception\ExceptionInterface as HttpExceptionInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+/**
+ * Handles the low-level OpenID Connect "Authorization Code Flow":
+ * endpoint discovery, building the authorization URL, exchanging the
+ * authorization code for tokens and fetching the user claims.
+ *
+ * @final
+ */
+class OidcClient
+{
+    public function __construct(
+        private readonly HttpClientInterface $httpClient,
+        private readonly OidcConfigurationInterface $configuration,
+        private readonly CacheItemPoolInterface $cache,
+        private readonly LoggerInterface $logger
+    ) {
+    }
+
+    /**
+     * Builds the URL the user is redirected to, in order to authenticate at the identity provider.
+     */
+    public function getAuthorizationUrl(string $redirectUri, string $state, string $nonce, ?string $codeVerifier = null): string
+    {
+        $endpoint = $this->configuration->getAuthorizationUrl();
+        if ($endpoint === null || $endpoint === '') {
+            $endpoint = $this->getFromDiscovery('authorization_endpoint');
+        }
+
+        $scopes = $this->configuration->getScopes();
+        if (!\in_array('openid', $scopes, true)) {
+            array_unshift($scopes, 'openid');
+        }
+
+        $params = [
+            'response_type' => 'code',
+            'client_id' => $this->configuration->getClientId(),
+            'redirect_uri' => $redirectUri,
+            'scope' => implode(' ', $scopes),
+            'state' => $state,
+            'nonce' => $nonce,
+        ];
+
+        // PKCE (RFC 7636): providers without PKCE support will ignore these parameters
+        if ($codeVerifier !== null && $codeVerifier !== '') {
+            $params['code_challenge'] = rtrim(strtr(base64_encode(hash('sha256', $codeVerifier, true)), '+/', '-_'), '=');
+            $params['code_challenge_method'] = 'S256';
+        }
+
+        $separator = str_contains($endpoint, '?') ? '&' : '?';
+
+        return $endpoint . $separator . http_build_query($params);
+    }
+
+    /**
+     * Exchanges the authorization code for tokens and returns the resolved user claims.
+     *
+     * @return array<string, mixed>
+     */
+    public function fetchUserClaims(string $code, string $redirectUri, string $expectedNonce, ?string $codeVerifier = null): array
+    {
+        $tokens = $this->exchangeCode($code, $redirectUri, $codeVerifier);
+
+        if (!isset($tokens['access_token']) || !\is_string($tokens['access_token'])) {
+            throw new AuthenticationException('OIDC token response did not contain an access_token.');
+        }
+
+        // validate the ID token (issuer, audience, expiration and nonce) when present
+        if (isset($tokens['id_token']) && \is_string($tokens['id_token'])) {
+            $this->validateIdToken($tokens['id_token'], $expectedNonce);
+        }
+
+        return $this->fetchUserInfo($tokens['access_token']);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function exchangeCode(string $code, string $redirectUri, ?string $codeVerifier = null): array
+    {
+        $endpoint = $this->configuration->getTokenUrl();
+        if ($endpoint === null || $endpoint === '') {
+            $endpoint = $this->getFromDiscovery('token_endpoint');
+        }
+
+        $body = [
+            'grant_type' => 'authorization_code',
+            'code' => $code,
+            'redirect_uri' => $redirectUri,
+            'client_id' => $this->configuration->getClientId(),
+            'client_secret' => $this->configuration->getClientSecret(),
+        ];
+
+        if ($codeVerifier !== null && $codeVerifier !== '') {
+            $body['code_verifier'] = $codeVerifier;
+        }
+
+        try {
+            $response = $this->httpClient->request('POST', $endpoint, [
+                'headers' => [
+                    'Accept' => 'application/json',
+                ],
+                'body' => $body,
+            ]);
+
+            $statusCode = $response->getStatusCode();
+            /** @var array<string, mixed> $data */
+            $data = $response->toArray(false);
+        } catch (HttpExceptionInterface $ex) {
+            $this->logger->critical('OIDC token exchange failed: ' . $ex->getMessage());
+            throw new AuthenticationException('OIDC token exchange failed.');
+        }
+
+        if (isset($data['error'])) {
+            $error = \is_string($data['error']) ? $data['error'] : 'unknown';
+            $description = \is_string($data['error_description'] ?? null) ? $data['error_description'] : $error;
+            $this->logger->critical('OIDC token exchange returned an error: ' . $description);
+            throw new AuthenticationException('OIDC token exchange returned an error.');
+        }
+
+        if ($statusCode !== 200) {
+            $this->logger->critical('OIDC token endpoint returned unexpected status code: ' . $statusCode);
+            throw new AuthenticationException('OIDC token exchange failed.');
+        }
+
+        return $data;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function fetchUserInfo(string $accessToken): array
+    {
+        $endpoint = $this->configuration->getUserInfoUrl();
+        if ($endpoint === null || $endpoint === '') {
+            $endpoint = $this->getFromDiscovery('userinfo_endpoint');
+        }
+
+        try {
+            $response = $this->httpClient->request('GET', $endpoint, [
+                'headers' => [
+                    'Accept' => 'application/json',
+                    'Authorization' => 'Bearer ' . $accessToken,
+                ],
+            ]);
+
+            $statusCode = $response->getStatusCode();
+            /** @var array<string, mixed> $data */
+            $data = $response->toArray(false);
+        } catch (HttpExceptionInterface $ex) {
+            $this->logger->critical('OIDC userinfo request failed: ' . $ex->getMessage());
+            throw new AuthenticationException('OIDC userinfo request failed.');
+        }
+
+        if ($statusCode !== 200) {
+            $this->logger->critical('OIDC userinfo endpoint returned unexpected status code: ' . $statusCode);
+            throw new AuthenticationException('OIDC userinfo request failed.');
+        }
+
+        if (\count($data) === 0) {
+            throw new AuthenticationException('OIDC userinfo response was empty.');
+        }
+
+        return $data;
+    }
+
+    /**
+     * Validates the ID token claims. The token itself is retrieved through the
+     * trusted back-channel (direct TLS connection to the token endpoint), which is
+     * why we validate the standard claims (iss, aud, exp, nonce) instead of the
+     * signature.
+     */
+    private function validateIdToken(string $idToken, string $expectedNonce): void
+    {
+        $parts = explode('.', $idToken);
+        if (\count($parts) !== 3) {
+            throw new AuthenticationException('OIDC ID token is malformed.');
+        }
+
+        $payload = $this->decodeSegment($parts[1]);
+
+        // nonce binds the token to this specific login attempt (replay protection)
+        if (($payload['nonce'] ?? null) !== $expectedNonce) {
+            throw new AuthenticationException('OIDC ID token nonce mismatch.');
+        }
+
+        $issuer = $this->configuration->getIssuer();
+        if ($issuer !== null && $issuer !== '' && isset($payload['iss']) && rtrim((string) $payload['iss'], '/') !== rtrim($issuer, '/')) {
+            throw new AuthenticationException('OIDC ID token issuer mismatch.');
+        }
+
+        if (isset($payload['aud'])) {
+            $audiences = \is_array($payload['aud']) ? $payload['aud'] : [$payload['aud']];
+            if (!\in_array($this->configuration->getClientId(), $audiences, true)) {
+                throw new AuthenticationException('OIDC ID token audience mismatch.');
+            }
+        }
+
+        // "exp" is a REQUIRED claim in ID tokens, so a missing value is treated as an error
+        if (!isset($payload['exp']) || !is_numeric($payload['exp'])) {
+            throw new AuthenticationException('OIDC ID token is missing the "exp" claim.');
+        }
+
+        if ((int) $payload['exp'] < time()) {
+            throw new AuthenticationException('OIDC ID token has expired.');
+        }
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function decodeSegment(string $segment): array
+    {
+        $decoded = base64_decode(strtr($segment, '-_', '+/'), true);
+        if ($decoded === false) {
+            throw new AuthenticationException('OIDC ID token could not be decoded.');
+        }
+
+        $data = json_decode($decoded, true);
+        if (!\is_array($data)) {
+            throw new AuthenticationException('OIDC ID token payload is invalid.');
+        }
+
+        /** @var array<string, mixed> $data */
+        return $data;
+    }
+
+    private function getFromDiscovery(string $key): string
+    {
+        $config = $this->getDiscoveryDocument();
+
+        if (!isset($config[$key]) || !\is_string($config[$key]) || $config[$key] === '') {
+            throw new AuthenticationException(\sprintf('OIDC discovery document is missing the "%s" endpoint.', $key));
+        }
+
+        return $config[$key];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function getDiscoveryDocument(): array
+    {
+        $issuer = $this->configuration->getIssuer();
+        if ($issuer === null || $issuer === '') {
+            throw new AuthenticationException('OIDC issuer is not configured, cannot discover endpoints.');
+        }
+
+        $url = rtrim($issuer, '/') . '/.well-known/openid-configuration';
+        $cacheKey = 'oidc_discovery_' . sha1($url);
+
+        $item = $this->cache->getItem($cacheKey);
+        if ($item->isHit()) {
+            /** @var array<string, mixed> $cached */
+            $cached = $item->get();
+
+            return $cached;
+        }
+
+        try {
+            $response = $this->httpClient->request('GET', $url, [
+                'headers' => ['Accept' => 'application/json'],
+            ]);
+
+            $statusCode = $response->getStatusCode();
+            /** @var array<string, mixed> $data */
+            $data = $response->toArray(false);
+        } catch (HttpExceptionInterface $ex) {
+            $this->logger->critical('OIDC discovery request failed: ' . $ex->getMessage());
+            throw new AuthenticationException('OIDC discovery request failed.');
+        }
+
+        if ($statusCode !== 200) {
+            $this->logger->critical('OIDC discovery endpoint returned unexpected status code: ' . $statusCode);
+            throw new AuthenticationException('OIDC discovery request failed.');
+        }
+
+        // the spec requires that the "issuer" in the discovery document matches the configured issuer
+        if (!isset($data['issuer']) || !\is_string($data['issuer']) || rtrim($data['issuer'], '/') !== rtrim($issuer, '/')) {
+            $this->logger->critical('OIDC discovery document issuer does not match the configured issuer.');
+            throw new AuthenticationException('OIDC discovery document issuer mismatch.');
+        }
+
+        $item->set($data);
+        $item->expiresAfter(3600);
+        $this->cache->save($item);
+
+        return $data;
+    }
+}

--- a/src/Oidc/OidcLoginAttributes.php
+++ b/src/Oidc/OidcLoginAttributes.php
@@ -1,0 +1,59 @@
+<?php
+
+/*
+ * This file is part of the Kimai time-tracking app.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Oidc;
+
+final class OidcLoginAttributes
+{
+    /**
+     * @var array<string, mixed>
+     */
+    private array $attributes = [];
+    private ?string $userIdentifier = null;
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getAttributes(): array
+    {
+        return $this->attributes;
+    }
+
+    /**
+     * @param array<string, mixed> $attributes
+     */
+    public function setAttributes(array $attributes): void
+    {
+        $this->attributes = $attributes;
+    }
+
+    public function hasAttribute(string $name): bool
+    {
+        return \array_key_exists($name, $this->attributes);
+    }
+
+    public function getAttribute(string $name): mixed
+    {
+        if (!\array_key_exists($name, $this->attributes)) {
+            throw new \InvalidArgumentException(\sprintf('This OIDC login has no "%s" attribute.', $name));
+        }
+
+        return $this->attributes[$name];
+    }
+
+    public function getUserIdentifier(): ?string
+    {
+        return $this->userIdentifier;
+    }
+
+    public function setUserIdentifier(?string $userIdentifier): void
+    {
+        $this->userIdentifier = $userIdentifier;
+    }
+}

--- a/src/Oidc/OidcProvider.php
+++ b/src/Oidc/OidcProvider.php
@@ -1,0 +1,139 @@
+<?php
+
+/*
+ * This file is part of the Kimai time-tracking app.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Oidc;
+
+use App\Configuration\OidcConfigurationInterface;
+use App\Entity\User;
+use App\User\UserService;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Security\Core\Exception\AuthenticationException;
+use Symfony\Component\Security\Core\Exception\UserNotFoundException;
+use Symfony\Component\Security\Core\User\UserProviderInterface;
+
+final class OidcProvider
+{
+    /**
+     * @param UserProviderInterface<User> $userProvider
+     */
+    public function __construct(
+        private readonly UserService $userService,
+        private readonly UserProviderInterface $userProvider,
+        private readonly OidcConfigurationInterface $configuration,
+        private readonly LoggerInterface $logger
+    ) {
+    }
+
+    public function findUser(OidcLoginAttributes $token): User
+    {
+        $user = null;
+
+        try {
+            if ($token->getUserIdentifier() !== null) {
+                /** @var User $user */
+                $user = $this->userProvider->loadUserByIdentifier($token->getUserIdentifier());
+            }
+        } catch (UserNotFoundException) {
+            // this is expected for new users
+            $this->logger->debug('OIDC user is not existing: ' . $token->getUserIdentifier());
+        }
+
+        try {
+            if (null === $user) {
+                $user = $this->userService->createNewUser();
+                $user->setUserIdentifier((string) $token->getUserIdentifier());
+            }
+            $this->hydrateUser($user, $token);
+            $this->userService->saveUser($user);
+        } catch (\Exception $ex) {
+            $this->logger->error($ex->getMessage());
+            throw new AuthenticationException(
+                \sprintf('Failed creating or hydrating user "%s": %s', $token->getUserIdentifier() ?? '*unknown*', $ex->getMessage())
+            );
+        }
+
+        return $user;
+    }
+
+    private function hydrateUser(User $user, OidcLoginAttributes $token): void
+    {
+        $rolesClaim = $this->configuration->getRolesClaim();
+        $rolesMapping = $this->configuration->getRolesMapping();
+
+        // extract user roles from a dedicated claim (e.g. "groups")
+        if (!empty($rolesClaim) && $token->hasAttribute($rolesClaim)) {
+            $roleMap = [];
+            foreach ($rolesMapping as $mapping) {
+                $roleMap[$mapping['oidc']] = $mapping['kimai'];
+            }
+
+            $roles = [];
+            $claimGroups = $token->getAttribute($rolesClaim);
+            if (!\is_array($claimGroups)) {
+                $claimGroups = [$claimGroups];
+            }
+            foreach ($claimGroups as $groupName) {
+                if (\is_string($groupName) && \array_key_exists($groupName, $roleMap)) {
+                    $roles[] = $roleMap[$groupName];
+                }
+            }
+
+            if ($this->configuration->isRolesResetOnLogin()) {
+                $user->setRoles($roles);
+            } else {
+                foreach ($roles as $role) {
+                    $user->addRole($role);
+                }
+            }
+        }
+
+        foreach ($this->configuration->getAttributeMapping() as $mapping) {
+            $field = $mapping['kimai'];
+            $value = $this->getClaimValue($token, $mapping['oidc']);
+            if ($value === null) {
+                continue;
+            }
+            $setter = 'set' . ucfirst($field);
+            if (method_exists($user, $setter)) {
+                $user->$setter($value);
+            } else {
+                throw new \RuntimeException('Invalid OIDC mapping field: ' . $field);
+            }
+        }
+
+        // change after hydrating account, so it can't be overwritten by mapping attributes
+        if ($user->getId() === null) {
+            // set a plain password to satisfy the validator
+            $user->setPlainPassword(substr(bin2hex(random_bytes(100)), 0, 50));
+            $user->setPassword('');
+        }
+
+        $user->setUserIdentifier((string) $token->getUserIdentifier());
+        $user->setAuth(User::AUTH_OIDC);
+    }
+
+    private function getClaimValue(OidcLoginAttributes $token, string $claim): ?string
+    {
+        if (!$token->hasAttribute($claim)) {
+            return null;
+        }
+
+        $value = $token->getAttribute($claim);
+
+        if (\is_array($value)) {
+            $value = $value[0] ?? null;
+        }
+
+        if ($value === null || \is_bool($value)) {
+            return null;
+        }
+
+        return (string) $value;
+    }
+}

--- a/src/Oidc/OidcProvider.php
+++ b/src/Oidc/OidcProvider.php
@@ -130,7 +130,7 @@ final class OidcProvider
             $value = $value[0] ?? null;
         }
 
-        if ($value === null || \is_bool($value)) {
+        if (!\is_scalar($value) || \is_bool($value)) {
             return null;
         }
 

--- a/src/Oidc/OidcToken.php
+++ b/src/Oidc/OidcToken.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * This file is part of the Kimai time-tracking app.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Oidc;
+
+use Symfony\Component\Security\Http\Authenticator\Token\PostAuthenticationToken;
+
+final class OidcToken extends PostAuthenticationToken
+{
+}

--- a/src/Oidc/Security/OidcAuthenticationFailureHandler.php
+++ b/src/Oidc/Security/OidcAuthenticationFailureHandler.php
@@ -9,14 +9,19 @@
 
 namespace App\Oidc\Security;
 
+use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\Security\Http\Authentication\DefaultAuthenticationFailureHandler;
+use Symfony\Component\Security\Http\HttpUtils;
 
 final class OidcAuthenticationFailureHandler extends DefaultAuthenticationFailureHandler
 {
-    protected $defaultOptions = [
-        'failure_path' => 'login',
-        'failure_forward' => false,
-        'login_path' => 'login',
-        'failure_path_parameter' => '_failure_path',
-    ];
+    public function __construct(HttpKernelInterface $httpKernel, HttpUtils $httpUtils)
+    {
+        parent::__construct($httpKernel, $httpUtils, [
+            'failure_path' => 'login',
+            'failure_forward' => false,
+            'login_path' => 'login',
+            'failure_path_parameter' => '_failure_path',
+        ]);
+    }
 }

--- a/src/Oidc/Security/OidcAuthenticationFailureHandler.php
+++ b/src/Oidc/Security/OidcAuthenticationFailureHandler.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Kimai time-tracking app.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Oidc\Security;
+
+use Symfony\Component\Security\Http\Authentication\DefaultAuthenticationFailureHandler;
+
+final class OidcAuthenticationFailureHandler extends DefaultAuthenticationFailureHandler
+{
+    protected $defaultOptions = [
+        'failure_path' => 'login',
+        'failure_forward' => false,
+        'login_path' => 'login',
+        'failure_path_parameter' => '_failure_path',
+    ];
+}

--- a/src/Oidc/Security/OidcAuthenticationSuccessHandler.php
+++ b/src/Oidc/Security/OidcAuthenticationSuccessHandler.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the Kimai time-tracking app.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Oidc\Security;
+
+use Symfony\Component\Security\Http\Authentication\DefaultAuthenticationSuccessHandler;
+
+final class OidcAuthenticationSuccessHandler extends DefaultAuthenticationSuccessHandler
+{
+    protected $defaultOptions = [
+        'always_use_default_target_path' => false,
+        'default_target_path' => 'homepage',
+        'login_path' => 'oidc_login',
+        'target_path_parameter' => '_target_path',
+        'use_referer' => false,
+    ];
+}

--- a/src/Oidc/Security/OidcAuthenticationSuccessHandler.php
+++ b/src/Oidc/Security/OidcAuthenticationSuccessHandler.php
@@ -10,14 +10,18 @@
 namespace App\Oidc\Security;
 
 use Symfony\Component\Security\Http\Authentication\DefaultAuthenticationSuccessHandler;
+use Symfony\Component\Security\Http\HttpUtils;
 
 final class OidcAuthenticationSuccessHandler extends DefaultAuthenticationSuccessHandler
 {
-    protected $defaultOptions = [
-        'always_use_default_target_path' => false,
-        'default_target_path' => 'homepage',
-        'login_path' => 'oidc_login',
-        'target_path_parameter' => '_target_path',
-        'use_referer' => false,
-    ];
+    public function __construct(HttpUtils $httpUtils)
+    {
+        parent::__construct($httpUtils, [
+            'always_use_default_target_path' => false,
+            'default_target_path' => 'homepage',
+            'login_path' => 'oidc_login',
+            'target_path_parameter' => '_target_path',
+            'use_referer' => false,
+        ]);
+    }
 }

--- a/templates/security/login.html.twig
+++ b/templates/security/login.html.twig
@@ -47,7 +47,7 @@
 {% endblock %}
 
 {% block login_social_auth %}
-    {% if saml_config.isActivated() %}
+    {% if saml_config.isActivated() or oidc_config.isActivated() %}
         {% if config('loginFormActive') %}
             <div class="hr-text">{{ 'or'|trans({}, 'TablerBundle') }}</div>
         {% endif %}
@@ -56,19 +56,36 @@
                 {% if not config('loginFormActive') %}
                     <h2 class="card-title text-center mb-4">{{ block('login_box_msg') }}</h2>
                 {% endif %}
-                <div class="col text-center">
-                    <a href="{{ path('saml_login') }}" id="social-login-button" tabindex="50" class="btn btn-white w-50">
-                        {% set provider = saml_config.getProvider() %}
-                        {% if provider is not null %}
-                            {% if 'fa-' in provider %}
-                                <i class="icon {{ provider }} text-{{ provider|replace({'fas ': '', 'far ': '', 'fab ': ''}) }}"></i>
-                            {% else %}
-                                <i class="icon fab fa-{{ provider }} text-{{ provider }}"></i>
+                {% if saml_config.isActivated() %}
+                    <div class="col text-center">
+                        <a href="{{ path('saml_login') }}" id="social-login-button" tabindex="50" class="btn btn-white w-50">
+                            {% set provider = saml_config.getProvider() %}
+                            {% if provider is not null %}
+                                {% if 'fa-' in provider %}
+                                    <i class="icon {{ provider }} text-{{ provider|replace({'fas ': '', 'far ': '', 'fab ': ''}) }}"></i>
+                                {% else %}
+                                    <i class="icon fab fa-{{ provider }} text-{{ provider }}"></i>
+                                {% endif %}
                             {% endif %}
-                        {% endif %}
-                        {{ saml_config.getTitle()|trans }}
-                    </a>
-                </div>
+                            {{ saml_config.getTitle()|trans }}
+                        </a>
+                    </div>
+                {% endif %}
+                {% if oidc_config.isActivated() %}
+                    <div class="col text-center">
+                        <a href="{{ path('oidc_login') }}" id="oidc-login-button" tabindex="51" class="btn btn-white w-50">
+                            {% set provider = oidc_config.getProvider() %}
+                            {% if provider is not null %}
+                                {% if 'fa-' in provider %}
+                                    <i class="icon {{ provider }} text-{{ provider|replace({'fas ': '', 'far ': '', 'fab ': ''}) }}"></i>
+                                {% else %}
+                                    <i class="icon fab fa-{{ provider }} text-{{ provider }}"></i>
+                                {% endif %}
+                            {% endif %}
+                            {{ oidc_config.getTitle()|trans }}
+                        </a>
+                    </div>
+                {% endif %}
             </div>
         </div>
     {% endif %}

--- a/tests/Configuration/OidcConfigurationTest.php
+++ b/tests/Configuration/OidcConfigurationTest.php
@@ -1,0 +1,103 @@
+<?php
+
+/*
+ * This file is part of the Kimai time-tracking app.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Tests\Configuration;
+
+use App\Configuration\OidcConfiguration;
+use App\Configuration\SystemConfiguration;
+use App\Tests\Mocks\SystemConfigurationFactory;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(OidcConfiguration::class)]
+#[CoversClass(SystemConfiguration::class)]
+class OidcConfigurationTest extends TestCase
+{
+    protected function getSut(array $settings): OidcConfiguration
+    {
+        $systemConfig = SystemConfigurationFactory::create(new TestConfigLoader([]), ['oidc' => $settings]);
+
+        return new OidcConfiguration($systemConfig);
+    }
+
+    protected function getDefaultSettings(): array
+    {
+        return [
+            'activate' => true,
+            'title' => 'OIDC title',
+            'provider' => 'keycloak',
+            'client_id' => 'my-client-id',
+            'client_secret' => 'my-client-secret',
+            'issuer' => 'https://id.example.com',
+            'authorization_url' => 'https://id.example.com/authorize',
+            'token_url' => 'https://id.example.com/token',
+            'userinfo_url' => 'https://id.example.com/userinfo',
+            'scopes' => 'openid profile email groups',
+            'username_claim' => 'email',
+            'mapping' => [
+                ['oidc' => 'email', 'kimai' => 'email'],
+                ['oidc' => 'name', 'kimai' => 'alias'],
+            ],
+            'roles' => [
+                'claim' => 'groups',
+                'resetOnLogin' => true,
+                'mapping' => [
+                    ['oidc' => 'kimai-admin', 'kimai' => 'ROLE_SUPER_ADMIN'],
+                    ['oidc' => 'management', 'kimai' => 'ROLE_TEAMLEAD'],
+                ],
+            ],
+        ];
+    }
+
+    public function testDefault(): void
+    {
+        $sut = $this->getSut([]);
+        self::assertFalse($sut->isActivated());
+        self::assertEquals('', $sut->getTitle());
+        self::assertNull($sut->getProvider());
+        self::assertEquals('', $sut->getClientId());
+        self::assertEquals('', $sut->getClientSecret());
+        self::assertNull($sut->getIssuer());
+        self::assertNull($sut->getAuthorizationUrl());
+        self::assertNull($sut->getTokenUrl());
+        self::assertNull($sut->getUserInfoUrl());
+        self::assertEquals(['openid', 'profile', 'email'], $sut->getScopes());
+        self::assertEquals('preferred_username', $sut->getUsernameClaim());
+        self::assertEquals([], $sut->getAttributeMapping());
+        self::assertNull($sut->getRolesClaim());
+        self::assertEquals([], $sut->getRolesMapping());
+        self::assertFalse($sut->isRolesResetOnLogin());
+    }
+
+    public function testDefaultSettings(): void
+    {
+        $sut = $this->getSut($this->getDefaultSettings());
+        self::assertTrue($sut->isActivated());
+        self::assertTrue($sut->isRolesResetOnLogin());
+        self::assertEquals('OIDC title', $sut->getTitle());
+        self::assertEquals('keycloak', $sut->getProvider());
+        self::assertEquals('my-client-id', $sut->getClientId());
+        self::assertEquals('my-client-secret', $sut->getClientSecret());
+        self::assertEquals('https://id.example.com', $sut->getIssuer());
+        self::assertEquals('https://id.example.com/authorize', $sut->getAuthorizationUrl());
+        self::assertEquals('https://id.example.com/token', $sut->getTokenUrl());
+        self::assertEquals('https://id.example.com/userinfo', $sut->getUserInfoUrl());
+        self::assertEquals(['openid', 'profile', 'email', 'groups'], $sut->getScopes());
+        self::assertEquals('email', $sut->getUsernameClaim());
+        self::assertEquals([
+            ['oidc' => 'email', 'kimai' => 'email'],
+            ['oidc' => 'name', 'kimai' => 'alias'],
+        ], $sut->getAttributeMapping());
+        self::assertEquals('groups', $sut->getRolesClaim());
+        self::assertEquals([
+            ['oidc' => 'kimai-admin', 'kimai' => 'ROLE_SUPER_ADMIN'],
+            ['oidc' => 'management', 'kimai' => 'ROLE_TEAMLEAD'],
+        ], $sut->getRolesMapping());
+    }
+}

--- a/tests/Controller/Auth/OidcControllerTest.php
+++ b/tests/Controller/Auth/OidcControllerTest.php
@@ -1,0 +1,123 @@
+<?php
+
+/*
+ * This file is part of the Kimai time-tracking app.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Tests\Controller\Auth;
+
+use App\Configuration\OidcConfigurationInterface;
+use App\Controller\Auth\OidcController;
+use App\Oidc\OidcAuthenticator;
+use App\Oidc\OidcClient;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\Container;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+
+#[CoversClass(OidcController::class)]
+class OidcControllerTest extends TestCase
+{
+    public function testLoginActionThrowsWhenDeactivated(): void
+    {
+        $this->expectException(NotFoundHttpException::class);
+        $this->expectExceptionMessage('OIDC deactivated');
+
+        $sut = $this->createSut($this->createMock(OidcClient::class), false);
+
+        $sut->loginAction($this->createRequest());
+    }
+
+    public function testLoginActionRedirectsToAuthorizationUrl(): void
+    {
+        $oidcClient = $this->createMock(OidcClient::class);
+        $oidcClient
+            ->expects($this->once())
+            ->method('getAuthorizationUrl')
+            ->willReturn('https://id.example.com/authorize?client_id=my-client');
+
+        $sut = $this->createSut($oidcClient, true);
+        $request = $this->createRequest();
+
+        $response = $sut->loginAction($request);
+
+        self::assertInstanceOf(RedirectResponse::class, $response);
+        self::assertSame('https://id.example.com/authorize?client_id=my-client', $response->getTargetUrl());
+
+        $session = $request->getSession();
+        self::assertNotEmpty($session->get(OidcAuthenticator::SESSION_STATE));
+        self::assertNotEmpty($session->get(OidcAuthenticator::SESSION_NONCE));
+        self::assertNotEmpty($session->get(OidcAuthenticator::SESSION_PKCE));
+    }
+
+    public function testCallbackActionThrowsWhenDeactivated(): void
+    {
+        $this->expectException(NotFoundHttpException::class);
+        $this->expectExceptionMessage('OIDC deactivated');
+
+        $sut = $this->createSut($this->createMock(OidcClient::class), false);
+
+        $sut->callbackAction();
+    }
+
+    public function testCallbackActionThrowsRuntimeExceptionWhenActivated(): void
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('You must configure the check path to be handled by the firewall.');
+
+        $sut = $this->createSut($this->createMock(OidcClient::class), true);
+
+        $sut->callbackAction();
+    }
+
+    private function createSut(OidcClient $oidcClient, bool $activated): OidcController
+    {
+        $configuration = $this->createConfiguration($activated);
+
+        $controller = new OidcController($oidcClient, $configuration);
+
+        $container = new Container();
+        $container->set('router', $this->createUrlGenerator());
+        $controller->setContainer($container);
+
+        return $controller;
+    }
+
+    /**
+     * @return OidcConfigurationInterface&MockObject
+     */
+    private function createConfiguration(bool $activated): OidcConfigurationInterface
+    {
+        $configuration = $this->createMock(OidcConfigurationInterface::class);
+        $configuration->method('isActivated')->willReturn($activated);
+
+        return $configuration;
+    }
+
+    private function createRequest(): Request
+    {
+        $request = Request::create('/oidc/login', 'GET');
+        $request->setSession(new Session(new MockArraySessionStorage()));
+
+        return $request;
+    }
+
+    private function createUrlGenerator(): UrlGeneratorInterface
+    {
+        $urlGenerator = $this->createMock(UrlGeneratorInterface::class);
+        $urlGenerator
+            ->method('generate')
+            ->willReturnCallback(static fn ($name): string => (string) $name);
+
+        return $urlGenerator;
+    }
+}

--- a/tests/Controller/Security/SecurityControllerTest.php
+++ b/tests/Controller/Security/SecurityControllerTest.php
@@ -9,6 +9,7 @@
 
 namespace App\Tests\Controller\Security;
 
+use App\Configuration\OidcConfiguration;
 use App\Configuration\SamlConfiguration;
 use App\Configuration\SystemConfiguration;
 use App\Controller\Security\SecurityController;
@@ -124,7 +125,8 @@ class SecurityControllerTest extends AbstractControllerBaseTestCase
         $csrf = $this->createMock(CsrfTokenManagerInterface::class);
         $systemConfig = new SystemConfiguration(new TestConfigLoader([]), ['saml' => ['activate' => true]]);
         $samlConfig = new SamlConfiguration($systemConfig);
-        $sut = new SecurityController($csrf, $samlConfig);
+        $oidcConfig = new OidcConfiguration($systemConfig);
+        $sut = new SecurityController($csrf, $samlConfig, $oidcConfig);
         $sut->checkAction();
     }
 
@@ -137,7 +139,8 @@ class SecurityControllerTest extends AbstractControllerBaseTestCase
         $csrf = $this->createMock(CsrfTokenManagerInterface::class);
         $systemConfig = new SystemConfiguration(new TestConfigLoader([]), ['saml' => ['activate' => true]]);
         $samlConfig = new SamlConfiguration($systemConfig);
-        $sut = new SecurityController($csrf, $samlConfig);
+        $oidcConfig = new OidcConfiguration($systemConfig);
+        $sut = new SecurityController($csrf, $samlConfig, $oidcConfig);
         $sut->logoutAction();
     }
 }

--- a/tests/DependencyInjection/ConfigurationTest.php
+++ b/tests/DependencyInjection/ConfigurationTest.php
@@ -592,6 +592,25 @@ class ConfigurationTest extends TestCase
             'features' => [
                 'user_registration' => false,
             ],
+            'oidc' => [
+                'activate' => false,
+                'title' => 'Login with SSO',
+                'provider' => 'openid',
+                'client_id' => null,
+                'client_secret' => null,
+                'issuer' => null,
+                'authorization_url' => null,
+                'token_url' => null,
+                'userinfo_url' => null,
+                'scopes' => 'openid profile email',
+                'username_claim' => 'preferred_username',
+                'roles' => [
+                    'resetOnLogin' => true,
+                    'claim' => null,
+                    'mapping' => [],
+                ],
+                'mapping' => [],
+            ],
         ];
 
         $this->assertConfig($this->getMinConfig(), $fullDefaultConfig);

--- a/tests/DependencyInjection/ConfigurationTest.php
+++ b/tests/DependencyInjection/ConfigurationTest.php
@@ -51,6 +51,49 @@ class ConfigurationTest extends TestCase
         $this->assertConfig($this->getMinConfig('sdfsdfsdfds'), []);
     }
 
+    public function testValidateOidcRequiresClientCredentialsWhenActivated(): void
+    {
+        $this->expectException(InvalidConfigurationException::class);
+        $this->expectExceptionMessage('You need to configure "oidc.client_id" and "oidc.client_secret" when OIDC is activated.');
+
+        $config = $this->getMinConfig();
+        $config['oidc'] = [
+            'activate' => true,
+        ];
+
+        $this->assertConfig($config, []);
+    }
+
+    public function testValidateOidcRequiresIssuerOrEndpointsWhenActivated(): void
+    {
+        $this->expectException(InvalidConfigurationException::class);
+        $this->expectExceptionMessage('You need to configure "oidc.issuer" or the explicit "oidc.authorization_url", "oidc.token_url" and "oidc.userinfo_url" endpoints.');
+
+        $config = $this->getMinConfig();
+        $config['oidc'] = [
+            'activate' => true,
+            'client_id' => 'my-client-id',
+            'client_secret' => 'my-client-secret',
+        ];
+
+        $this->assertConfig($config, []);
+    }
+
+    public function testValidateOidcRejectsReservedAttributeMapping(): void
+    {
+        $this->expectException(InvalidConfigurationException::class);
+        $this->expectExceptionMessage('You cannot configure "username" and "userIdentifier" for OIDC attribute mapping.');
+
+        $config = $this->getMinConfig();
+        $config['oidc'] = [
+            'mapping' => [
+                ['oidc' => 'preferred_username', 'kimai' => 'username'],
+            ],
+        ];
+
+        $this->assertConfig($config, []);
+    }
+
     public function testValidateLdapConfigUserBaseDn(): void
     {
         $this->expectException(InvalidConfigurationException::class);

--- a/tests/Oidc/OidcAuthenticatorTest.php
+++ b/tests/Oidc/OidcAuthenticatorTest.php
@@ -1,0 +1,440 @@
+<?php
+
+/*
+ * This file is part of the Kimai time-tracking app.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Tests\Oidc;
+
+use App\Configuration\OidcConfigurationInterface;
+use App\Entity\User;
+use App\Oidc\OidcAuthenticator;
+use App\Oidc\OidcBadge;
+use App\Oidc\OidcClient;
+use App\Oidc\OidcLoginAttributes;
+use App\Oidc\OidcProvider;
+use App\Oidc\OidcToken;
+use App\Oidc\Security\OidcAuthenticationFailureHandler;
+use App\Oidc\Security\OidcAuthenticationSuccessHandler;
+use App\User\UserService;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Component\Routing\Matcher\UrlMatcherInterface;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Exception\AuthenticationException;
+use Symfony\Component\Security\Core\User\UserProviderInterface;
+use Symfony\Component\Security\Http\Authenticator\Passport\Badge\RememberMeBadge;
+use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
+use Symfony\Component\Security\Http\Authenticator\Passport\SelfValidatingPassport;
+use Symfony\Component\Security\Http\HttpUtils;
+
+#[CoversClass(OidcAuthenticator::class)]
+class OidcAuthenticatorTest extends TestCase
+{
+    public function testSupportsReturnsFalseIfOidcIsDisabled(): void
+    {
+        $sut = $this->createSut($this->createConfiguration(false));
+
+        self::assertFalse($sut->supports($this->createRequest(['code' => 'abc'])));
+    }
+
+    public function testSupportsReturnsFalseForNonGetRequests(): void
+    {
+        $sut = $this->createSut($this->createConfiguration());
+
+        $request = Request::create('/oidc_callback', 'POST', ['code' => 'abc']);
+
+        self::assertFalse($sut->supports($request));
+    }
+
+    public function testSupportsReturnsFalseForDifferentPath(): void
+    {
+        $sut = $this->createSut($this->createConfiguration());
+
+        self::assertFalse($sut->supports(Request::create('/login', 'GET', ['code' => 'abc'])));
+    }
+
+    public function testSupportsReturnsFalseWithoutCodeOrError(): void
+    {
+        $sut = $this->createSut($this->createConfiguration());
+
+        self::assertFalse($sut->supports($this->createRequest()));
+    }
+
+    public function testSupportsReturnsTrueWithCode(): void
+    {
+        $sut = $this->createSut($this->createConfiguration());
+
+        self::assertTrue($sut->supports($this->createRequest(['code' => 'abc'])));
+    }
+
+    public function testSupportsReturnsTrueWithError(): void
+    {
+        $sut = $this->createSut($this->createConfiguration());
+
+        self::assertTrue($sut->supports($this->createRequest(['error' => 'access_denied'])));
+    }
+
+    public function testAuthenticateBuildsPassport(): void
+    {
+        $oidcClient = $this->createMock(OidcClient::class);
+        $oidcClient
+            ->expects($this->once())
+            ->method('fetchUserClaims')
+            ->with('auth-code', $this->anything(), 'nonce-abc', 'verifier-abc')
+            ->willReturn([
+                'preferred_username' => 'john@example.com',
+                'email' => 'john@example.com',
+            ]);
+
+        $sut = $this->createSut($this->createConfiguration(), $oidcClient);
+
+        $request = $this->createRequest(
+            ['code' => 'auth-code', 'state' => 'state-abc'],
+            [
+                OidcAuthenticator::SESSION_STATE => 'state-abc',
+                OidcAuthenticator::SESSION_NONCE => 'nonce-abc',
+                OidcAuthenticator::SESSION_PKCE => 'verifier-abc',
+            ]
+        );
+
+        $passport = $sut->authenticate($request);
+
+        self::assertInstanceOf(SelfValidatingPassport::class, $passport);
+
+        $userBadge = $passport->getBadge(UserBadge::class);
+        self::assertInstanceOf(UserBadge::class, $userBadge);
+        self::assertSame('john@example.com', $userBadge->getUserIdentifier());
+
+        self::assertTrue($passport->hasBadge(RememberMeBadge::class));
+
+        $oidcBadge = $passport->getBadge(OidcBadge::class);
+        self::assertInstanceOf(OidcBadge::class, $oidcBadge);
+        self::assertSame('john@example.com', $oidcBadge->getOidcLoginAttributes()->getUserIdentifier());
+    }
+
+    public function testAuthenticateResolvesArrayIdentifier(): void
+    {
+        $oidcClient = $this->createMock(OidcClient::class);
+        $oidcClient
+            ->expects($this->once())
+            ->method('fetchUserClaims')
+            ->willReturn([
+                'preferred_username' => ['john@example.com', 'second@example.com'],
+            ]);
+
+        $sut = $this->createSut($this->createConfiguration(), $oidcClient);
+
+        $passport = $sut->authenticate($this->createValidRequest());
+
+        $userBadge = $passport->getBadge(UserBadge::class);
+        self::assertInstanceOf(UserBadge::class, $userBadge);
+        self::assertSame('john@example.com', $userBadge->getUserIdentifier());
+    }
+
+    public function testAuthenticateThrowsOnProviderError(): void
+    {
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage('OIDC login failed: access_denied');
+
+        $sut = $this->createSut($this->createConfiguration());
+
+        $sut->authenticate($this->createRequest(['error' => 'access_denied']));
+    }
+
+    public function testAuthenticateThrowsOnStateMismatch(): void
+    {
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage('OIDC state mismatch.');
+
+        $sut = $this->createSut($this->createConfiguration());
+
+        $request = $this->createRequest(
+            ['code' => 'auth-code', 'state' => 'wrong-state'],
+            [OidcAuthenticator::SESSION_STATE => 'state-abc']
+        );
+
+        $sut->authenticate($request);
+    }
+
+    public function testAuthenticateThrowsOnMissingState(): void
+    {
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage('OIDC state mismatch.');
+
+        $sut = $this->createSut($this->createConfiguration());
+
+        $request = $this->createRequest(['code' => 'auth-code', 'state' => 'state-abc']);
+
+        $sut->authenticate($request);
+    }
+
+    public function testAuthenticateThrowsOnMissingNonce(): void
+    {
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage('OIDC nonce is missing.');
+
+        $sut = $this->createSut($this->createConfiguration());
+
+        $request = $this->createRequest(
+            ['code' => 'auth-code', 'state' => 'state-abc'],
+            [OidcAuthenticator::SESSION_STATE => 'state-abc']
+        );
+
+        $sut->authenticate($request);
+    }
+
+    public function testAuthenticateThrowsOnMissingCodeVerifier(): void
+    {
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage('OIDC PKCE code verifier is missing.');
+
+        $sut = $this->createSut($this->createConfiguration());
+
+        $request = $this->createRequest(
+            ['code' => 'auth-code', 'state' => 'state-abc'],
+            [
+                OidcAuthenticator::SESSION_STATE => 'state-abc',
+                OidcAuthenticator::SESSION_NONCE => 'nonce-abc',
+            ]
+        );
+
+        $sut->authenticate($request);
+    }
+
+    public function testAuthenticateThrowsWhenUsernameClaimIsMissing(): void
+    {
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage('Claim "preferred_username" not found in OIDC response.');
+
+        $oidcClient = $this->createMock(OidcClient::class);
+        $oidcClient->method('fetchUserClaims')->willReturn(['email' => 'john@example.com']);
+
+        $sut = $this->createSut($this->createConfiguration(), $oidcClient);
+
+        $sut->authenticate($this->createValidRequest());
+    }
+
+    public function testAuthenticateThrowsWhenIdentifierIsEmpty(): void
+    {
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage('Claim "preferred_username" did not contain a valid user identifier.');
+
+        $oidcClient = $this->createMock(OidcClient::class);
+        $oidcClient->method('fetchUserClaims')->willReturn(['preferred_username' => '']);
+
+        $sut = $this->createSut($this->createConfiguration(), $oidcClient);
+
+        $sut->authenticate($this->createValidRequest());
+    }
+
+    public function testCreateTokenCopiesUserRolesAndOidcAttributes(): void
+    {
+        $user = new User();
+        $user->setUserIdentifier('oidc-user');
+        $user->setRoles(['ROLE_TEAMLEAD']);
+
+        $loginAttributes = new OidcLoginAttributes();
+        $loginAttributes->setAttributes([
+            'email' => 'foo@example.com',
+            'name' => 'John Doe',
+        ]);
+
+        $passport = new SelfValidatingPassport(
+            new UserBadge('oidc-user', static fn (): User => $user),
+            [new OidcBadge($loginAttributes)]
+        );
+
+        $sut = $this->createSut($this->createConfiguration());
+        $token = $sut->createToken($passport, 'secured_area');
+
+        self::assertInstanceOf(OidcToken::class, $token);
+        self::assertSame($user, $token->getUser());
+        self::assertSame('oidc-user', $token->getUserIdentifier());
+        self::assertEqualsCanonicalizing(['ROLE_TEAMLEAD', 'ROLE_USER'], $token->getRoleNames());
+        self::assertSame([
+            'email' => 'foo@example.com',
+            'name' => 'John Doe',
+        ], $token->getAttributes());
+    }
+
+    public function testAuthenticationSuccessDelegatesToSuccessHandler(): void
+    {
+        $user = new User();
+        $user->setUserIdentifier('success-user');
+        $token = $this->createTokenForUser($user);
+        $successHandler = $this->createSuccessHandler(['homepage' => '/dashboard']);
+
+        $sut = $this->createSut($this->createConfiguration(), successHandler: $successHandler);
+
+        $response = $sut->onAuthenticationSuccess(Request::create('/oidc_callback', 'GET'), $token, 'secured_area');
+
+        self::assertInstanceOf(RedirectResponse::class, $response);
+        self::assertSame('/dashboard', $response->getTargetUrl());
+    }
+
+    public function testAuthenticationFailureDelegatesToFailureHandler(): void
+    {
+        $request = Request::create('/oidc_callback', 'GET');
+        $request->attributes->set('_stateless', true);
+        $failureHandler = $this->createFailureHandler(['login' => '/login']);
+
+        $sut = $this->createSut($this->createConfiguration(), failureHandler: $failureHandler);
+
+        $response = $sut->onAuthenticationFailure($request, new AuthenticationException('failure'));
+
+        self::assertInstanceOf(RedirectResponse::class, $response);
+        self::assertSame('/login', $response->getTargetUrl());
+    }
+
+    private function createSut(
+        OidcConfigurationInterface $configuration,
+        ?OidcClient $oidcClient = null,
+        ?OidcProvider $provider = null,
+        ?OidcAuthenticationSuccessHandler $successHandler = null,
+        ?OidcAuthenticationFailureHandler $failureHandler = null,
+        ?LoggerInterface $logger = null
+    ): OidcAuthenticator {
+        return new OidcAuthenticator(
+            new HttpUtils($this->createUrlGenerator(), $this->createUrlMatcher()),
+            $successHandler ?? $this->createSuccessHandler(),
+            $failureHandler ?? $this->createFailureHandler(),
+            $oidcClient ?? $this->createMock(OidcClient::class),
+            $provider ?? $this->createUnusedProvider(),
+            $configuration,
+            $this->createUrlGenerator(),
+            $logger ?? $this->createMock(LoggerInterface::class)
+        );
+    }
+
+    /**
+     * @return OidcConfigurationInterface&MockObject
+     */
+    private function createConfiguration(bool $activated = true, string $usernameClaim = 'preferred_username'): OidcConfigurationInterface
+    {
+        $configuration = $this->createMock(OidcConfigurationInterface::class);
+        $configuration->method('isActivated')->willReturn($activated);
+        $configuration->method('getUsernameClaim')->willReturn($usernameClaim);
+
+        return $configuration;
+    }
+
+    /**
+     * @param array<string, mixed> $query
+     * @param array<string, mixed> $session
+     */
+    private function createRequest(array $query = [], array $session = []): Request
+    {
+        $request = Request::create('/oidc_callback', 'GET', $query);
+
+        $store = new Session(new MockArraySessionStorage());
+        foreach ($session as $key => $value) {
+            $store->set($key, $value);
+        }
+        $request->setSession($store);
+
+        return $request;
+    }
+
+    private function createValidRequest(): Request
+    {
+        return $this->createRequest(
+            ['code' => 'auth-code', 'state' => 'state-abc'],
+            [
+                OidcAuthenticator::SESSION_STATE => 'state-abc',
+                OidcAuthenticator::SESSION_NONCE => 'nonce-abc',
+                OidcAuthenticator::SESSION_PKCE => 'verifier-abc',
+            ]
+        );
+    }
+
+    private function createTokenForUser(User $user): TokenInterface
+    {
+        $passport = new SelfValidatingPassport(new UserBadge($user->getUserIdentifier(), static fn (): User => $user));
+
+        return $this->createSut($this->createConfiguration())->createToken($passport, 'secured_area');
+    }
+
+    private function createUnusedProvider(): OidcProvider
+    {
+        /** @var UserProviderInterface<User>&MockObject $userProvider */
+        $userProvider = $this->getMockBuilder(UserProviderInterface::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['refreshUser', 'supportsClass', 'loadUserByIdentifier'])
+            ->getMock();
+        $userProvider->expects($this->never())->method('loadUserByIdentifier');
+
+        $userService = $this->createMock(UserService::class);
+        $userService->expects($this->never())->method('createNewUser');
+        $userService->expects($this->never())->method('saveUser');
+
+        return new OidcProvider(
+            $userService,
+            $userProvider,
+            $this->createMock(OidcConfigurationInterface::class),
+            $this->createMock(LoggerInterface::class)
+        );
+    }
+
+    private function createSuccessHandler(array $rules = []): OidcAuthenticationSuccessHandler
+    {
+        return new OidcAuthenticationSuccessHandler(new HttpUtils($this->createUrlGenerator($rules)));
+    }
+
+    private function createFailureHandler(array $rules = []): OidcAuthenticationFailureHandler
+    {
+        return new OidcAuthenticationFailureHandler(
+            $this->createMock(HttpKernelInterface::class),
+            new HttpUtils($this->createUrlGenerator($rules))
+        );
+    }
+
+    /**
+     * @param array<string, string> $rules
+     */
+    private function createUrlGenerator(array $rules = []): UrlGeneratorInterface
+    {
+        $urlGenerator = $this->getMockBuilder(UrlGeneratorInterface::class)->getMock();
+        $urlGenerator
+            ->expects($this->any())
+            ->method('generate')
+            ->willReturnCallback(static function ($name) use ($rules): string {
+                if (\array_key_exists((string) $name, $rules)) {
+                    return $rules[(string) $name];
+                }
+
+                return (string) $name;
+            })
+        ;
+
+        return $urlGenerator;
+    }
+
+    /**
+     * @return UrlMatcherInterface&MockObject
+     */
+    private function createUrlMatcher(): UrlMatcherInterface
+    {
+        $matcher = $this->getMockBuilder(UrlMatcherInterface::class)->getMock();
+        $matcher
+            ->expects($this->any())
+            ->method('match')
+            ->willReturnCallback(static function (string $pathInfo): array {
+                return ['_route' => ltrim($pathInfo, '/')];
+            })
+        ;
+
+        return $matcher;
+    }
+}

--- a/tests/Oidc/OidcBadgeTest.php
+++ b/tests/Oidc/OidcBadgeTest.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Kimai time-tracking app.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Tests\Oidc;
+
+use App\Oidc\OidcBadge;
+use App\Oidc\OidcLoginAttributes;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(OidcBadge::class)]
+class OidcBadgeTest extends TestCase
+{
+    public function testBadge(): void
+    {
+        $attributes = new OidcLoginAttributes();
+        $attributes->setUserIdentifier('foo@example.com');
+
+        $sut = new OidcBadge($attributes);
+
+        self::assertSame($attributes, $sut->getOidcLoginAttributes());
+        self::assertTrue($sut->isResolved());
+    }
+}

--- a/tests/Oidc/OidcClientTest.php
+++ b/tests/Oidc/OidcClientTest.php
@@ -1,0 +1,360 @@
+<?php
+
+/*
+ * This file is part of the Kimai time-tracking app.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Tests\Oidc;
+
+use App\Configuration\OidcConfiguration;
+use App\Oidc\OidcClient;
+use App\Tests\Configuration\TestConfigLoader;
+use App\Tests\Mocks\SystemConfigurationFactory;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+use Symfony\Component\Security\Core\Exception\AuthenticationException;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+#[CoversClass(OidcClient::class)]
+class OidcClientTest extends TestCase
+{
+    private function getConfiguration(array $override = []): OidcConfiguration
+    {
+        $settings = array_merge([
+            'activate' => true,
+            'client_id' => 'my-client-id',
+            'client_secret' => 'my-client-secret',
+            'issuer' => 'https://id.example.com',
+            'authorization_url' => 'https://id.example.com/authorize',
+            'token_url' => 'https://id.example.com/token',
+            'userinfo_url' => 'https://id.example.com/userinfo',
+            'scopes' => 'openid profile email',
+        ], $override);
+
+        $configuration = SystemConfigurationFactory::create(new TestConfigLoader([]), ['oidc' => $settings]);
+
+        return new OidcConfiguration($configuration);
+    }
+
+    private function getSut(HttpClientInterface $httpClient, array $configOverride = []): OidcClient
+    {
+        return new OidcClient(
+            $httpClient,
+            $this->getConfiguration($configOverride),
+            new ArrayAdapter(),
+            $this->createMock(LoggerInterface::class)
+        );
+    }
+
+    private function createIdToken(array $payload): string
+    {
+        $encode = static fn (array $data): string => rtrim(strtr(base64_encode((string) json_encode($data)), '+/', '-_'), '=');
+
+        return $encode(['alg' => 'RS256', 'typ' => 'JWT']) . '.' . $encode($payload) . '.signature';
+    }
+
+    public function testGetAuthorizationUrl(): void
+    {
+        $sut = $this->getSut(new MockHttpClient());
+
+        $url = $sut->getAuthorizationUrl('https://kimai.local/oidc/callback', 'state-123', 'nonce-123');
+
+        self::assertStringStartsWith('https://id.example.com/authorize?', $url);
+
+        $query = [];
+        parse_str((string) parse_url($url, PHP_URL_QUERY), $query);
+
+        self::assertEquals('code', $query['response_type']);
+        self::assertEquals('my-client-id', $query['client_id']);
+        self::assertEquals('https://kimai.local/oidc/callback', $query['redirect_uri']);
+        self::assertEquals('openid profile email', $query['scope']);
+        self::assertEquals('state-123', $query['state']);
+        self::assertEquals('nonce-123', $query['nonce']);
+    }
+
+    public function testGetAuthorizationUrlEnforcesOpenidScope(): void
+    {
+        $sut = $this->getSut(new MockHttpClient(), ['scopes' => 'profile email']);
+
+        $url = $sut->getAuthorizationUrl('https://kimai.local/oidc/callback', 'state', 'nonce');
+
+        $query = [];
+        parse_str((string) parse_url($url, PHP_URL_QUERY), $query);
+
+        self::assertEquals('openid profile email', $query['scope']);
+    }
+
+    public function testGetAuthorizationUrlUsesDiscovery(): void
+    {
+        $httpClient = new MockHttpClient([
+            new MockResponse((string) json_encode([
+                'issuer' => 'https://id.example.com',
+                'authorization_endpoint' => 'https://id.example.com/discovered/authorize',
+            ]), ['response_headers' => ['content-type' => 'application/json']]),
+        ]);
+
+        $sut = $this->getSut($httpClient, ['authorization_url' => '']);
+
+        $url = $sut->getAuthorizationUrl('https://kimai.local/oidc/callback', 'state', 'nonce');
+
+        self::assertStringStartsWith('https://id.example.com/discovered/authorize?', $url);
+    }
+
+    public function testGetAuthorizationUrlThrowsOnDiscoveryIssuerMismatch(): void
+    {
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage('OIDC discovery document issuer mismatch.');
+
+        $httpClient = new MockHttpClient([
+            new MockResponse((string) json_encode([
+                'issuer' => 'https://evil.example.com',
+                'authorization_endpoint' => 'https://id.example.com/discovered/authorize',
+            ]), ['response_headers' => ['content-type' => 'application/json']]),
+        ]);
+
+        $sut = $this->getSut($httpClient, ['authorization_url' => '']);
+        $sut->getAuthorizationUrl('https://kimai.local/oidc/callback', 'state', 'nonce');
+    }
+
+    public function testGetAuthorizationUrlContainsPkceChallenge(): void
+    {
+        $sut = $this->getSut(new MockHttpClient());
+
+        $verifier = 'my-code-verifier';
+        $url = $sut->getAuthorizationUrl('https://kimai.local/oidc/callback', 'state', 'nonce', $verifier);
+
+        $query = [];
+        parse_str((string) parse_url($url, PHP_URL_QUERY), $query);
+
+        $expected = rtrim(strtr(base64_encode(hash('sha256', $verifier, true)), '+/', '-_'), '=');
+        self::assertEquals($expected, $query['code_challenge']);
+        self::assertEquals('S256', $query['code_challenge_method']);
+    }
+
+    public function testFetchUserClaims(): void
+    {
+        $idToken = $this->createIdToken([
+            'nonce' => 'nonce-123',
+            'iss' => 'https://id.example.com',
+            'aud' => 'my-client-id',
+            'exp' => time() + 3600,
+        ]);
+
+        $httpClient = new MockHttpClient([
+            new MockResponse((string) json_encode([
+                'access_token' => 'the-access-token',
+                'id_token' => $idToken,
+                'token_type' => 'Bearer',
+            ]), ['response_headers' => ['content-type' => 'application/json']]),
+            new MockResponse((string) json_encode([
+                'sub' => '12345',
+                'email' => 'foo@example.com',
+                'name' => 'John Doe',
+            ]), ['response_headers' => ['content-type' => 'application/json']]),
+        ]);
+
+        $sut = $this->getSut($httpClient);
+
+        $claims = $sut->fetchUserClaims('the-code', 'https://kimai.local/oidc/callback', 'nonce-123');
+
+        self::assertEquals('12345', $claims['sub']);
+        self::assertEquals('foo@example.com', $claims['email']);
+        self::assertEquals('John Doe', $claims['name']);
+    }
+
+    public function testFetchUserClaimsSendsPkceVerifier(): void
+    {
+        $idToken = $this->createIdToken([
+            'nonce' => 'nonce-123',
+            'iss' => 'https://id.example.com',
+            'aud' => 'my-client-id',
+            'exp' => time() + 3600,
+        ]);
+
+        $tokenRequestBody = null;
+        $httpClient = new MockHttpClient(function (string $method, string $url, array $options) use ($idToken, &$tokenRequestBody) {
+            if (str_contains($url, '/token')) {
+                $tokenRequestBody = $options['body'] ?? null;
+
+                return new MockResponse((string) json_encode([
+                    'access_token' => 'the-access-token',
+                    'id_token' => $idToken,
+                ]), ['response_headers' => ['content-type' => 'application/json']]);
+            }
+
+            return new MockResponse((string) json_encode([
+                'sub' => '12345',
+            ]), ['response_headers' => ['content-type' => 'application/json']]);
+        });
+
+        $sut = $this->getSut($httpClient);
+        $sut->fetchUserClaims('the-code', 'https://kimai.local/oidc/callback', 'nonce-123', 'my-code-verifier');
+
+        self::assertIsString($tokenRequestBody);
+        self::assertStringContainsString('code_verifier=my-code-verifier', $tokenRequestBody);
+    }
+
+    public function testFetchUserClaimsThrowsOnTokenError(): void
+    {
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage('OIDC token exchange returned an error.');
+
+        $httpClient = new MockHttpClient([
+            new MockResponse((string) json_encode([
+                'error' => 'invalid_grant',
+                'error_description' => 'code expired',
+            ]), ['response_headers' => ['content-type' => 'application/json']]),
+        ]);
+
+        $sut = $this->getSut($httpClient);
+        $sut->fetchUserClaims('the-code', 'https://kimai.local/oidc/callback', 'nonce-123');
+    }
+
+    public function testFetchUserClaimsThrowsOnMissingAccessToken(): void
+    {
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage('OIDC token response did not contain an access_token.');
+
+        $httpClient = new MockHttpClient([
+            new MockResponse((string) json_encode([
+                'token_type' => 'Bearer',
+            ]), ['response_headers' => ['content-type' => 'application/json']]),
+        ]);
+
+        $sut = $this->getSut($httpClient);
+        $sut->fetchUserClaims('the-code', 'https://kimai.local/oidc/callback', 'nonce-123');
+    }
+
+    public function testFetchUserClaimsThrowsOnNonceMismatch(): void
+    {
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage('OIDC ID token nonce mismatch.');
+
+        $idToken = $this->createIdToken([
+            'nonce' => 'a-different-nonce',
+            'iss' => 'https://id.example.com',
+            'aud' => 'my-client-id',
+            'exp' => time() + 3600,
+        ]);
+
+        $httpClient = new MockHttpClient([
+            new MockResponse((string) json_encode([
+                'access_token' => 'the-access-token',
+                'id_token' => $idToken,
+            ]), ['response_headers' => ['content-type' => 'application/json']]),
+        ]);
+
+        $sut = $this->getSut($httpClient);
+        $sut->fetchUserClaims('the-code', 'https://kimai.local/oidc/callback', 'nonce-123');
+    }
+
+    public function testFetchUserClaimsThrowsOnAudienceMismatch(): void
+    {
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage('OIDC ID token audience mismatch.');
+
+        $idToken = $this->createIdToken([
+            'nonce' => 'nonce-123',
+            'iss' => 'https://id.example.com',
+            'aud' => 'a-different-client',
+            'exp' => time() + 3600,
+        ]);
+
+        $httpClient = new MockHttpClient([
+            new MockResponse((string) json_encode([
+                'access_token' => 'the-access-token',
+                'id_token' => $idToken,
+            ]), ['response_headers' => ['content-type' => 'application/json']]),
+        ]);
+
+        $sut = $this->getSut($httpClient);
+        $sut->fetchUserClaims('the-code', 'https://kimai.local/oidc/callback', 'nonce-123');
+    }
+
+    public function testFetchUserClaimsThrowsOnExpiredIdToken(): void
+    {
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage('OIDC ID token has expired.');
+
+        $idToken = $this->createIdToken([
+            'nonce' => 'nonce-123',
+            'iss' => 'https://id.example.com',
+            'aud' => 'my-client-id',
+            'exp' => time() - 60,
+        ]);
+
+        $httpClient = new MockHttpClient([
+            new MockResponse((string) json_encode([
+                'access_token' => 'the-access-token',
+                'id_token' => $idToken,
+            ]), ['response_headers' => ['content-type' => 'application/json']]),
+        ]);
+
+        $sut = $this->getSut($httpClient);
+        $sut->fetchUserClaims('the-code', 'https://kimai.local/oidc/callback', 'nonce-123');
+    }
+
+    public function testFetchUserClaimsThrowsOnMissingExpClaim(): void
+    {
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage('OIDC ID token is missing the "exp" claim.');
+
+        $idToken = $this->createIdToken([
+            'nonce' => 'nonce-123',
+            'iss' => 'https://id.example.com',
+            'aud' => 'my-client-id',
+        ]);
+
+        $httpClient = new MockHttpClient([
+            new MockResponse((string) json_encode([
+                'access_token' => 'the-access-token',
+                'id_token' => $idToken,
+            ]), ['response_headers' => ['content-type' => 'application/json']]),
+        ]);
+
+        $sut = $this->getSut($httpClient);
+        $sut->fetchUserClaims('the-code', 'https://kimai.local/oidc/callback', 'nonce-123');
+    }
+
+    public function testFetchUserClaimsThrowsOnUserInfoErrorStatus(): void
+    {
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage('OIDC userinfo request failed.');
+
+        $httpClient = new MockHttpClient([
+            new MockResponse((string) json_encode([
+                'access_token' => 'the-access-token',
+            ]), ['response_headers' => ['content-type' => 'application/json']]),
+            new MockResponse((string) json_encode(['error' => 'invalid_token']), [
+                'http_code' => 401,
+                'response_headers' => ['content-type' => 'application/json'],
+            ]),
+        ]);
+
+        $sut = $this->getSut($httpClient);
+        $sut->fetchUserClaims('the-code', 'https://kimai.local/oidc/callback', 'nonce-123');
+    }
+
+    public function testFetchUserClaimsThrowsOnEmptyUserInfo(): void
+    {
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage('OIDC userinfo response was empty.');
+
+        $httpClient = new MockHttpClient([
+            new MockResponse((string) json_encode([
+                'access_token' => 'the-access-token',
+            ]), ['response_headers' => ['content-type' => 'application/json']]),
+            new MockResponse((string) json_encode([]), ['response_headers' => ['content-type' => 'application/json']]),
+        ]);
+
+        $sut = $this->getSut($httpClient);
+        $sut->fetchUserClaims('the-code', 'https://kimai.local/oidc/callback', 'nonce-123');
+    }
+}

--- a/tests/Oidc/OidcClientTest.php
+++ b/tests/Oidc/OidcClientTest.php
@@ -357,4 +357,155 @@ class OidcClientTest extends TestCase
         $sut = $this->getSut($httpClient);
         $sut->fetchUserClaims('the-code', 'https://kimai.local/oidc/callback', 'nonce-123');
     }
+
+    public function testFetchUserClaimsThrowsWhenTokenResponseIsNotJson(): void
+    {
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage('OIDC token exchange failed.');
+
+        $httpClient = new MockHttpClient([
+            new MockResponse('not-a-json-response', ['response_headers' => ['content-type' => 'application/json']]),
+        ]);
+
+        $sut = $this->getSut($httpClient);
+        $sut->fetchUserClaims('the-code', 'https://kimai.local/oidc/callback', 'nonce-123');
+    }
+
+    public function testFetchUserClaimsThrowsOnTokenErrorStatus(): void
+    {
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage('OIDC token exchange failed.');
+
+        $httpClient = new MockHttpClient([
+            new MockResponse((string) json_encode(['message' => 'server error']), [
+                'http_code' => 500,
+                'response_headers' => ['content-type' => 'application/json'],
+            ]),
+        ]);
+
+        $sut = $this->getSut($httpClient);
+        $sut->fetchUserClaims('the-code', 'https://kimai.local/oidc/callback', 'nonce-123');
+    }
+
+    public function testFetchUserClaimsThrowsWhenUserInfoResponseIsNotJson(): void
+    {
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage('OIDC userinfo request failed.');
+
+        $httpClient = new MockHttpClient([
+            new MockResponse((string) json_encode([
+                'access_token' => 'the-access-token',
+            ]), ['response_headers' => ['content-type' => 'application/json']]),
+            new MockResponse('not-a-json-response', ['response_headers' => ['content-type' => 'application/json']]),
+        ]);
+
+        $sut = $this->getSut($httpClient);
+        $sut->fetchUserClaims('the-code', 'https://kimai.local/oidc/callback', 'nonce-123');
+    }
+
+    public function testFetchUserClaimsThrowsOnMalformedIdToken(): void
+    {
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage('OIDC ID token is malformed.');
+
+        $httpClient = new MockHttpClient([
+            new MockResponse((string) json_encode([
+                'access_token' => 'the-access-token',
+                'id_token' => 'only.two-parts',
+            ]), ['response_headers' => ['content-type' => 'application/json']]),
+        ]);
+
+        $sut = $this->getSut($httpClient);
+        $sut->fetchUserClaims('the-code', 'https://kimai.local/oidc/callback', 'nonce-123');
+    }
+
+    public function testFetchUserClaimsThrowsOnUndecodableIdToken(): void
+    {
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage('OIDC ID token could not be decoded.');
+
+        $httpClient = new MockHttpClient([
+            new MockResponse((string) json_encode([
+                'access_token' => 'the-access-token',
+                'id_token' => 'header.@@@invalid@@@.signature',
+            ]), ['response_headers' => ['content-type' => 'application/json']]),
+        ]);
+
+        $sut = $this->getSut($httpClient);
+        $sut->fetchUserClaims('the-code', 'https://kimai.local/oidc/callback', 'nonce-123');
+    }
+
+    public function testFetchUserClaimsThrowsOnIdTokenIssuerMismatch(): void
+    {
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage('OIDC ID token issuer mismatch.');
+
+        $idToken = $this->createIdToken([
+            'nonce' => 'nonce-123',
+            'iss' => 'https://evil.example.com',
+            'aud' => 'my-client-id',
+            'exp' => time() + 3600,
+        ]);
+
+        $httpClient = new MockHttpClient([
+            new MockResponse((string) json_encode([
+                'access_token' => 'the-access-token',
+                'id_token' => $idToken,
+            ]), ['response_headers' => ['content-type' => 'application/json']]),
+        ]);
+
+        $sut = $this->getSut($httpClient);
+        $sut->fetchUserClaims('the-code', 'https://kimai.local/oidc/callback', 'nonce-123');
+    }
+
+    public function testGetAuthorizationUrlThrowsOnDiscoveryErrorStatus(): void
+    {
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage('OIDC discovery request failed.');
+
+        $httpClient = new MockHttpClient([
+            new MockResponse((string) json_encode(['message' => 'down']), [
+                'http_code' => 500,
+                'response_headers' => ['content-type' => 'application/json'],
+            ]),
+        ]);
+
+        $sut = $this->getSut($httpClient, ['authorization_url' => '']);
+        $sut->getAuthorizationUrl('https://kimai.local/oidc/callback', 'state-123', 'nonce-123');
+    }
+
+    public function testGetAuthorizationUrlThrowsWhenDiscoveryEndpointMissing(): void
+    {
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage('OIDC discovery document is missing the "authorization_endpoint" endpoint.');
+
+        $httpClient = new MockHttpClient([
+            new MockResponse((string) json_encode([
+                'issuer' => 'https://id.example.com',
+            ]), ['response_headers' => ['content-type' => 'application/json']]),
+        ]);
+
+        $sut = $this->getSut($httpClient, ['authorization_url' => '']);
+        $sut->getAuthorizationUrl('https://kimai.local/oidc/callback', 'state-123', 'nonce-123');
+    }
+
+    public function testGetAuthorizationUrlCachesDiscoveryDocument(): void
+    {
+        $httpClient = new MockHttpClient([
+            new MockResponse((string) json_encode([
+                'issuer' => 'https://id.example.com',
+                'authorization_endpoint' => 'https://id.example.com/authorize',
+            ]), ['response_headers' => ['content-type' => 'application/json']]),
+        ]);
+
+        $sut = $this->getSut($httpClient, ['authorization_url' => '']);
+
+        $first = $sut->getAuthorizationUrl('https://kimai.local/oidc/callback', 'state-123', 'nonce-123');
+        $second = $sut->getAuthorizationUrl('https://kimai.local/oidc/callback', 'state-456', 'nonce-456');
+
+        self::assertStringStartsWith('https://id.example.com/authorize?', $first);
+        self::assertStringStartsWith('https://id.example.com/authorize?', $second);
+        // the discovery document must only be fetched once and then served from the cache
+        self::assertSame(1, $httpClient->getRequestsCount());
+    }
 }

--- a/tests/Oidc/OidcLoginAttributesTest.php
+++ b/tests/Oidc/OidcLoginAttributesTest.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * This file is part of the Kimai time-tracking app.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Tests\Oidc;
+
+use App\Oidc\OidcLoginAttributes;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(OidcLoginAttributes::class)]
+class OidcLoginAttributesTest extends TestCase
+{
+    public function testAttributesAccess(): void
+    {
+        $sut = new OidcLoginAttributes();
+        $sut->setAttributes([
+            'email' => 'foo@example.com',
+            'groups' => ['Sales', 'Admins'],
+        ]);
+
+        self::assertSame([
+            'email' => 'foo@example.com',
+            'groups' => ['Sales', 'Admins'],
+        ], $sut->getAttributes());
+        self::assertTrue($sut->hasAttribute('email'));
+        self::assertSame('foo@example.com', $sut->getAttribute('email'));
+        self::assertTrue($sut->hasAttribute('groups'));
+        self::assertSame(['Sales', 'Admins'], $sut->getAttribute('groups'));
+        self::assertFalse($sut->hasAttribute('missing'));
+    }
+
+    public function testGetAttributeThrowsExceptionForUnknownAttribute(): void
+    {
+        $sut = new OidcLoginAttributes();
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('This OIDC login has no "missing" attribute.');
+
+        $sut->getAttribute('missing');
+    }
+
+    public function testUserIdentifierAccess(): void
+    {
+        $sut = new OidcLoginAttributes();
+
+        self::assertNull($sut->getUserIdentifier());
+
+        $sut->setUserIdentifier('john.doe@example.com');
+        self::assertSame('john.doe@example.com', $sut->getUserIdentifier());
+
+        $sut->setUserIdentifier(null);
+        self::assertNull($sut->getUserIdentifier());
+    }
+}

--- a/tests/Oidc/OidcProviderTest.php
+++ b/tests/Oidc/OidcProviderTest.php
@@ -199,4 +199,116 @@ class OidcProviderTest extends TestCase
         $sut = $this->getOidcProvider($settings);
         $sut->findUser($token);
     }
+
+    public function testRolesMappingWithoutResetAppendsRoles(): void
+    {
+        $settings = [
+            'mapping' => [],
+            'roles' => [
+                'claim' => 'groups',
+                'resetOnLogin' => false,
+                'mapping' => [
+                    ['oidc' => 'management', 'kimai' => 'ROLE_TEAMLEAD'],
+                ],
+            ],
+        ];
+
+        $token = new OidcLoginAttributes();
+        $token->setUserIdentifier('foo7@example.com');
+        $token->setAttributes([
+            'groups' => 'management',
+        ]);
+
+        $sut = $this->getOidcProvider($settings);
+        $tokenUser = $sut->findUser($token);
+
+        self::assertContains('ROLE_TEAMLEAD', $tokenUser->getRoles());
+        self::assertContains('ROLE_USER', $tokenUser->getRoles());
+    }
+
+    public function testNonStringClaimValueIsCastToString(): void
+    {
+        $settings = [
+            'mapping' => [
+                ['oidc' => 'employee_id', 'kimai' => 'title'],
+            ],
+            'roles' => [
+                'claim' => '',
+                'mapping' => [],
+            ],
+        ];
+
+        $token = new OidcLoginAttributes();
+        $token->setUserIdentifier('foo8@example.com');
+        $token->setAttributes([
+            'employee_id' => 4711,
+        ]);
+
+        $sut = $this->getOidcProvider($settings);
+        $tokenUser = $sut->findUser($token);
+
+        self::assertSame('4711', $tokenUser->getTitle());
+    }
+
+    public function testBooleanClaimValueIsIgnored(): void
+    {
+        $settings = [
+            'mapping' => [
+                ['oidc' => 'is_admin', 'kimai' => 'title'],
+            ],
+            'roles' => [
+                'claim' => '',
+                'mapping' => [],
+            ],
+        ];
+
+        $user = new User();
+        $user->setAuth(User::AUTH_OIDC);
+        $user->setUserIdentifier('foo9@example.com');
+        $user->setTitle('unchanged');
+
+        $token = new OidcLoginAttributes();
+        $token->setUserIdentifier($user->getUserIdentifier());
+        $token->setAttributes([
+            'is_admin' => true,
+        ]);
+
+        $sut = $this->getOidcProvider($settings, $user);
+        $tokenUser = $sut->findUser($token);
+
+        self::assertSame('unchanged', $tokenUser->getTitle());
+    }
+
+    public function testFindUserThrowsAuthenticationExceptionWhenSavingFails(): void
+    {
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage('Failed creating or hydrating user');
+
+        $configuration = SystemConfigurationFactory::create(new TestConfigLoader([]), [
+            'oidc' => [
+                'mapping' => [],
+                'roles' => ['claim' => '', 'mapping' => []],
+            ],
+        ]);
+        $oidcConfig = new OidcConfiguration($configuration);
+
+        $userProvider = $this->getMockBuilder(UserProviderInterface::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['refreshUser', 'supportsClass', 'loadUserByIdentifier'])
+            ->getMock();
+        $userProvider->method('loadUserByIdentifier')->willReturn(new User());
+
+        $userService = $this->getMockBuilder(UserService::class)->disableOriginalConstructor()->getMock();
+        $userService->method('saveUser')->willThrowException(new \RuntimeException('database is down'));
+
+        $sut = new OidcProvider($userService, $userProvider, $oidcConfig, $this->createMock(LoggerInterface::class));
+
+        $token = new OidcLoginAttributes();
+        $token->setUserIdentifier('foo10@example.com');
+        $token->setAttributes([
+            'email' => 'foo@example.com',
+        ]);
+
+        $sut->findUser($token);
+    }
 }

--- a/tests/Oidc/OidcProviderTest.php
+++ b/tests/Oidc/OidcProviderTest.php
@@ -1,0 +1,202 @@
+<?php
+
+/*
+ * This file is part of the Kimai time-tracking app.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Tests\Oidc;
+
+use App\Configuration\OidcConfiguration;
+use App\Entity\User;
+use App\Oidc\OidcLoginAttributes;
+use App\Oidc\OidcProvider;
+use App\Tests\Configuration\TestConfigLoader;
+use App\Tests\Mocks\SystemConfigurationFactory;
+use App\User\UserService;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Security\Core\Exception\AuthenticationException;
+use Symfony\Component\Security\Core\User\UserProviderInterface;
+
+#[CoversClass(OidcProvider::class)]
+class OidcProviderTest extends TestCase
+{
+    protected function getOidcProvider(array $settings = null, ?User $user = null): OidcProvider
+    {
+        if (null === $settings) {
+            $settings = [
+                'mapping' => [
+                    ['oidc' => 'email', 'kimai' => 'email'],
+                    ['oidc' => 'name', 'kimai' => 'title'],
+                ],
+                'roles' => [
+                    'claim' => '',
+                    'mapping' => [],
+                ],
+            ];
+        }
+
+        $configuration = SystemConfigurationFactory::create(new TestConfigLoader([]), [
+            'oidc' => $settings,
+        ]);
+        $oidcConfig = new OidcConfiguration($configuration);
+
+        $userProvider = $this->getMockBuilder(UserProviderInterface::class)->disableOriginalConstructor();
+        $userProvider->onlyMethods(['refreshUser', 'supportsClass', 'loadUserByIdentifier']);
+        $userProvider = $userProvider->getMock();
+        $userService = $this->getMockBuilder(UserService::class)->disableOriginalConstructor()->getMock();
+        if ($user !== null) {
+            $userProvider->method('loadUserByIdentifier')->willReturn($user);
+        } else {
+            $userProvider->method('loadUserByIdentifier')->willReturn(new User());
+        }
+
+        return new OidcProvider($userService, $userProvider, $oidcConfig, $this->createMock(LoggerInterface::class));
+    }
+
+    public function testFindUserHydratesUser(): void
+    {
+        $user = new User();
+        $user->setAuth(User::AUTH_INTERNAL);
+        $user->setUserIdentifier('foo1@example.com');
+        $user->setTitle('will be overwritten');
+
+        $token = new OidcLoginAttributes();
+        $token->setUserIdentifier($user->getUserIdentifier());
+        $token->setAttributes([
+            'email' => 'foo@example.com',
+            'name' => 'John Doe',
+        ]);
+
+        $sut = $this->getOidcProvider(null, $user);
+        $tokenUser = $sut->findUser($token);
+
+        self::assertSame($user, $tokenUser);
+        self::assertTrue($tokenUser->isOidcUser());
+        self::assertEquals('foo1@example.com', $tokenUser->getUserIdentifier());
+        self::assertEquals('John Doe', $tokenUser->getTitle());
+        self::assertEquals('foo@example.com', $tokenUser->getEmail());
+    }
+
+    public function testFindUserCreatesNewUser(): void
+    {
+        $token = new OidcLoginAttributes();
+        $token->setUserIdentifier('foo2@example.com');
+        $token->setAttributes([
+            'email' => 'foo@example.com',
+            'name' => 'Jane Doe',
+        ]);
+
+        $sut = $this->getOidcProvider(null);
+        $tokenUser = $sut->findUser($token);
+
+        self::assertTrue($tokenUser->isOidcUser());
+        self::assertEquals('foo2@example.com', $tokenUser->getUserIdentifier());
+        self::assertEquals('Jane Doe', $tokenUser->getTitle());
+        self::assertEquals('foo@example.com', $tokenUser->getEmail());
+    }
+
+    public function testFindUserResolvesArrayClaims(): void
+    {
+        $token = new OidcLoginAttributes();
+        $token->setUserIdentifier('foo3@example.com');
+        $token->setAttributes([
+            'email' => ['foo@example.com'],
+            'name' => ['John Doe'],
+        ]);
+
+        $sut = $this->getOidcProvider(null);
+        $tokenUser = $sut->findUser($token);
+
+        self::assertEquals('John Doe', $tokenUser->getTitle());
+        self::assertEquals('foo@example.com', $tokenUser->getEmail());
+    }
+
+    public function testRolesMapping(): void
+    {
+        $settings = [
+            'mapping' => [],
+            'roles' => [
+                'claim' => 'groups',
+                'resetOnLogin' => true,
+                'mapping' => [
+                    ['oidc' => 'kimai-admin', 'kimai' => 'ROLE_SUPER_ADMIN'],
+                    ['oidc' => 'management', 'kimai' => 'ROLE_TEAMLEAD'],
+                ],
+            ],
+        ];
+
+        $token = new OidcLoginAttributes();
+        $token->setUserIdentifier('foo4@example.com');
+        $token->setAttributes([
+            'groups' => ['kimai-admin', 'unknown-group'],
+        ]);
+
+        $sut = $this->getOidcProvider($settings);
+        $tokenUser = $sut->findUser($token);
+
+        self::assertContains('ROLE_SUPER_ADMIN', $tokenUser->getRoles());
+        self::assertNotContains('ROLE_TEAMLEAD', $tokenUser->getRoles());
+    }
+
+    public function testMissingClaimIsIgnored(): void
+    {
+        $settings = [
+            'mapping' => [
+                ['oidc' => 'email', 'kimai' => 'email'],
+                ['oidc' => 'missing_claim', 'kimai' => 'title'],
+            ],
+            'roles' => [
+                'claim' => '',
+                'mapping' => [],
+            ],
+        ];
+
+        $user = new User();
+        $user->setAuth(User::AUTH_OIDC);
+        $user->setUserIdentifier('foo5@example.com');
+        $user->setTitle('I will not be overwritten');
+
+        $token = new OidcLoginAttributes();
+        $token->setUserIdentifier($user->getUserIdentifier());
+        $token->setAttributes([
+            'email' => 'foo@example.com',
+        ]);
+
+        $sut = $this->getOidcProvider($settings, $user);
+        $tokenUser = $sut->findUser($token);
+
+        self::assertSame($user, $tokenUser);
+        self::assertEquals('foo@example.com', $tokenUser->getEmail());
+        self::assertEquals('I will not be overwritten', $tokenUser->getTitle());
+    }
+
+    public function testInvalidMappingFieldThrowsAuthenticationException(): void
+    {
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage('Invalid OIDC mapping field: notExistingField');
+
+        $settings = [
+            'mapping' => [
+                ['oidc' => 'email', 'kimai' => 'notExistingField'],
+            ],
+            'roles' => [
+                'claim' => '',
+                'mapping' => [],
+            ],
+        ];
+
+        $token = new OidcLoginAttributes();
+        $token->setUserIdentifier('foo6@example.com');
+        $token->setAttributes([
+            'email' => 'foo@example.com',
+        ]);
+
+        $sut = $this->getOidcProvider($settings);
+        $sut->findUser($token);
+    }
+}

--- a/tests/Oidc/OidcTokenTest.php
+++ b/tests/Oidc/OidcTokenTest.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of the Kimai time-tracking app.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Tests\Oidc;
+
+use App\Entity\User;
+use App\Oidc\OidcToken;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(OidcToken::class)]
+class OidcTokenTest extends TestCase
+{
+    public function testToken(): void
+    {
+        $user = new User();
+        $user->setUserIdentifier('foo@example.com');
+
+        $sut = new OidcToken($user, 'secured_area', ['ROLE_USER', 'ROLE_ADMIN']);
+
+        self::assertSame($user, $sut->getUser());
+        self::assertEquals('foo@example.com', $sut->getUserIdentifier());
+        self::assertContains('ROLE_USER', $sut->getRoleNames());
+        self::assertContains('ROLE_ADMIN', $sut->getRoleNames());
+    }
+
+    public function testAttributes(): void
+    {
+        $user = new User();
+        $user->setUserIdentifier('foo@example.com');
+
+        $sut = new OidcToken($user, 'secured_area', $user->getRoles());
+        $sut->setAttributes(['email' => 'foo@example.com', 'groups' => ['Admins']]);
+
+        self::assertSame(['email' => 'foo@example.com', 'groups' => ['Admins']], $sut->getAttributes());
+        self::assertSame('foo@example.com', $sut->getAttribute('email'));
+    }
+}


### PR DESCRIPTION
## Description

I'd like to propose adding OpenID Connect support to Kimai, alongside the existing SAML2 integration. While SAML2 works well, OIDC has become the de-facto standard for modern identity providers. Many popular IdPs (Keycloak, Authentik, Authelia, Zitadel, Entra ID, Google, PocketID, ...) offer OIDC as their primary protocol. Supporting it would give admins many more options to connect their existing identity provider and help organizations consolidate their IT landscape by reusing one central SSO solution instead of maintaining separate credentials or an extra SAML bridge. 

The code in this PR was generated with the help of Claude Fable 5. I have reviewed it tested the full login flow against "Pocket ID" as identity provider. (https://pocket-id.org/)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] I verified that my code applies to the guidelines (`composer code-check`)
- [ ] I updated the documentation (see [here](https://github.com/kimai/www.kimai.org/tree/master/_documentation))
- [ ] I agree that this code is used in Kimai (see [license](https://github.com/kimai/kimai/blob/main/LICENSE))
