### PR TITLE
Hide sidebar in landscape print layouts

### DIFF
--- a/assets/sass/print.scss
+++ b/assets/sass/print.scss
@@ -6,7 +6,7 @@
  */
 
 @media print{
-    .sf-toolbar, .control-sidebar {
+    .sf-toolbar, .control-sidebar, .navbar-vertical {
         display: none !important;
     }
     .col-print-12{


### PR DESCRIPTION
## Description

Hide the current Tabler vertical navbar in print layouts. The existing print rule still targeted the legacy `.control-sidebar` class, which allowed the fixed sidebar to appear when a landscape print viewport crossed the `lg` breakpoint.

Closes #6016.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [ ] I verified that my code applies to the guidelines (`composer code-check`)
- [ ] I updated the documentation (see [here](https://github.com/kimai/www.kimai.org/tree/master/_documentation))
- [x] I agree that this code is used in Kimai (see [license](https://github.com/kimai/kimai/blob/main/LICENSE))

## Testing

- `npm run build`
- Verified the sidebar is hidden in Chromium print media at landscape and portrait viewport sizes while report content remains visible.
- Verified the sidebar remains visible in screen media.
