### PR TITLE
Add stable id tie-breaker to timesheet pagination order

### DIFF
--- a/src/Repository/TimesheetRepository.php
+++ b/src/Repository/TimesheetRepository.php
@@ -555,6 +555,10 @@ class TimesheetRepository extends EntityRepository
         }
 
         $qb->addOrderBy($orderBy, $query->getOrder());
+        // add the primary key as a stable tie-breaker, otherwise records sharing
+        // the same value in the sort column have no deterministic order and can be
+        // returned on more than one page (or skipped entirely) when paginating (#4881)
+        $qb->addOrderBy('t.id', $query->getOrder());
 
         $user = [];
         if (null !== $query->getUser()) {

--- a/tests/Repository/TimesheetRepositoryTest.php
+++ b/tests/Repository/TimesheetRepositoryTest.php
@@ -49,6 +49,55 @@ class TimesheetRepositoryTest extends AbstractRepositoryTestCase
         self::assertIsArray($result);
     }
 
+    public function testPaginationReturnsDistinctResultsWithIdenticalBegin(): void
+    {
+        $em = $this->getEntityManager();
+        /** @var ActivityRepository $activityRepository */
+        $activityRepository = $em->getRepository(Activity::class);
+        $activity = $activityRepository->find(1);
+        /** @var ProjectRepository $projectRepository */
+        $projectRepository = $em->getRepository(Project::class);
+        $project = $projectRepository->find(1);
+
+        $user = $this->getUserByRole(User::ROLE_USER);
+        /** @var TimesheetRepository $repository */
+        $repository = $em->getRepository(Timesheet::class);
+
+        // all records share the exact same begin, so the default "begin DESC"
+        // order alone cannot produce a stable order across paginated queries
+        $begin = new \DateTime('2015-06-15 10:00:00');
+        $end = new \DateTime('2015-06-15 11:00:00');
+        $amount = 20;
+        for ($i = 0; $i < $amount; $i++) {
+            $timesheet = new Timesheet();
+            $timesheet
+                ->setBegin(clone $begin)
+                ->setEnd(clone $end)
+                ->setUser($user)
+                ->setActivity($activity)
+                ->setProject($project);
+            $repository->save($timesheet);
+        }
+
+        $pageSize = 5;
+        $collected = [];
+        $pages = (int) ceil($amount / $pageSize);
+        for ($page = 1; $page <= $pages; $page++) {
+            $query = new TimesheetQuery();
+            $query->setUser($user);
+            $query->setPage($page);
+            $query->setPageSize($pageSize);
+            $pager = $repository->getPagerfantaForQuery($query);
+            /** @var Timesheet $timesheet */
+            foreach ($pager->getCurrentPageResults() as $timesheet) {
+                $collected[] = $timesheet->getId();
+            }
+        }
+
+        self::assertCount($amount, $collected);
+        self::assertCount($amount, array_unique($collected), 'Pagination returned the same timesheet on more than one page');
+    }
+
     public function testSave(): void
     {
         $em = $this->getEntityManager();

--- a/tests/Repository/TimesheetRepositoryTest.php
+++ b/tests/Repository/TimesheetRepositoryTest.php
@@ -76,8 +76,9 @@ class TimesheetRepositoryTest extends AbstractRepositoryTestCase
                 ->setUser($user)
                 ->setActivity($activity)
                 ->setProject($project);
-            $repository->save($timesheet);
+            $em->persist($timesheet);
         }
+        $em->flush();
 
         $pageSize = 5;
         $collected = [];


### PR DESCRIPTION
## Description

Timesheet queries are ordered only by a single, non-unique column (e.g. the default `begin DESC`, or a project/customer/activity name). Records sharing the same value in that column have no deterministic order, so with `LIMIT`/`OFFSET` pagination the database can return the same record on more than one page while skipping others. API consumers observe this as duplicate timesheet ids across consecutive pages (#4881).

Adding the primary key as a secondary sort criterion in `TimesheetRepository::getQueryBuilderForQuery()` makes the order stable across pages. This only breaks ties — it cannot change which rows match. Added an integration test that inserts 20 records with an identical `begin` and asserts pagination returns each exactly once.

Closes #4881

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I verified that my code applies to the guidelines (`composer code-check`) — php-cs-fixer + PHPStan clean, integration test fails before / passes after (verified against MariaDB 10.5)
- [ ] Documentation update — n/a
- [x] I agree that this code is used in Kimai

This change was prepared with AI assistance (Claude) and reviewed/verified by me; see the `Co-Authored-By` trailer.
