### PR TITLE
fix: validate every entry of the color choices list

### DIFF
--- a/src/Validator/Constraints/ColorChoicesValidator.php
+++ b/src/Validator/Constraints/ColorChoicesValidator.php
@@ -28,6 +28,11 @@ final class ColorChoicesValidator extends ConstraintValidator
         $colors = explode(',', $value);
 
         foreach ($colors as $color) {
+            // skip empty entries, e.g. caused by a trailing or duplicated comma
+            if (trim($color) === '') {
+                continue;
+            }
+
             $color = explode('|', $color);
             $name = $color[0];
             $code = $color[0];
@@ -49,7 +54,7 @@ final class ColorChoicesValidator extends ConstraintValidator
             }
 
             if ($name === $code) {
-                return;
+                continue;
             }
 
             $name = str_replace(['-', ' '], '', $name);

--- a/tests/Validator/Constraints/ColorChoicesValidatorTest.php
+++ b/tests/Validator/Constraints/ColorChoicesValidatorTest.php
@@ -74,6 +74,13 @@ class ColorChoicesValidatorTest extends ConstraintValidatorTestCase
         yield ['#ffdd', '#ffdd', null];
         yield ['#ffddd', '#ffddd', null];
         yield ['#ffddddd', '#ffddddd', null];
+        // an invalid entry placed *after* a valid "bare" color (where name === code) must still
+        // be reported - every comma-separated entry has to be validated, not only the ones up to
+        // the first bare color
+        yield ['#fffaaa,fffaaa', 'fffaaa', null];
+        yield ['#fffaaa,#f', '#f', null];
+        yield ['#fffaaa,string', 'string', null];
+        yield ['#fffaaa,abcdefghijklmnopqrstu|#aaabbb', null, 'abcdefghijklmnopqrstu', '#aaabbb'];
     }
 
     /**


### PR DESCRIPTION
## Description

`ColorChoicesValidator` stopped validating the color list as soon as it reached a valid "bare" color (a hex code with no custom label), because that branch used `return` instead of `continue`. Any invalid color placed after such an entry was silently accepted — e.g. `#fffaaa,fffaaa` passed validation, even though `fffaaa` on its own is correctly rejected (order-dependent: `fffaaa,#fffaaa` is still caught).

This affects the `theme.color_choices` system setting, letting an admin save malformed color codes.

Fix: use `continue` so every comma-separated entry is validated, and skip empty entries (trailing/duplicated commas) so existing valid lists like `Foo|#fffaaa,` keep passing.

Added regression cases to `ColorChoicesValidatorTest` covering an invalid hex and an over-long name placed after a valid bare color (they fail on `main`, pass with this change).

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I verified that my code applies to the guidelines — php-cs-fixer + PHPStan clean; the validator unit test fails before and passes after (29 tests OK).

Prepared with AI assistance (Claude) and reviewed/verified by me.
