### PR TITLE
fix: use 24-hour format for invoice date_process variables

### DIFF
--- a/src/Invoice/Hydrator/InvoiceItemDefaultHydrator.php
+++ b/src/Invoice/Hydrator/InvoiceItemDefaultHydrator.php
@@ -15,7 +15,7 @@ use App\Invoice\InvoiceModel;
 
 final class InvoiceItemDefaultHydrator implements InvoiceItemHydrator
 {
-    private const DATE_PROCESS_FORMAT = 'Y-m-d h:i:s';
+    private const DATE_PROCESS_FORMAT = 'Y-m-d H:i:s';
 
     private InvoiceModel $model;
 

--- a/src/Invoice/Hydrator/InvoiceModelDefaultHydrator.php
+++ b/src/Invoice/Hydrator/InvoiceModelDefaultHydrator.php
@@ -15,7 +15,7 @@ use Symfony\Component\Intl\Countries;
 
 final class InvoiceModelDefaultHydrator implements InvoiceModelHydrator
 {
-    private const DATE_PROCESS_FORMAT = 'Y-m-d h:i:s';
+    private const DATE_PROCESS_FORMAT = 'Y-m-d H:i:s';
 
     public function hydrate(InvoiceModel $model): array
     {

--- a/tests/Invoice/Hydrator/InvoiceItemDefaultHydratorTest.php
+++ b/tests/Invoice/Hydrator/InvoiceItemDefaultHydratorTest.php
@@ -48,6 +48,27 @@ class InvoiceItemDefaultHydratorTest extends TestCase
         }
     }
 
+    public function testDateProcessUsesTwentyFourHourFormat(): void
+    {
+        $model = $this->getInvoiceModel();
+
+        $sut = new InvoiceItemDefaultHydrator();
+        $sut->setInvoiceModel($model);
+
+        $dateProcessValues = [];
+        foreach ($model->getCalculator()->getEntries() as $entry) {
+            $result = $sut->hydrate($entry);
+            $dateProcessValues[] = $result['entry.date_process'];
+        }
+
+        // afternoon times must not be truncated to an ambiguous 12-hour value:
+        // with the buggy "h" format 14:00 became "02:00:00" and 18:00 became "06:00:00"
+        self::assertContains('2020-12-13 14:00:00', $dateProcessValues);
+        self::assertContains('2020-08-12 18:00:00', $dateProcessValues);
+        self::assertNotContains('2020-12-13 02:00:00', $dateProcessValues);
+        self::assertNotContains('2020-08-12 06:00:00', $dateProcessValues);
+    }
+
     public function assertEntryStructure(array $model, array $metaFields): void
     {
         $keys = [

--- a/tests/Invoice/Hydrator/InvoiceItemDefaultHydratorTest.php
+++ b/tests/Invoice/Hydrator/InvoiceItemDefaultHydratorTest.php
@@ -34,8 +34,11 @@ class InvoiceItemDefaultHydratorTest extends TestCase
             ['meta_fields' => []],
         ];
 
+        $calculator = $model->getCalculator();
+        self::assertNotNull($calculator);
+
         $i = 0;
-        foreach ($model->getCalculator()->getEntries() as $entry) {
+        foreach ($calculator->getEntries() as $entry) {
             $result = $sut->hydrate($entry);
             $exp = $expected[$i++];
             $this->assertEntryStructure($result, $exp['meta_fields']);
@@ -55,8 +58,11 @@ class InvoiceItemDefaultHydratorTest extends TestCase
         $sut = new InvoiceItemDefaultHydrator();
         $sut->setInvoiceModel($model);
 
+        $calculator = $model->getCalculator();
+        self::assertNotNull($calculator);
+
         $dateProcessValues = [];
-        foreach ($model->getCalculator()->getEntries() as $entry) {
+        foreach ($calculator->getEntries() as $entry) {
             $result = $sut->hydrate($entry);
             $dateProcessValues[] = $result['entry.date_process'];
         }

--- a/tests/Invoice/Hydrator/InvoiceModelDefaultHydratorTest.php
+++ b/tests/Invoice/Hydrator/InvoiceModelDefaultHydratorTest.php
@@ -33,17 +33,21 @@ class InvoiceModelDefaultHydratorTest extends TestCase
             $result['invoice.first']
         );
         self::assertSame(
-            $model->getInvoicePeriod()->getStart()->format('Y-m-d h:i:s'),
+            $model->getInvoicePeriod()->getStart()->format('Y-m-d H:i:s'),
             $result['invoice.first_process']
         );
+        // the _process fields must use the 24-hour format (H, not h), otherwise
+        // an afternoon time like 18:00 would be rendered as an ambiguous "06:00:00"
+        self::assertSame('2020-08-12 18:00:00', $result['invoice.first_process']);
         self::assertSame(
             $model->getFormatter()->getFormattedDateTime($model->getInvoicePeriod()->getEnd()),
             $result['invoice.last']
         );
         self::assertSame(
-            $model->getInvoicePeriod()->getEnd()->format('Y-m-d h:i:s'),
+            $model->getInvoicePeriod()->getEnd()->format('Y-m-d H:i:s'),
             $result['invoice.last_process']
         );
+        self::assertSame('2021-03-12 12:17:40', $result['invoice.last_process']);
     }
 
     public function testHydrateThrowsOnMissing(): void

--- a/tests/phpstan.neon
+++ b/tests/phpstan.neon
@@ -1337,11 +1337,6 @@ parameters:
             path: Invoice/Calculator/AbstractCalculatorTestCase.php
 
         -
-            message: "#^Cannot call method getEntries\\(\\) on App\\\\Invoice\\\\CalculatorInterface\\|null\\.$#"
-            count: 2
-            path: Invoice/Hydrator/InvoiceItemDefaultHydratorTest.php
-
-        -
             message: "#^Method App\\\\Tests\\\\Invoice\\\\Hydrator\\\\InvoiceItemDefaultHydratorTest\\:\\:assertEntryStructure\\(\\) has parameter \\$metaFields with no value type specified in iterable type array\\.$#"
             count: 1
             path: Invoice/Hydrator/InvoiceItemDefaultHydratorTest.php

--- a/tests/phpstan.neon
+++ b/tests/phpstan.neon
@@ -1338,7 +1338,7 @@ parameters:
 
         -
             message: "#^Cannot call method getEntries\\(\\) on App\\\\Invoice\\\\CalculatorInterface\\|null\\.$#"
-            count: 1
+            count: 2
             path: Invoice/Hydrator/InvoiceItemDefaultHydratorTest.php
 
         -


### PR DESCRIPTION
The `*_process` invoice template variables (`entry.date_process`, `invoice.date_process`, `invoice.due_date_process`, `invoice.first_process`, `invoice.last_process`, `query.begin_process`, `query.end_process`) are documented as machine-processable timestamps, but were formatted with the lowercase `h` (12-hour) placeholder and no AM/PM marker. Afternoon times were therefore rendered ambiguously — e.g. an entry beginning at 18:00 produced `... 06:00:00` and 14:00 produced `... 02:00:00`, making the values impossible to sort or parse correctly.

This switches `DATE_PROCESS_FORMAT` to the 24-hour `H` placeholder in both default hydrators and adds regression tests (the model hydrator test previously asserted against the same buggy `h` format, so it never caught this).

Verified locally: the new test fails before the change (`06:00:00` for an 18:00 entry) and passes after; both hydrator test files green.

Prepared with AI assistance (Claude) and reviewed/verified by me.
