### PR TITLE
Fix: team list was removed before re-adding new member

### DIFF
--- a/src/API/TeamController.php
+++ b/src/API/TeamController.php
@@ -136,16 +136,6 @@ final class TeamController extends BaseApiController
     #[Route(methods: ['PATCH'], path: '/{id}', name: 'patch_team', requirements: ['id' => '\d+'])]
     public function patchAction(Request $request, Team $team): Response
     {
-        if ($request->request->has('members')) {
-            foreach ($team->getMembers() as $member) {
-                $team->removeMember($member);
-                $this->repository->removeTeamMember($member);
-            }
-            // this fails, if we use the teamservice, because the validator
-            // complains about teams without members or teamleads
-            $this->repository->saveTeam($team);
-        }
-
         $form = $this->createForm(TeamApiEditForm::class, $team);
 
         $form->setData($team);

--- a/tests/API/TeamControllerTest.php
+++ b/tests/API/TeamControllerTest.php
@@ -237,6 +237,55 @@ class TeamControllerTest extends APIControllerBaseTestCase
         $this->assertApiCallValidationError($response, ['name', 'members.0.user']);
     }
 
+    public function testPatchActionWithInvalidMembersPayloadKeepsExistingMembers(): void
+    {
+        $client = $this->getClientForAuthenticatedUser(User::ROLE_ADMIN);
+        $data = [
+            'name' => 'foo',
+            'members' => [
+                ['user' => 1, 'teamlead' => true],
+                ['user' => 5, 'teamlead' => true],
+            ],
+        ];
+        $this->request($client, '/api/teams', 'POST', [], json_encode($data, JSON_THROW_ON_ERROR));
+        self::assertTrue($client->getResponse()->isSuccessful());
+
+        $createdContent = $client->getResponse()->getContent();
+        self::assertIsString($createdContent);
+        $created = json_decode($createdContent, true, 512, JSON_THROW_ON_ERROR);
+        self::assertIsArray($created);
+        self::assertIsNumeric($created['id']);
+
+        $teamId = (int) $created['id'];
+
+        $payload = [
+            'members' => 'invalid',
+        ];
+        $this->request($client, '/api/teams/' . $teamId, 'PATCH', [], json_encode($payload, JSON_THROW_ON_ERROR));
+
+        $response = $client->getResponse();
+        self::assertEquals(400, $response->getStatusCode());
+        $this->assertApiCallValidationError($response, ['members']);
+
+        $this->request($client, '/api/teams/' . $teamId);
+        self::assertTrue($client->getResponse()->isSuccessful());
+
+        $reloadedContent = $client->getResponse()->getContent();
+        self::assertIsString($reloadedContent);
+        $reloaded = json_decode($reloadedContent, true, 512, JSON_THROW_ON_ERROR);
+        self::assertIsArray($reloaded);
+        self::assertIsArray($reloaded['members']);
+        self::assertCount(2, $reloaded['members']);
+        self::assertIsArray($reloaded['members'][0]);
+        self::assertIsArray($reloaded['members'][0]['user']);
+        self::assertIsArray($reloaded['members'][1]);
+        self::assertIsArray($reloaded['members'][1]['user']);
+        self::assertEquals(1, $reloaded['members'][0]['user']['id']);
+        self::assertEquals(5, $reloaded['members'][1]['user']['id']);
+        self::assertTrue($reloaded['members'][0]['teamlead']);
+        self::assertTrue($reloaded['members'][1]['teamlead']);
+    }
+
     public function testDeleteAction(): void
     {
         $client = $this->getClientForAuthenticatedUser(User::ROLE_ADMIN);

--- a/tests/API/TeamControllerTest.php
+++ b/tests/API/TeamControllerTest.php
@@ -265,7 +265,7 @@ class TeamControllerTest extends APIControllerBaseTestCase
 
         $response = $client->getResponse();
         self::assertEquals(400, $response->getStatusCode());
-        $this->assertApiCallValidationError($response, ['members']);
+        $this->assertApiCallValidationError($response, [], false, ['The collection is invalid.']);
 
         $this->request($client, '/api/teams/' . $teamId);
         self::assertTrue($client->getResponse()->isSuccessful());


### PR DESCRIPTION
## Description

- API endpoint to change members remove existing members, before validating iof the new ones are valid

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] I verified that my code applies to the guidelines (`composer code-check`)
- [ ] I updated the documentation (see [here](https://github.com/kimai/www.kimai.org/tree/master/_documentation))
- [x] I agree that this code is used in Kimai (see [license](https://github.com/kimai/kimai/blob/main/LICENSE))
