### PR TITLE
[3.0] Docker: log the real client IP behind a reverse proxy

### DIFF
--- a/.docker/000-default.conf
+++ b/.docker/000-default.conf
@@ -9,6 +9,13 @@
     PassEnv MAILER_URL
     PassEnv TRUSTED_PROXIES
 
+    # Log the real client IP when running behind a reverse proxy (issue #5021).
+    # entrypoint.sh replaces the line below with RemoteIPHeader + RemoteIPTrustedProxy
+    # only when $TRUSTED_PROXIES holds valid IP/CIDR values. When it is empty the line
+    # stays an inert comment so that mod_remoteip is NOT active and clients cannot spoof
+    # their address via an X-Forwarded-For header.
+    # __KIMAI_REMOTEIP_TRUSTED_PROXY__
+
     <Directory "/opt/kimai/public">
         Require all granted
         DirectoryIndex index.php

--- a/.docker/entrypoint.sh
+++ b/.docker/entrypoint.sh
@@ -64,6 +64,27 @@ function handleStartup() {
     export APACHE_LOCK_DIR=/var/lock/apache2
     export APACHE_LOG_DIR=/var/log/apache2
     export LANG=C
+
+    # Real client IP behind a reverse proxy (issue #5021). mod_remoteip needs the
+    # trusted proxies as a static directive that cannot read env at parse time, so
+    # generate the RemoteIP* directives here from $TRUSTED_PROXIES. RemoteIPHeader is
+    # only enabled together with a trusted proxy list, otherwise mod_remoteip would
+    # trust X-Forwarded-For from ANY client and allow IP spoofing.
+    if [ -n "$TRUSTED_PROXIES" ]; then
+      APACHE_TRUSTED_PROXIES=""
+      IFS=',' read -ra _proxies <<< "$TRUSTED_PROXIES"
+      for _p in "${_proxies[@]}"; do
+        _p=$(echo "$_p" | xargs)   # trim
+        # Accept only IPv4/IPv6/CIDR tokens; skip Symfony keywords (REMOTE_ADDR, PRIVATE_SUBNETS)
+        if [[ "$_p" =~ ^[0-9a-fA-F:.]+(/[0-9]+)?$ ]]; then
+          APACHE_TRUSTED_PROXIES="$APACHE_TRUSTED_PROXIES $_p"
+        fi
+      done
+      if [ -n "$APACHE_TRUSTED_PROXIES" ]; then
+        sed -i "s|# __KIMAI_REMOTEIP_TRUSTED_PROXY__|RemoteIPHeader X-Forwarded-For\n    RemoteIPTrustedProxy${APACHE_TRUSTED_PROXIES}|" \
+          /etc/apache2/sites-available/000-default.conf
+      fi
+    fi
   elif [ -e /use_fpm ]; then
     sed -i "s/user = .*/user = $USER_ID/g" /usr/local/etc/php-fpm.d/www.conf
     sed -i "s/group = .*/group = $GROUP_ID/g" /usr/local/etc/php-fpm.d/www.conf

--- a/.docker/entrypoint.sh
+++ b/.docker/entrypoint.sh
@@ -71,17 +71,43 @@ function handleStartup() {
     # only enabled together with a trusted proxy list, otherwise mod_remoteip would
     # trust X-Forwarded-For from ANY client and allow IP spoofing.
     if [ -n "$TRUSTED_PROXIES" ]; then
-      APACHE_TRUSTED_PROXIES=""
-      IFS=',' read -ra _proxies <<< "$TRUSTED_PROXIES"
-      for _p in "${_proxies[@]}"; do
-        _p=$(echo "$_p" | xargs)   # trim
-        # Accept only IPv4/IPv6/CIDR tokens; skip Symfony keywords (REMOTE_ADDR, PRIVATE_SUBNETS)
-        if [[ "$_p" =~ ^[0-9a-fA-F:.]+(/[0-9]+)?$ ]]; then
-          APACHE_TRUSTED_PROXIES="$APACHE_TRUSTED_PROXIES $_p"
-        fi
-      done
+      # Keep only real IPv4/IPv6 addresses and CIDR ranges. Everything else is dropped:
+      # Symfony keywords (REMOTE_ADDR, PRIVATE_SUBNETS), typos, hostname-like tokens and
+      # out-of-range prefixes such as 10.0.0.0/99. RemoteIPTrustedProxy is evaluated while
+      # Apache parses its configuration, so a single value it cannot parse aborts startup.
+      APACHE_TRUSTED_PROXIES=$(php -r '
+        $valid = [];
+        foreach (explode(",", $argv[1]) as $proxy) {
+            $proxy = trim($proxy);
+            if ($proxy === "") {
+                continue;
+            }
+            $address = $proxy;
+            $prefix = null;
+            if (str_contains($address, "/")) {
+                [$address, $prefix] = explode("/", $address, 2);
+                if (!ctype_digit($prefix)) {
+                    continue;
+                }
+                $prefix = (int) $prefix;
+            }
+            if (filter_var($address, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4) !== false) {
+                $maxPrefix = 32;
+            } elseif (filter_var($address, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6) !== false) {
+                $maxPrefix = 128;
+            } else {
+                continue;
+            }
+            if ($prefix !== null && $prefix > $maxPrefix) {
+                continue;
+            }
+            $valid[] = $proxy;
+        }
+        echo implode(" ", $valid);
+      ' "$TRUSTED_PROXIES")
+
       if [ -n "$APACHE_TRUSTED_PROXIES" ]; then
-        sed -i "s|# __KIMAI_REMOTEIP_TRUSTED_PROXY__|RemoteIPHeader X-Forwarded-For\n    RemoteIPTrustedProxy${APACHE_TRUSTED_PROXIES}|" \
+        sed -i "s|# __KIMAI_REMOTEIP_TRUSTED_PROXY__|RemoteIPHeader X-Forwarded-For\n    RemoteIPTrustedProxy ${APACHE_TRUSTED_PROXIES}|" \
           /etc/apache2/sites-available/000-default.conf
       fi
     fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -170,6 +170,7 @@ RUN apt-get update && \
         unzip && \
     echo "Listen 8001" > /etc/apache2/ports.conf && \
     a2enmod rewrite && \
+    a2enmod remoteip && \
     touch /use_apache
 
 COPY .docker/000-default.conf /etc/apache2/sites-available/000-default.conf


### PR DESCRIPTION
Fixes #5021. Reworks the approach from #5071.

## Description

When the Docker image runs behind a reverse proxy, Apache logs the internal
Docker network IP (e.g. `172.20.0.1`) instead of the real client IP, which
breaks fail2ban and similar log-based tooling.

### Why the config in #5071 didn't work

The configuration in #5071 prevents Apache from starting at all:

```
AH00526: Syntax error on line 1 of macro 'settrustedproxy' ...:
RemoteIP: Error parsing IP ${%{TRUSTED_PROXIES}e} (Name or service not known error) for RemoteIPTrustedProxy
```

`RemoteIPTrustedProxy` is evaluated at **config parse time** and does not expand
runtime environment variables (`%{...}e`). Passing `%{TRUSTED_PROXIES}e` through
the macro forwards a literal string that mod_remoteip then tries to resolve as a
hostname → fatal syntax error → the container exits with code 1. (The macro
parameter also needed a `$` prefix.) That is why the PR was stuck on
"waiting for feedback": the container never boots, so nobody could confirm it.

### What this change does

- Enable **only** `mod_remoteip` (the `mod_headers`/`mod_macro` from #5071 are
  not needed).
- `entrypoint.sh` generates the `RemoteIPHeader` + `RemoteIPTrustedProxy`
  directives at container start from `$TRUSTED_PROXIES` (the same comma-separated
  variable Symfony already consumes). Only IP/CIDR tokens are accepted, so a
  Symfony keyword such as `REMOTE_ADDR` cannot break Apache startup.
- `RemoteIPHeader` is enabled **only together with** a trusted-proxy list.
  Enabling it on its own would make mod_remoteip trust `X-Forwarded-For` from
  *any* client (IP spoofing). When `TRUSTED_PROXIES` is empty, no RemoteIP
  directive is emitted and behavior is identical to today.
- Dropped the `SetEnvIf` / `RequestHeader set X-Forwarded-*` lines from #5071:
  they overwrote the incoming `X-Forwarded-For` and forced
  `X-Forwarded-Proto: https`. Symfony's `trusted_proxies` already handles
  forwarded-proto detection for the application.

## How it was verified

Tested against the same base image (`php:8.3-apache-bookworm`) with the exact
directives this PR emits. A fake client IP is sent via `X-Forwarded-For` and we
check what Apache/PHP report as the client IP.

| Case | `TRUSTED_PROXIES` | Expected | Result |
| --- | --- | --- | --- |
| Real client IP | `169.254.0.0/16,10.0.0.0/8` | `REMOTE_ADDR` = XFF client IP | ✅ `203.0.113.45`, access log shows it too |
| No env (regression + anti-spoof) | *(unset)* | XFF ignored, `REMOTE_ADDR` = peer | ✅ peer IP, XFF not trusted |
| Symfony keyword | `REMOTE_ADDR` | Apache still starts | ✅ HTTP 200 |
| Mixed valid/invalid | `REMOTE_ADDR,10.0.0.0/8,169.254.0.0/16` | only valid tokens used | ✅ `203.0.113.45` |

<details>
<summary><b>Self-contained reproduction</b> (click to expand)</summary>

```bash
mkdir kimai-remoteip-test && cd kimai-remoteip-test

cat > whoami.php <<'PHP'
<?php
header('Content-Type: text/plain');
echo 'REMOTE_ADDR=' . ($_SERVER['REMOTE_ADDR'] ?? '(none)') . "\n";
PHP

# Mirrors the vhost snippet added by this PR
cat > vhost.conf <<'CONF'
<VirtualHost *:8001>
    DocumentRoot /var/www/html
    PassEnv TRUSTED_PROXIES
    # __KIMAI_REMOTEIP_TRUSTED_PROXY__
    <Directory "/var/www/html">
        Require all granted
        DirectoryIndex index.php
    </Directory>
</VirtualHost>
ServerName localhost
CONF

# Mirrors the entrypoint.sh block added by this PR
cat > entrypoint.sh <<'SH'
#!/bin/bash
set -e
if [ -n "$TRUSTED_PROXIES" ]; then
  P=""
  IFS=',' read -ra proxies <<< "$TRUSTED_PROXIES"
  for p in "${proxies[@]}"; do
    p=$(echo "$p" | xargs)
    if [[ "$p" =~ ^[0-9a-fA-F:.]+(/[0-9]+)?$ ]]; then P="$P $p"; fi
  done
  if [ -n "$P" ]; then
    sed -i "s|# __KIMAI_REMOTEIP_TRUSTED_PROXY__|RemoteIPHeader X-Forwarded-For\n    RemoteIPTrustedProxy${P}|" \
      /etc/apache2/sites-available/000-default.conf
  fi
fi
source /etc/apache2/envvars; exec /usr/sbin/apache2 -D FOREGROUND
SH

cat > Dockerfile <<'DOCKER'
FROM php:8.3-apache-bookworm
RUN echo "Listen 8001" > /etc/apache2/ports.conf && a2enmod rewrite && a2enmod remoteip
COPY whoami.php /var/www/html/whoami.php
COPY vhost.conf /etc/apache2/sites-available/000-default.conf
COPY entrypoint.sh /entrypoint.sh
RUN chmod +x /entrypoint.sh
ENTRYPOINT ["/entrypoint.sh"]
DOCKER

docker build -t kimai-remoteip-test .

# 1) Behind a trusted proxy -> real client IP is used
docker run -d --rm --name t1 -p 8090:8001 -e TRUSTED_PROXIES=169.254.0.0/16,10.0.0.0/8 kimai-remoteip-test
curl -s -H "X-Forwarded-For: 203.0.113.45" http://localhost:8090/whoami.php   # REMOTE_ADDR=203.0.113.45
docker logs t1 | grep whoami                                                  # access log shows 203.0.113.45
docker stop t1

# 2) No TRUSTED_PROXIES -> XFF is ignored (no spoofing, unchanged behavior)
docker run -d --rm --name t2 -p 8091:8001 kimai-remoteip-test
curl -s -H "X-Forwarded-For: 203.0.113.45" http://localhost:8091/whoami.php   # REMOTE_ADDR = real peer, NOT 203.0.113.45
docker stop t2

# 3) Symfony keyword value -> Apache still starts
docker run -d --rm --name t3 -p 8092:8001 -e TRUSTED_PROXIES=REMOTE_ADDR kimai-remoteip-test
curl -s -o /dev/null -w "%{http_code}\n" http://localhost:8092/whoami.php     # 200
docker stop t3
```

</details>

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] I verified that my code applies to the guidelines (`composer code-check`)
- [x] I updated the documentation
- [x] I agree that this code is used in Kimai
