### PR TITLE
Improve validation message when contract hours exceed 24h

### DIFF
--- a/src/Validator/Constraints/MaxDuration.php
+++ b/src/Validator/Constraints/MaxDuration.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the Kimai time-tracking app.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Validator\Constraints;
+
+use Symfony\Component\Validator\Constraint;
+
+#[\Attribute(\Attribute::TARGET_PROPERTY)]
+final class MaxDuration extends Constraint
+{
+    public const MAX_DURATION_ERROR = '8b2f4a1c-7d3e-4f6b-9a05-1c8e2d7b3f49';
+
+    protected const ERROR_NAMES = [
+        self::MAX_DURATION_ERROR => 'MAX_DURATION_ERROR',
+    ];
+
+    public string $message = 'A maximum duration of {{ value }} is allowed.';
+
+    /**
+     * @param int $value the maximum allowed duration in seconds
+     * @param array<string>|null $groups
+     */
+    public function __construct(
+        public int $value,
+        ?array $groups = null,
+        mixed $payload = null,
+    ) {
+        parent::__construct([], $groups, $payload);
+    }
+}

--- a/src/Validator/Constraints/MaxDuration.php
+++ b/src/Validator/Constraints/MaxDuration.php
@@ -28,9 +28,14 @@ final class MaxDuration extends Constraint
      */
     public function __construct(
         public int $value,
+        ?string $message = null,
         ?array $groups = null,
         mixed $payload = null,
     ) {
         parent::__construct([], $groups, $payload);
+
+        if ($message !== null) {
+            $this->message = $message;
+        }
     }
 }

--- a/src/Validator/Constraints/MaxDurationValidator.php
+++ b/src/Validator/Constraints/MaxDurationValidator.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of the Kimai time-tracking app.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Validator\Constraints;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+use Symfony\Component\Validator\Exception\UnexpectedTypeException;
+use Symfony\Component\Validator\Exception\UnexpectedValueException;
+
+final class MaxDurationValidator extends ConstraintValidator
+{
+    public function validate(mixed $value, Constraint $constraint): void
+    {
+        if (!$constraint instanceof MaxDuration) {
+            throw new UnexpectedTypeException($constraint, MaxDuration::class);
+        }
+
+        if ($value === null || $value === '') {
+            return;
+        }
+
+        if (!\is_int($value)) {
+            throw new UnexpectedValueException($value, 'int');
+        }
+
+        if ($value <= $constraint->value) {
+            return;
+        }
+
+        $duration = new \App\Utils\Duration();
+
+        $this->context->buildViolation($constraint->message)
+            ->setTranslationDomain('validators')
+            ->setParameter('{{ value }}', $duration->format($constraint->value) ?? '')
+            ->setCode(MaxDuration::MAX_DURATION_ERROR)
+            ->addViolation();
+    }
+}

--- a/src/WorkingTime/Mode/WorkingTimeModeDay.php
+++ b/src/WorkingTime/Mode/WorkingTimeModeDay.php
@@ -61,7 +61,7 @@ class WorkingTimeModeDay implements WorkingTimeMode
             'translation_domain' => 'system-configuration',
             'constraints' => [
                 new GreaterThanOrEqual(0),
-                new LessThanOrEqual(86400),
+                new LessThanOrEqual(86400, message: 'A maximum of 24 hours is allowed.'),
             ],
         ];
 

--- a/src/WorkingTime/Mode/WorkingTimeModeDay.php
+++ b/src/WorkingTime/Mode/WorkingTimeModeDay.php
@@ -11,11 +11,11 @@ namespace App\WorkingTime\Mode;
 
 use App\Entity\User;
 use App\Form\Type\DurationType;
+use App\Validator\Constraints\MaxDuration;
 use App\WorkingTime\Calculator\WorkingTimeCalculator;
 use App\WorkingTime\Calculator\WorkingTimeCalculatorDay;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Validator\Constraints\GreaterThanOrEqual;
-use Symfony\Component\Validator\Constraints\LessThanOrEqual;
 
 class WorkingTimeModeDay implements WorkingTimeMode
 {
@@ -61,7 +61,7 @@ class WorkingTimeModeDay implements WorkingTimeMode
             'translation_domain' => 'system-configuration',
             'constraints' => [
                 new GreaterThanOrEqual(0),
-                new LessThanOrEqual(86400, message: 'A maximum of 24 hours is allowed.'),
+                new MaxDuration(86400),
             ],
         ];
 

--- a/tests/Controller/ProfileControllerTest.php
+++ b/tests/Controller/ProfileControllerTest.php
@@ -582,6 +582,22 @@ class ProfileControllerTest extends AbstractControllerBaseTestCase
         self::assertFalse($client->getResponse()->isSuccessful());
     }
 
+    public function testContractActionWithTooManyHours(): void
+    {
+        $client = $this->getClientForAuthenticatedUser(User::ROLE_SUPER_ADMIN);
+        $crawler = $this->request($client, '/profile/' . UserFixtures::USERNAME_USER . '/contract');
+        $form = $crawler->filter('form[name=user_contract]')->form();
+
+        $result = $client->submit($form, [
+            'user_contract[workHoursMonday]' => '25:00',
+        ]);
+
+        self::assertTrue($client->getResponse()->isSuccessful());
+        $validationErrors = $result->filter('form[name=user_contract] div.invalid-feedback.d-block');
+        self::assertCount(1, $validationErrors);
+        self::assertSame('A maximum of 24 hours is allowed.', $validationErrors->text(null, true));
+    }
+
     public function testContractAction(): void
     {
         $client = $this->getClientForAuthenticatedUser(User::ROLE_SUPER_ADMIN);

--- a/tests/Controller/ProfileControllerTest.php
+++ b/tests/Controller/ProfileControllerTest.php
@@ -595,7 +595,7 @@ class ProfileControllerTest extends AbstractControllerBaseTestCase
         self::assertTrue($client->getResponse()->isSuccessful());
         $validationErrors = $result->filter('form[name=user_contract] div.invalid-feedback.d-block');
         self::assertCount(1, $validationErrors);
-        self::assertSame('A maximum of 24 hours is allowed.', $validationErrors->text(null, true));
+        self::assertSame('A maximum duration of 24:00 is allowed.', $validationErrors->text(null, true));
     }
 
     public function testContractAction(): void

--- a/translations/validators.en.xlf
+++ b/translations/validators.en.xlf
@@ -174,9 +174,9 @@
         <source>The field {{ field }} is required, please select a value</source>
         <target>Bitten wählen Sie einen Wert für {{ field }} aus</target>
       </trans-unit>
-      <trans-unit id="4fhT2gH" resname="A maximum of 24 hours is allowed.">
-        <source>A maximum of 24 hours is allowed.</source>
-        <target>A maximum of 24 hours is allowed.</target>
+      <trans-unit id="4fhT2gH" resname="A maximum duration of {{ value }} is allowed.">
+        <source>A maximum duration of {{ value }} is allowed.</source>
+        <target>A maximum duration of {{ value }} is allowed.</target>
       </trans-unit>
     </body>
   </file>

--- a/translations/validators.en.xlf
+++ b/translations/validators.en.xlf
@@ -174,6 +174,10 @@
         <source>The field {{ field }} is required, please select a value</source>
         <target>Bitten wählen Sie einen Wert für {{ field }} aus</target>
       </trans-unit>
+      <trans-unit id="4fhT2gH" resname="A maximum of 24 hours is allowed.">
+        <source>A maximum of 24 hours is allowed.</source>
+        <target>A maximum of 24 hours is allowed.</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>


### PR DESCRIPTION
Fixes #5277.

## Description

When configuring an employment contract in the "Hours per day" mode, entering
more than 24 hours for a single day produced a confusing validation message that
exposed the internal limit in **seconds**:

> This value should be less than or equal to 86400.

Since users enter the value as hours (e.g. `25:00`), the message is hard to
understand. This replaces it with a clear, human-readable message.

## Before / After

| Before | After |
| --- | --- |
| ![before](https://raw.githubusercontent.com/JamBalaya56562/kimai/pr-assets/screenshots/contract-24h-before.png) | ![after](https://raw.githubusercontent.com/JamBalaya56562/kimai/pr-assets/screenshots/contract-24h-after.png) |

## Changes

- New `MaxDuration` constraint with the default message
  `A maximum duration of {{ value }} is allowed.`. The validator fills `{{ value }}`
  with the configured maximum, formatted through `App\Utils\Duration`, so a single
  translation covers every maximum duration.
- `WorkingTimeModeDay`: use `new MaxDuration(86400)` instead of `LessThanOrEqual(86400)`.
- `validators.en.xlf`: add the translation unit for the new message.
- `ProfileControllerTest`: add `testContractActionWithTooManyHours` covering the message.

## How it was verified

Reproduced on a running instance (Docker image `kimai/kimai2:apache`, v2.62.0,
with this change applied): entering `25:00` for Monday in Profile → Employment
contract now shows *"A maximum duration of 24:00 is allowed."* instead of the
seconds-based message (see the screenshots above).

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [ ] I verified that my code applies to the guidelines (`composer code-check`)
- [ ] I updated the documentation
- [x] I agree that this code is used in Kimai
