### PR TITLE
Prevent PDF tables from shrinking

### DIFF
--- a/src/Pdf/MPdfConverter.php
+++ b/src/Pdf/MPdfConverter.php
@@ -131,6 +131,7 @@ final class MPdfConverter implements HtmlToPdfConverter
 
         $mpdf = new Mpdf($options, $container);
         $mpdf->creator = Constants::SOFTWARE;
+        $mpdf->shrink_tables_to_fit = 1;
 
         if (\count($associatedFiles) > 0) {
             // remove "path" so mPDF will not use file_get_contents() on local files

--- a/tests/Pdf/MPdfConverterTest.php
+++ b/tests/Pdf/MPdfConverterTest.php
@@ -38,6 +38,43 @@ class MPdfConverterTest extends KernelTestCase
         self::assertCount(2, $matches);
     }
 
+    public function testTablesAreNotShrunkToFitTheRemainingPage(): void
+    {
+        $kernel = self::bootKernel();
+        /** @var string $cacheDir */
+        $cacheDir = $kernel->getContainer()->getParameter('kernel.cache_dir');
+
+        $rows = str_repeat('<tr><td>2026-07-19</td><td>A readable timesheet description.</td></tr>', 20);
+        $html = <<<HTML
+            <div style="height: 140mm"></div>
+            <table style="page-break-inside: avoid">
+                <tr>
+                    <th>Date</th>
+                    <th>Description</th>
+                </tr>
+                {$rows}
+            </table>
+            HTML;
+
+        $sut = new MPdfConverter((new FileHelperFactory($this))->create(), $cacheDir);
+        $result = $sut->convertToPdf($html);
+
+        $content = '';
+        if (preg_match_all('/stream\r?\n(.*?)\r?\nendstream/s', $result, $streams) > 0) {
+            foreach ($streams[1] as $stream) {
+                $decoded = @gzuncompress($stream);
+                if ($decoded !== false) {
+                    $content .= $decoded;
+                }
+            }
+        }
+
+        preg_match_all('/\/F\d+\s+([0-9.]+)\s+Tf/', $content, $matches);
+
+        self::assertNotEmpty($matches[1]);
+        self::assertGreaterThanOrEqual(10.0, min(array_map('floatval', $matches[1])));
+    }
+
     public function testAssociatedFilesPathIsStripped(): void
     {
         $kernel = self::bootKernel();

--- a/tests/Pdf/MPdfConverterTest.php
+++ b/tests/Pdf/MPdfConverterTest.php
@@ -47,7 +47,7 @@ class MPdfConverterTest extends KernelTestCase
         $rows = str_repeat('<tr><td>2026-07-19</td><td>A readable timesheet description.</td></tr>', 20);
         $html = <<<HTML
             <div style="height: 140mm"></div>
-            <table style="page-break-inside: avoid">
+            <table style="font-size: 10pt; page-break-inside: avoid">
                 <tr>
                     <th>Date</th>
                     <th>Description</th>
@@ -72,7 +72,7 @@ class MPdfConverterTest extends KernelTestCase
         preg_match_all('/\/F\d+\s+([0-9.]+)\s+Tf/', $content, $matches);
 
         self::assertNotEmpty($matches[1]);
-        self::assertGreaterThanOrEqual(10.0, min(array_map('floatval', $matches[1])));
+        self::assertGreaterThanOrEqual(9.99, min(array_map('floatval', $matches[1])));
     }
 
     public function testAssociatedFilesPathIsStripped(): void


### PR DESCRIPTION
## Description

Prevents mPDF from shrinking PDF tables to fit the remaining space on a page. Tables now retain their configured font size and move to the next page when necessary, keeping timesheet exports readable.

The mPDF default allows tables to shrink by a factor of up to 1.4. Setting `shrink_tables_to_fit` to `1` disables that unnecessary resizing while preserving normal page breaks.

Fixes #5762

## Before and after

The same long table sample was rendered before and after the change. The updated output preserves the configured 10 pt font instead of shrinking it to about 7.27 pt.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update

## Validation

- `vendor/bin/phpunit tests/Pdf/MPdfConverterTest.php`
- `./php-cs-fixer.sh core`
- `./phpstan.sh core`
- `./phpstan.sh test`

## Checklist

- [x] I verified that this change does not introduce regressions in the affected PDF conversion path.
- [x] I added a regression test covering the reported table-shrinking behavior.
- [x] I followed the existing code style and project conventions.
- [x] I have read and understood the contribution guidelines.


| Before | After |
|:---:|:---:|
| <img width="600" alt="Before: table text shrunk to about 7.27 pt" src="https://github.com/user-attachments/assets/5f2617c5-6bf5-4bbf-a2cd-b9b45c67d56e" /> | <img width="600" alt="After: table text preserved at 10 pt" src="https://github.com/user-attachments/assets/3e68e750-2e72-4717-88fd-7da6674fda32" /> |
