### PR TITLE
Do not reject bookings that consume no budget

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -3128,7 +3128,7 @@ parameters:
             path: src/Validator/Constraints/TimesheetBudgetUsedValidator.php
 
         -
-            message: "#^Parameter \\#4 \\$duration of method App\\\\Validator\\\\Constraints\\\\TimesheetBudgetUsedValidator\\:\\:checkBudgets\\(\\) expects int, float\\|int\\|null given\\.$#"
+            message: "#^Parameter \\#4 \\$durationDelta of method App\\\\Validator\\\\Constraints\\\\TimesheetBudgetUsedValidator\\:\\:checkBudgets\\(\\) expects int, float\\|int\\|null given\\.$#"
             count: 3
             path: src/Validator/Constraints/TimesheetBudgetUsedValidator.php
 

--- a/src/Validator/Constraints/TimesheetBudgetUsedValidator.php
+++ b/src/Validator/Constraints/TimesheetBudgetUsedValidator.php
@@ -155,7 +155,7 @@ final class TimesheetBudgetUsedValidator extends ConstraintValidator
                 $activityDuration = $duration;
             }
             $stat = $this->activityStatisticService->getBudgetStatisticModel($activity, $dateTime);
-            $this->checkBudgets($constraint, $stat, $value, $activityDuration, $activityRate, 'activity');
+            $this->checkBudgets($constraint, $stat, $value, $activityDuration, $activityRate, 'activity', $duration ?? 0, $rate);
         }
 
         if (null !== ($project = $value->getProject())) {
@@ -165,7 +165,7 @@ final class TimesheetBudgetUsedValidator extends ConstraintValidator
                     $projectDuration = $duration;
                 }
                 $stat = $this->projectStatisticService->getBudgetStatisticModel($project, $dateTime);
-                $this->checkBudgets($constraint, $stat, $value, $projectDuration, $projectRate, 'project');
+                $this->checkBudgets($constraint, $stat, $value, $projectDuration, $projectRate, 'project', $duration ?? 0, $rate);
             }
             if (null !== ($customer = $project->getCustomer()) && $customer->hasBudgets()) {
                 $dateTime = $customer->isMonthlyBudget() ? $recordDate : $now;
@@ -173,18 +173,20 @@ final class TimesheetBudgetUsedValidator extends ConstraintValidator
                     $customerDuration = $duration;
                 }
                 $stat = $this->customerStatisticService->getBudgetStatisticModel($customer, $dateTime);
-                $this->checkBudgets($constraint, $stat, $value, $customerDuration, $customerRate, 'customer');
+                $this->checkBudgets($constraint, $stat, $value, $customerDuration, $customerRate, 'customer', $duration ?? 0, $rate);
             }
         }
     }
 
-    private function checkBudgets(TimesheetBudgetUsed $constraint, BudgetStatisticModel $stat, TimesheetEntity $timesheet, int $duration, float $rate, string $field): bool
+    private function checkBudgets(TimesheetBudgetUsed $constraint, BudgetStatisticModel $stat, TimesheetEntity $timesheet, int $durationDelta, float $rateDelta, string $field, int $duration, float $rate): bool
     {
-        // only check the budgets if the given record adds to the budget consumption ($rate and
-        // $duration hold the delta for updated records): entries that do not increase the used
-        // budget must not be rejected, even if the budget is already overbooked - see #6015
+        // records that do not consume any budget must not be rejected, even if the budget is
+        // already overbooked - see #6015. The guard uses the values of the validated record
+        // itself ($rate / $duration): a record with a rate of 0.00 never consumes money budget
+        // and a record without duration never consumes time budget. The deltas may not be used
+        // here, otherwise shrinking a record that still overbooks the budget would be allowed.
 
-        $fullRate = ($stat->getBudgetSpent() + $rate);
+        $fullRate = ($stat->getBudgetSpent() + $rateDelta);
 
         if ($rate > 0 && $stat->hasBudget() && $fullRate > $stat->getBudget()) {
             $this->addBudgetViolation($constraint, $timesheet, $field, $stat->getBudget(), $stat->getBudgetSpent());
@@ -192,7 +194,7 @@ final class TimesheetBudgetUsedValidator extends ConstraintValidator
             return true;
         }
 
-        $fullDuration = ($stat->getTimeBudgetSpent() + $duration);
+        $fullDuration = ($stat->getTimeBudgetSpent() + $durationDelta);
 
         if ($duration > 0 && $stat->hasTimeBudget() && $fullDuration > $stat->getTimeBudget()) {
             $this->addTimeBudgetViolation($constraint, $field, $stat->getTimeBudget(), $stat->getTimeBudgetSpent());

--- a/src/Validator/Constraints/TimesheetBudgetUsedValidator.php
+++ b/src/Validator/Constraints/TimesheetBudgetUsedValidator.php
@@ -180,9 +180,13 @@ final class TimesheetBudgetUsedValidator extends ConstraintValidator
 
     private function checkBudgets(TimesheetBudgetUsed $constraint, BudgetStatisticModel $stat, TimesheetEntity $timesheet, int $duration, float $rate, string $field): bool
     {
+        // only check the budgets if the given record adds to the budget consumption ($rate and
+        // $duration hold the delta for updated records): entries that do not increase the used
+        // budget must not be rejected, even if the budget is already overbooked - see #6015
+
         $fullRate = ($stat->getBudgetSpent() + $rate);
 
-        if ($stat->hasBudget() && $fullRate > $stat->getBudget()) {
+        if ($rate > 0 && $stat->hasBudget() && $fullRate > $stat->getBudget()) {
             $this->addBudgetViolation($constraint, $timesheet, $field, $stat->getBudget(), $stat->getBudgetSpent());
 
             return true;
@@ -190,7 +194,7 @@ final class TimesheetBudgetUsedValidator extends ConstraintValidator
 
         $fullDuration = ($stat->getTimeBudgetSpent() + $duration);
 
-        if ($stat->hasTimeBudget() && $fullDuration > $stat->getTimeBudget()) {
+        if ($duration > 0 && $stat->hasTimeBudget() && $fullDuration > $stat->getTimeBudget()) {
             $this->addTimeBudgetViolation($constraint, $field, $stat->getTimeBudget(), $stat->getTimeBudgetSpent());
 
             return true;

--- a/tests/Validator/Constraints/TimesheetBudgetUsedValidatorTest.php
+++ b/tests/Validator/Constraints/TimesheetBudgetUsedValidatorTest.php
@@ -219,6 +219,8 @@ class TimesheetBudgetUsedValidatorTest extends ConstraintValidatorTestCase
             'a_f1' => [1320, null, null, null, null, null,      null, 3600, null, null, null, null, null, null, null,       '0:22', '0:38', '1:00', 'activity',          '+3600 seconds',    ['rate' => 1.0, 'duration' => 1000]],
             'a_h1' => [7200, null, null, null, null, null,      null, 7200, null, null, null, null, null, null, null,       '2:00', '0:00', '2:00', 'activity',          '+3601 seconds',    ['rate' => 1.0, 'duration' => 3600]],
             'a_h2' => [3601, null, null, null, null, null,      null, 3600, null, null, null, null, null, null, null,       null, null, null, null,                         '+3600 seconds',    ['rate' => 1.0, 'duration' => 3601]],
+            // shrinking an entry is not enough, if the remaining total still overbooks the time budget
+            'a_h3' => [10800, null, null, null, null, null,     null, 3600, null, null, null, null, null, null, null,      '3:00', '0:00', '1:00', 'activity',          '+3600 seconds',    ['rate' => 1.0, 'duration' => 7200]],
             // lowering the rate of an existing entry must be allowed, even if the budget is already overbooked - see #6015
             'a_g0' => [null, 1002.0, null, null, null, null,    null, null, 1000.0, null, null, null, null, null, null,     null, null, null, null,                         '+3600 seconds',    ['rate' => 1.0, 'duration' => 1010]],
             'a_g1' => [null, 1002.0, null, null, null, null,    null, null, 1000.0, null, null, null, null, null, null,     null, null, null, null,                         '+3600 seconds',    ['rate' => 2.0, 'duration' => 0]],

--- a/tests/Validator/Constraints/TimesheetBudgetUsedValidatorTest.php
+++ b/tests/Validator/Constraints/TimesheetBudgetUsedValidatorTest.php
@@ -204,7 +204,11 @@ class TimesheetBudgetUsedValidatorTest extends ConstraintValidatorTestCase
             // activity: violations ----------------------------------------------------------------------
             //        previously logged                         available budgets                                           expected violation                              duration            entry currently in database
             'a_a' => [1230, null, null, null, null, null,       null, 3600, null, null, null, null, null, null, null,       '0:20', '0:39', '1:00', 'activity',          '+3600 seconds'],
-            'a_b' => [null, 1001.0, null, null, null, null,     null, null, 1000.0, null, null, null, null, null, null,     '€1,001.00', '€0.00', '€1,000.00', 'activity',  '+3600 seconds'],
+            'a_b' => [null, 900.0, null, null, null, null,      null, null, 1000.0, null, null, null, null, null, null,     '€900.00', '€100.00', '€1,000.00', 'activity',  '+3600 seconds',   [], new Rate(101.0, 0.00)],
+
+            // entries that do not consume any budget are allowed, even if the budget is already used up - see #6015
+            'a_a2' => [3601, null, null, null, null, null,      null, 3600, null, null, null, null, null, null, null,       null, null, null, null,                         '+0 seconds'],
+            'a_b2' => [null, 1001.0, null, null, null, null,    null, null, 1000.0, null, null, null, null, null, null,     null, null, null, null,                         '+3600 seconds'],
 
             // activity: no violations
             'a_c' => [1230, null, null, null, null, null,       null, null, null, null, null, null, null, null, null,       null, null, null, null,                         '+3600 seconds'],
@@ -215,7 +219,8 @@ class TimesheetBudgetUsedValidatorTest extends ConstraintValidatorTestCase
             'a_f1' => [1320, null, null, null, null, null,      null, 3600, null, null, null, null, null, null, null,       '0:22', '0:38', '1:00', 'activity',          '+3600 seconds',    ['rate' => 1.0, 'duration' => 1000]],
             'a_h1' => [7200, null, null, null, null, null,      null, 7200, null, null, null, null, null, null, null,       '2:00', '0:00', '2:00', 'activity',          '+3601 seconds',    ['rate' => 1.0, 'duration' => 3600]],
             'a_h2' => [3601, null, null, null, null, null,      null, 3600, null, null, null, null, null, null, null,       null, null, null, null,                         '+3600 seconds',    ['rate' => 1.0, 'duration' => 3601]],
-            'a_g0' => [null, 1002.0, null, null, null, null,    null, null, 1000.0, null, null, null, null, null, null,     '€1,002.00', '€0.00', '€1,000.00', 'activity',     '+3600 seconds',    ['rate' => 1.0, 'duration' => 1010]],
+            // lowering the rate of an existing entry must be allowed, even if the budget is already overbooked - see #6015
+            'a_g0' => [null, 1002.0, null, null, null, null,    null, null, 1000.0, null, null, null, null, null, null,     null, null, null, null,                         '+3600 seconds',    ['rate' => 1.0, 'duration' => 1010]],
             'a_g1' => [null, 1002.0, null, null, null, null,    null, null, 1000.0, null, null, null, null, null, null,     null, null, null, null,                         '+3600 seconds',    ['rate' => 2.0, 'duration' => 0]],
             // nothing changed => no violation
             'a_x1' => [3600, 1000.0, null, null, null, null,    null, 3600, 1000.0, null, null, null, null, null, null,     null, null, null, null,                         '+3600 seconds',    ['rate' => 1000.0, 'duration' => 3600], new Rate(1000.0, 0.00)],
@@ -228,13 +233,17 @@ class TimesheetBudgetUsedValidatorTest extends ConstraintValidatorTestCase
 
             // project: violations ----------------------------------------------------------------------
             'p_j' => [null, null, 1230, null, null, null,       null, null, null, null, 3600, null, null, null, null,       '0:20', '0:39', '1:00', 'project',           '+3600 seconds'],
-            'p_k' => [null, null, null, 1001.0, null, null,     null, null, null, null, null, 1000.0, null, null, null,     '€1,001.00', '€0.00', '€1,000.00', 'project',   '+3600 seconds'],
+            'p_k' => [null, null, null, 900.0, null, null,      null, null, null, null, null, 1000.0, null, null, null,     '€900.00', '€100.00', '€1,000.00', 'project',   '+3600 seconds',   [], new Rate(101.0, 0.00)],
+
+            // entries that do not consume any budget are allowed, even if the budget is already used up - see #6015
+            'p_k2' => [null, null, null, 1001.0, null, null,    null, null, null, null, null, 1000.0, null, null, null,     null, null, null, null,                         '+3600 seconds'],
 
             //        previously logged                         available budgets                                           expected violation                              duration            entry currently in database
             'p_f1' => [null, null, 1320, null, null, null,      null, null, null, null, 3600, null, null, null, null,       '0:22', '0:38', '1:00', 'project',           '+3600 seconds',    ['rate' => 1.0, 'duration' => 1000]],
             'p_h1' => [null, null, 7200, null, null, null,      null, null, null, null, 7200, null, null, null, null,       '2:00', '0:00', '2:00', 'project',           '+3601 seconds',    ['rate' => 1.0, 'duration' => 3600]],
             'p_h2' => [null, null, 3601, null, null, null,      null, null, null, null, 3600, null, null, null, null,       null, null, null, null,                         '+3600 seconds',    ['rate' => 1.0, 'duration' => 3601]],
-            'p_g0' => [null, null, null, 1002.0, null, null,    null, null, null, null, null, 1000.0, null, null, null,     '€1,002.00', '€0.00', '€1,000.00', 'project',      '+3600 seconds',    ['rate' => 1.0, 'duration' => 1010]],
+            // lowering the rate of an existing entry must be allowed, even if the budget is already overbooked - see #6015
+            'p_g0' => [null, null, null, 1002.0, null, null,    null, null, null, null, null, 1000.0, null, null, null,     null, null, null, null,                         '+3600 seconds',    ['rate' => 1.0, 'duration' => 1010]],
             'p_g1' => [null, null, null, 1002.0, null, null,    null, null, null, null, null, 1000.0, null, null, null,     null, null, null, null,                         '+3600 seconds',    ['rate' => 2.0, 'duration' => 0]],
 
             // project: no violations
@@ -250,13 +259,17 @@ class TimesheetBudgetUsedValidatorTest extends ConstraintValidatorTestCase
 
             // customer: violations ----------------------------------------------------------------------
             'c_v' => [null, null, null, null, 1230, null,       null, null, null, null, null, null, null, 3600, null,       '0:20', '0:39', '1:00', 'customer',          '+3600 seconds'],
-            'c_w' => [null, null, null, null, null, 1001.0,     null, null, null, null, null, null, null, null, 1000.0,     '€1,001.00', '€0.00', '€1,000.00', 'customer',  '+3600 seconds'],
+            'c_w' => [null, null, null, null, null, 900.0,      null, null, null, null, null, null, null, null, 1000.0,     '€900.00', '€100.00', '€1,000.00', 'customer',  '+3600 seconds',   [], new Rate(101.0, 0.00)],
+
+            // entries that do not consume any budget are allowed, even if the budget is already used up - see #6015
+            'c_w2' => [null, null, null, null, null, 1001.0,    null, null, null, null, null, null, null, null, 1000.0,     null, null, null, null,                         '+3600 seconds'],
 
             //        previously logged                         available budgets                                           expected violation                              duration            entry currently in database
             'c_f1' => [null, null, null, null, 1320, null,      null, null, null, null, null, null, null, 3600, null,       '0:22', '0:38', '1:00', 'customer',          '+3600 seconds',    ['rate' => 1.0, 'duration' => 1000]],
             'c_h1' => [null, null, null, null, 7200, null,      null, null, null, null, null, null, null, 7200, null,       '2:00', '0:00', '2:00', 'customer',          '+3601 seconds',    ['rate' => 1.0, 'duration' => 3600]],
             'c_h2' => [null, null, null, null, 3601, null,      null, null, null, null, null, null, null, 3600, null,       null, null, null, null,                         '+3600 seconds',    ['rate' => 1.0, 'duration' => 3601]],
-            'c_g0' => [null, null, null, null, null, 1002.0,    null, null, null, null, null, null, null, null, 1000.0,     '€1,002.00', '€0.00', '€1,000.00', 'customer',     '+3600 seconds',    ['rate' => 1.0, 'duration' => 1010]],
+            // lowering the rate of an existing entry must be allowed, even if the budget is already overbooked - see #6015
+            'c_g0' => [null, null, null, null, null, 1002.0,    null, null, null, null, null, null, null, null, 1000.0,     null, null, null, null,                         '+3600 seconds',    ['rate' => 1.0, 'duration' => 1010]],
             'c_g1' => [null, null, null, null, null, 1002.0,    null, null, null, null, null, null, null, null, 1000.0,     null, null, null, null,                         '+3600 seconds',    ['rate' => 2.0, 'duration' => 0]],
 
             // customer: no violations


### PR DESCRIPTION
## Changelog 

Fixed budget check rejecting billable entries that consume no budget (rate 0.00 / zero duration) when a budget was already overbooked ([#6015](https://github.com/kimai/kimai/issues/6015)).

Fixes #6015.

## Description

When a monetary budget is already overbooked (e.g. the budget was lowered after
entries were recorded, with "allow overbooking" disabled), the validator rejects
**every** new billable entry with *"Sorry, the budget is used up."* — even
entries with a rate of 0.00 that do not consume any budget. When the budget is
exactly used up (spent == budget) the same zero-rate entry is accepted, so the
behavior was inconsistent.

Root cause in `TimesheetBudgetUsedValidator::checkBudgets()`:

```php
$fullRate = ($stat->getBudgetSpent() + $rate);
if ($stat->hasBudget() && $fullRate > $stat->getBudget()) { // violation
```

With `spent > budget` this is true even for `$rate = 0`, so the violation is
raised although the new record adds nothing. The time budget check has the same
problem with zero-duration records, and edits that *lower* the rate/duration of
an existing entry (negative delta) were also rejected while overbooked.

## Fix

Only run the budget checks when the validated record actually increases the
consumption (`$rate` / `$duration` hold the delta for updated records):

| Scenario (budget 1000, overbooking disallowed) | Before | After |
| --- | --- | --- |
| spent 1001, new entry rate 0.00 | ❌ rejected | ✅ accepted |
| spent 3601s, time budget 3600s, new entry duration 0 | ❌ rejected | ✅ accepted |
| spent 1002, lower an existing entry from rate 1.00 to 0.00 | ❌ rejected | ✅ accepted |
| spent 900, new entry rate 101.00 | ❌ rejected | ❌ rejected (unchanged) |

Records with a zero or negative delta can never overbook a budget any further.

## Tests

- Added regression cases (`a_b2`, `p_k2`, `c_w2`): zero-rate entry against an
  overbooked budget must not raise a violation — one per activity/project/customer.
- Added `a_a2`: zero-duration entry against an exhausted time budget.
- `a_g0` / `p_g0` / `c_g0` (lowering the rate of an existing entry while
  overbooked) now expect no violation — these cases previously pinned the buggy
  behavior of #6015.
- `a_b` / `p_k` / `c_w` keep covering the "budget exceeded" violation, now with
  an entry that actually adds to the consumption (`spent 900 + rate 101 > 1000`),
  so no violation coverage is lost.

## How it was verified

Ran the updated test class against the released image (`kimai/kimai2:apache`,
PHP 8.3) with `composer install` + PHPUnit:

- **Unpatched validator + new tests: 57 tests, 7 failures** — exactly the new
  regression cases, reproducing #6015.
- **Patched validator: OK (57 tests, 71 assertions).**

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] I verified that my code applies to the guidelines (`composer code-check`)
- [x] I updated the documentation
- [x] I agree that this code is used in Kimai
