### PR TITLE
Update PhpSpreadsheet to 2.4.7

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4251,16 +4251,16 @@
         },
         {
             "name": "phpoffice/phpspreadsheet",
-            "version": "2.4.6",
+            "version": "2.4.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPOffice/PhpSpreadsheet.git",
-                "reference": "0bbef382b7d9c1dbda10c8113d564ff9159a7e79"
+                "reference": "03e65f7c3399756d77f656118f75a61e0fca23c6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPOffice/PhpSpreadsheet/zipball/0bbef382b7d9c1dbda10c8113d564ff9159a7e79",
-                "reference": "0bbef382b7d9c1dbda10c8113d564ff9159a7e79",
+                "url": "https://api.github.com/repos/PHPOffice/PhpSpreadsheet/zipball/03e65f7c3399756d77f656118f75a61e0fca23c6",
+                "reference": "03e65f7c3399756d77f656118f75a61e0fca23c6",
                 "shasum": ""
             },
             "require": {
@@ -4351,9 +4351,9 @@
             ],
             "support": {
                 "issues": "https://github.com/PHPOffice/PhpSpreadsheet/issues",
-                "source": "https://github.com/PHPOffice/PhpSpreadsheet/tree/2.4.6"
+                "source": "https://github.com/PHPOffice/PhpSpreadsheet/tree/2.4.7"
             },
-            "time": "2026-06-07T02:31:12+00:00"
+            "time": "2026-07-12T19:37:16+00:00"
         },
         {
             "name": "phpoffice/phpword",


### PR DESCRIPTION
## Summary

- Update `phpoffice/phpspreadsheet` from 2.4.6 to 2.4.7.
- Pull in the upstream security patches for CVE-2026-59931, CVE-2026-59932, and CVE-2026-59933.
- Keep the existing `^2.0` Composer constraint and all other locked dependencies unchanged.

## Why

Composer audit started reporting three high-severity advisories for PhpSpreadsheet 2.4.6. Version 2.4.7 is the patched release for the existing 2.x dependency line, so no major-version upgrade or application code change is required.

## Impact

This removes the reported spreadsheet-reader denial-of-service and `WEBSERVICE()` SSRF advisories. There are no API, database schema, authentication, or permission changes.

## Validation

- `composer validate --strict --no-check-publish`
- `composer audit --locked --abandoned=report` — no security vulnerability advisories found
- PhpSpreadsheet-related PHPUnit coverage — 51 tests, 299 assertions
- `./php-cs-fixer.sh core`

## CI notes

- `Verify lock file integrity` rejects every `.lock` change unless the PR author is `kevinpapst`, so this external dependency-update PR requires maintainer handling.
- The frontend audit failure is unrelated to this Composer-only change and is addressed separately by #6070.

Upstream advisories:

- https://github.com/advisories/GHSA-6hq5-7373-42rg
- https://github.com/advisories/GHSA-2mrg-gjxq-2gvr
- https://github.com/advisories/GHSA-xh5m-36r6-47m3