### PR TITLE
Preserve multi-select values on reload

### DIFF
--- a/assets/js/forms/KimaiFormSelect.js
+++ b/assets/js/forms/KimaiFormSelect.js
@@ -217,7 +217,7 @@ export default class KimaiFormSelect extends KimaiFormTomselectPlugin {
             console.log('Missing select: ' + selectIdentifier);
             return;
         }
-        const selectedValue = node.value;
+        const selectedValue = node.multiple ? [...node.selectedOptions].map(option => option.value) : node.value;
         // this could mean the field is required
         const allowEmpty = node.tomselect.settings.allowEmptyOption === true;
         // this means the field has no emPty option and should be pre-selected
@@ -274,7 +274,13 @@ export default class KimaiFormSelect extends KimaiFormTomselectPlugin {
         }
 
         // if available, re-select the previous selected option (mostly usable for global activities)
-        node.value = selectedValue;
+        if (Array.isArray(selectedValue)) {
+            for (const option of node.options) {
+                option.selected = selectedValue.includes(option.value);
+            }
+        } else {
+            node.value = selectedValue;
+        }
 
         // pre-select an option if it is the only available one
         if (node.value === '' || node.value === null) {
@@ -298,7 +304,8 @@ export default class KimaiFormSelect extends KimaiFormTomselectPlugin {
         }
 
         // this will update the attached javascript component
-        node.dispatchEvent(new CustomEvent('data-reloaded', {detail: node.value}));
+        const reloadedValue = node.multiple ? [...node.selectedOptions].map(option => option.value) : node.value;
+        node.dispatchEvent(new CustomEvent('data-reloaded', {detail: reloadedValue}));
         // if we don't trigger the change, the other selects won't reset
         node.dispatchEvent(new Event('change'));
     }


### PR DESCRIPTION
## Description

Fixes #4689.

API-backed multi-select fields now preserve every still-valid selected value when their options are reloaded. Single-select fields keep their existing behavior.

The previous implementation stored only `node.value` before rebuilding the options. For a multiple select, that value represents only the first selected option. The updated implementation stores `selectedOptions` as an array, restores every value that still exists after the reload, and passes the restored array to Tom Select through the `data-reloaded` event.

### User impact

Selecting another customer in a multi-customer and multi-project filter no longer removes all previously selected projects except the first one. Projects that are not present in the reloaded API result remain correctly excluded.

### Visual verification

A browser regression harness reproduced the old behavior with 1 of 3 selections preserved and verified the fix with 3 of 3 selections preserved.

| Before | After |
|:--:|:--:|
| <img width="430" height="271" alt="Before: only the first project remains selected" src="https://github.com/user-attachments/assets/56307aae-26d4-4662-8222-9ed3173e063c" /> | <img width="478" height="271" alt="After: all valid projects remain selected" src="https://github.com/user-attachments/assets/ce0e5e54-f415-4bb4-bcee-42ed16f2661f" /> |

### Validation

- Focused ESLint for `assets/js/forms/KimaiFormSelect.js`: passed after disabling the unrelated pre-existing `no-useless-assignment` finding at line 323.
- Production frontend build: passed with existing Sass deprecation warnings.
- PHP CS Fixer core check in the official Kimai Docker image: passed.
- Browser regression harness: before 1/3 selections, after 3/3 selections.
- Full `pnpm lint`: still reports 7 pre-existing errors outside this change, including the existing line 323 finding in `KimaiFormSelect.js`.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] I verified that my code applies to the guidelines (`composer code-check`)
- [ ] I updated the documentation (see [here](https://github.com/kimai/www.kimai.org/tree/master/_documentation))
- [x] I agree that this code is used in Kimai (see [license](https://github.com/kimai/kimai/blob/main/LICENSE))