### PR TITLE
Exclude non-billable entries from revenue

### DIFF
--- a/src/Controller/Reporting/AbstractUserReportController.php
+++ b/src/Controller/Reporting/AbstractUserReportController.php
@@ -68,6 +68,9 @@ abstract class AbstractUserReportController extends AbstractController
                 if (!isset($data[$projectId]['internalRate'])) {
                     $data[$projectId]['internalRate'] = 0.0;
                 }
+                if (!isset($data[$projectId]['billableRate'])) {
+                    $data[$projectId]['billableRate'] = 0.0;
+                }
                 if (!isset($data[$projectId]['activities'][$activityId]['duration'])) {
                     $data[$projectId]['activities'][$activityId]['duration'] = 0;
                 }
@@ -76,6 +79,9 @@ abstract class AbstractUserReportController extends AbstractController
                 }
                 if (!isset($data[$projectId]['activities'][$activityId]['internalRate'])) {
                     $data[$projectId]['activities'][$activityId]['internalRate'] = 0.0;
+                }
+                if (!isset($data[$projectId]['activities'][$activityId]['billableRate'])) {
+                    $data[$projectId]['activities'][$activityId]['billableRate'] = 0.0;
                 }
                 /** @var StatisticDate $date */
                 foreach ($activityValues['data']->getData() as $date) {
@@ -87,12 +93,15 @@ abstract class AbstractUserReportController extends AbstractController
                     $statisticDate->setTotalDuration($statisticDate->getTotalDuration() + $date->getTotalDuration());
                     $statisticDate->setTotalRate($statisticDate->getTotalRate() + $date->getTotalRate());
                     $statisticDate->setTotalInternalRate($statisticDate->getTotalInternalRate() + $date->getTotalInternalRate());
+                    $statisticDate->setBillableRate($statisticDate->getBillableRate() + $date->getBillableRate());
                     $data[$projectId]['duration'] = $data[$projectId]['duration'] + $date->getTotalDuration();
                     $data[$projectId]['rate'] = $data[$projectId]['rate'] + $date->getTotalRate();
                     $data[$projectId]['internalRate'] = $data[$projectId]['internalRate'] + $date->getTotalInternalRate();
+                    $data[$projectId]['billableRate'] = $data[$projectId]['billableRate'] + $date->getBillableRate();
                     $data[$projectId]['activities'][$activityId]['duration'] = $data[$projectId]['activities'][$activityId]['duration'] + $date->getTotalDuration();
                     $data[$projectId]['activities'][$activityId]['rate'] = $data[$projectId]['activities'][$activityId]['rate'] + $date->getTotalRate();
                     $data[$projectId]['activities'][$activityId]['internalRate'] = $data[$projectId]['activities'][$activityId]['internalRate'] + $date->getTotalInternalRate();
+                    $data[$projectId]['activities'][$activityId]['billableRate'] = $data[$projectId]['activities'][$activityId]['billableRate'] + $date->getBillableRate();
                 }
             }
             $data[$projectId]['data'] = $dailyProjectStatistic;
@@ -124,12 +133,14 @@ abstract class AbstractUserReportController extends AbstractController
                     'duration' => 0,
                     'rate' => 0.0,
                     'internalRate' => 0.0,
+                    'billableRate' => 0.0,
                 ];
             }
             $customers[$customerId]['projects'][$id] = $row;
             $customers[$customerId]['duration'] += $row['duration'];
             $customers[$customerId]['rate'] += $row['rate'];
             $customers[$customerId]['internalRate'] += $row['internalRate'];
+            $customers[$customerId]['billableRate'] += $row['billableRate'];
         }
 
         return $customers;

--- a/src/Reporting/CustomerMonthlyProjects/CustomerMonthlyProjectsRepository.php
+++ b/src/Reporting/CustomerMonthlyProjects/CustomerMonthlyProjectsRepository.php
@@ -38,7 +38,7 @@ final class CustomerMonthlyProjectsRepository
 
         $qb = $this->repository->createQueryBuilder('t');
         $qb
-            ->select('COALESCE(SUM(t.rate), 0) as rate')
+            ->select('COALESCE(SUM(CASE WHEN t.billable = true THEN t.rate ELSE 0 END), 0) as rate')
             ->addSelect('COALESCE(SUM(t.duration), 0) as duration')
             ->addSelect('COALESCE(SUM(t.internalRate), 0) as internalRate')
             ->addSelect('IDENTITY(t.user) as user')

--- a/templates/reporting/report_by_user_data.html.twig
+++ b/templates/reporting/report_by_user_data.html.twig
@@ -60,7 +60,7 @@
                 {% set dateKey = column.date|report_date %}
                 {% set customerTotalsDuration = customerTotalsDuration|merge({(dateKey): (customerTotalsDuration[dateKey] + column.duration)}) %}
                 {% set customerTotalsInternalRate = customerTotalsInternalRate|merge({(dateKey): (customerTotalsInternalRate[dateKey] + column.internalRate)}) %}
-                {% set customerTotalsRate = customerTotalsRate|merge({(dateKey): (customerTotalsRate[dateKey] + column.rate)}) %}
+                {% set customerTotalsRate = customerTotalsRate|merge({(dateKey): (customerTotalsRate[dateKey] + column.billableRate)}) %}
             {% endfor %}
         {% endfor %}
         <tr class="summary">
@@ -68,7 +68,7 @@
             <td class="text-center total">
                 {% if with_links %}<a href="{{ widgets.search_filter(filter_route, filter_options|merge({'customer': data.customer.id})) }}">{% endif %}
                 {% if dataType == 'rate' %}
-                    {{ data.rate|money(currency) }}
+                    {{ data.billableRate|money(currency) }}
                 {% elseif dataType == 'internalRate' %}
                     {{ data.internalRate|money(currency) }}
                 {% else %}
@@ -94,7 +94,7 @@
         {% for project in data.projects %}
             {% set absoluteDuration = absoluteDuration + project.duration %}
             {% set absoluteInternalRate = absoluteInternalRate + project.internalRate %}
-            {% set absoluteRate = absoluteRate + project.rate %}
+            {% set absoluteRate = absoluteRate + project.billableRate %}
             <tr class="project">
                 <td class="text-nowrap">
                     <strong>{{ widgets.label_project(project.project) }}</strong>
@@ -102,7 +102,7 @@
                 <td class="text-nowrap text-center total">
                     {% if with_links %}<a href="{{ widgets.search_filter(filter_route, filter_options|merge({'project': project.project.id})) }}">{% endif %}
                     {%- if dataType == 'rate' -%}
-                        {{ project.rate|money(currency) }}
+                        {{ project.billableRate|money(currency) }}
                     {%- elseif dataType == 'internalRate' -%}
                         {{ project.internalRate|money(currency) }}
                     {%- else -%}
@@ -113,10 +113,10 @@
                 {% for column in project.data.data %}
                     {% set dateKey = column.date|report_date %}
                     <td class="text-nowrap text-center day-total {% block column_classes_project %}{% endblock %}">
-                        {% if column.duration != 0 or column.rate != 0 or column.internalRate != 0 %}
+                        {% if column.duration != 0 or column.billableRate != 0 or column.internalRate != 0 %}
                             {% if dataType == 'rate' %}
-                                {% set totalsRate = totalsRate|merge({(dateKey): (totalsRate[dateKey] + column.rate)}) %}
-                                <strong>{{ column.rate|money(currency) }}</strong>
+                                {% set totalsRate = totalsRate|merge({(dateKey): (totalsRate[dateKey] + column.billableRate)}) %}
+                                <strong>{{ column.billableRate|money(currency) }}</strong>
                             {% elseif dataType == 'internalRate' %}
                                 {% set totalsInternalRate = totalsInternalRate|merge({(dateKey): (totalsInternalRate[dateKey] + column.internalRate)}) %}
                                 <strong>{{ column.internalRate|money(currency) }}</strong>
@@ -136,7 +136,7 @@
                     <td class="text-nowrap text-center">
                         {% if with_links %}<a href="{{ widgets.search_filter(filter_route, filter_options|merge({'activity': activity.activity.id})) }}">{% endif %}
                         {% if dataType == 'rate' %}
-                            {{ activity.rate|money(currency) }}
+                            {{ activity.billableRate|money(currency) }}
                         {% elseif dataType == 'internalRate' %}
                             {{ activity.internalRate|money(currency) }}
                         {% else %}
@@ -146,9 +146,9 @@
                     </td>
                     {% for column in activity.data.data %}
                         <td class="text-nowrap text-center day-total {% block column_classes_activity %}{% endblock %}">
-                            {% if column.duration != 0 or column.rate != 0 or column.internalRate != 0 %}
+                            {% if column.duration != 0 or column.billableRate != 0 or column.internalRate != 0 %}
                                 {% if dataType == 'rate' %}
-                                    {{ column.rate|money(currency) }}
+                                    {{ column.billableRate|money(currency) }}
                                 {% elseif dataType == 'internalRate' %}
                                     {{ column.internalRate|money(currency) }}
                                 {% else %}

--- a/templates/reporting/report_user_list.html.twig
+++ b/templates/reporting/report_user_list.html.twig
@@ -17,7 +17,7 @@
             <a href="{{ path(subReportRoute, {'sumType': dataType, 'date': subReportDate|report_date, 'user': userPeriod.user.id}) }}">{{ usersTotalDuration|duration(decimal) }}</a>
         {% endblock %}
         {% block rate %}
-            {{ period.totalRate|money }}
+            {{ period.billableRate|money }}
         {% endblock %}
         {% block internal_rate %}
             {{ period.totalInternalRate|money }}

--- a/templates/reporting/report_user_list_export.html.twig
+++ b/templates/reporting/report_user_list_export.html.twig
@@ -15,7 +15,7 @@
         {{ total|duration(true) }}
     {%- endblock %}
     {% block rate %}
-        {{ period.totalRate }}
+        {{ period.billableRate }}
     {% endblock %}
     {% block total_rate %}
         {{ absoluteRate }}

--- a/templates/reporting/report_user_list_monthly.html.twig
+++ b/templates/reporting/report_user_list_monthly.html.twig
@@ -27,7 +27,7 @@
         {% endblock %}
         {% block rate %}
             <a href="{{ path('report_user_month', {'sumType': dataType, 'date': create_date(period.date.format('Y') ~'-'~period.date.format('m')~'-01')|report_date, 'user': userPeriod.user.id}) }}" data-toggle="tooltip" title="{{ 'billable'|trans }}: {{ period.billableDuration|duration(decimal) }}">
-                {{ period.totalRate|money }}
+                {{ period.billableRate|money }}
             </a>
         {% endblock %}
         {% block internal_rate %}

--- a/templates/reporting/report_user_list_monthly_export.html.twig
+++ b/templates/reporting/report_user_list_monthly_export.html.twig
@@ -15,7 +15,7 @@
         {{ total|duration(true) }}
     {%- endblock %}
     {% block rate %}
-        {{ period.totalRate }}
+        {{ period.billableRate }}
     {% endblock %}
     {% block total_rate %}
         {{ absoluteRate }}

--- a/templates/reporting/user_list_period_data.html.twig
+++ b/templates/reporting/user_list_period_data.html.twig
@@ -44,12 +44,12 @@
             {% set absoluteDuration = absoluteDuration + period.totalDuration %}
             {% set usersTotalInternalRate = usersTotalInternalRate + period.totalInternalRate %}
             {% set absoluteInternalRate = absoluteInternalRate + period.totalInternalRate %}
-            {% set usersTotalRate = usersTotalRate + period.totalRate %}
-            {% set absoluteRate = absoluteRate + period.totalRate %}
+            {% set usersTotalRate = usersTotalRate + period.billableRate %}
+            {% set absoluteRate = absoluteRate + period.billableRate %}
             {% set reportDateKey = period.date|report_date %}
             {% set totalsDuration = totalsDuration|merge({(reportDateKey): (totalsDuration[reportDateKey] + period.totalDuration)}) %}
             {% set totalsInternalRate = totalsInternalRate|merge({(reportDateKey): (totalsInternalRate[reportDateKey] + period.totalInternalRate)}) %}
-            {% set totalsRate = totalsRate|merge({(reportDateKey): (totalsRate[reportDateKey] + period.totalRate)}) %}
+            {% set totalsRate = totalsRate|merge({(reportDateKey): (totalsRate[reportDateKey] + period.billableRate)}) %}
         {% endfor %}
         {% if (show_empty_rows and userPeriod.user.enabled) or usersTotalDuration != 0 %}
         <tr class="user">

--- a/tests/Controller/Reporting/AbstractUserPeriodControllerTestCase.php
+++ b/tests/Controller/Reporting/AbstractUserPeriodControllerTestCase.php
@@ -9,6 +9,7 @@
 
 namespace App\Tests\Controller\Reporting;
 
+use App\Entity\Timesheet;
 use App\Entity\User;
 use App\Tests\Controller\AbstractControllerBaseTestCase;
 use App\Tests\DataFixtures\TimesheetFixtures;
@@ -26,6 +27,21 @@ abstract class AbstractUserPeriodControllerTestCase extends AbstractControllerBa
         $fixture->setAmountRunning(10);
         $fixture->setUser($this->getUserByRole($role));
         $fixture->setStartDate(new \DateTime());
+        $this->importFixture($fixture);
+    }
+
+    protected function importRevenueFixture(User $user): void
+    {
+        $counter = 0;
+        $fixture = new TimesheetFixtures();
+        $fixture->setAmount(2);
+        $fixture->setUser($user);
+        $fixture->setFixedStartDate(new \DateTime('today 10:00'));
+        $fixture->setCallback(static function (Timesheet $timesheet) use (&$counter): void {
+            $timesheet->setRate($counter === 0 ? 100.0 : 40.0);
+            $timesheet->setBillable($counter === 0);
+            $counter++;
+        });
         $this->importFixture($fixture);
     }
 
@@ -95,5 +111,24 @@ abstract class AbstractUserPeriodControllerTestCase extends AbstractControllerBa
         self::assertEquals(0, $select->count());
         $cell = $client->getCrawler()->filterXPath("//th[contains(@class, 'reportDataTypeTitle')]");
         self::assertEquals('Total', $cell->text());
+    }
+
+    public function testRevenueExcludesNonBillableEntries(): void
+    {
+        $client = $this->getClientForAuthenticatedUser(User::ROLE_SUPER_ADMIN);
+        $user = $this->getUserByRole(User::ROLE_SUPER_ADMIN);
+        $this->importRevenueFixture($user);
+
+        $this->assertAccessIsGranted($client, \sprintf(
+            '%s?user=%s&date=%s&sumType=rate',
+            $this->getReportUrl(),
+            $user->getId(),
+            (new \DateTime())->format('Y-m-d')
+        ));
+
+        $content = $client->getResponse()->getContent();
+        self::assertIsString($content);
+        self::assertStringContainsString('100', $content);
+        self::assertStringNotContainsString('140', $content);
     }
 }

--- a/tests/Controller/Reporting/AbstractUserPeriodControllerTestCase.php
+++ b/tests/Controller/Reporting/AbstractUserPeriodControllerTestCase.php
@@ -38,7 +38,9 @@ abstract class AbstractUserPeriodControllerTestCase extends AbstractControllerBa
         $fixture->setUser($user);
         $fixture->setFixedStartDate(new \DateTime('today 10:00'));
         $fixture->setCallback(static function (Timesheet $timesheet) use (&$counter): void {
-            $timesheet->setRate($counter === 0 ? 100.0 : 40.0);
+            $rate = $counter === 0 ? 100.0 : 40.0;
+            $timesheet->setFixedRate($rate);
+            $timesheet->setRate($rate);
             $timesheet->setBillable($counter === 0);
             $counter++;
         });
@@ -126,9 +128,9 @@ abstract class AbstractUserPeriodControllerTestCase extends AbstractControllerBa
             (new \DateTime())->format('Y-m-d')
         ));
 
-        $content = $client->getResponse()->getContent();
-        self::assertIsString($content);
-        self::assertStringContainsString('100', $content);
-        self::assertStringNotContainsString('140', $content);
+        $total = $client->getCrawler()->filterXPath("//table[contains(@class, 'dataTable')]/tfoot/tr[contains(@class, 'summary')]/td[contains(concat(' ', normalize-space(@class), ' '), ' total ')]");
+        self::assertCount(1, $total);
+        self::assertMatchesRegularExpression('/\\b100(?:[.,]00)?\\b/u', $total->text());
+        self::assertDoesNotMatchRegularExpression('/\\b140(?:[.,]00)?\\b/u', $total->text());
     }
 }

--- a/tests/Controller/Reporting/AbstractUsersPeriodControllerTestCase.php
+++ b/tests/Controller/Reporting/AbstractUsersPeriodControllerTestCase.php
@@ -38,7 +38,9 @@ abstract class AbstractUsersPeriodControllerTestCase extends AbstractControllerB
         $fixture->setUser($user);
         $fixture->setFixedStartDate(new \DateTime('today 10:00'));
         $fixture->setCallback(static function (Timesheet $timesheet) use (&$counter): void {
-            $timesheet->setRate($counter === 0 ? 100.0 : 40.0);
+            $rate = $counter === 0 ? 100.0 : 40.0;
+            $timesheet->setFixedRate($rate);
+            $timesheet->setRate($rate);
             $timesheet->setBillable($counter === 0);
             $counter++;
         });
@@ -114,9 +116,9 @@ abstract class AbstractUsersPeriodControllerTestCase extends AbstractControllerB
             (new \DateTime())->format('Y-m-d')
         ));
 
-        $content = $client->getResponse()->getContent();
-        self::assertIsString($content);
-        self::assertStringContainsString('100', $content);
-        self::assertStringNotContainsString('140', $content);
+        $total = $client->getCrawler()->filterXPath("//table[contains(@class, 'dataTable')]/tfoot/tr[contains(@class, 'summary')]/td[2]");
+        self::assertCount(1, $total);
+        self::assertMatchesRegularExpression('/\\b100(?:[.,]00)?\\b/u', $total->text());
+        self::assertDoesNotMatchRegularExpression('/\\b140(?:[.,]00)?\\b/u', $total->text());
     }
 }

--- a/tests/Controller/Reporting/AbstractUsersPeriodControllerTestCase.php
+++ b/tests/Controller/Reporting/AbstractUsersPeriodControllerTestCase.php
@@ -9,6 +9,7 @@
 
 namespace App\Tests\Controller\Reporting;
 
+use App\Entity\Timesheet;
 use App\Entity\User;
 use App\Tests\Controller\AbstractControllerBaseTestCase;
 use App\Tests\DataFixtures\TimesheetFixtures;
@@ -26,6 +27,21 @@ abstract class AbstractUsersPeriodControllerTestCase extends AbstractControllerB
         $fixture->setAmountRunning(10);
         $fixture->setUser($this->getUserByRole($role));
         $fixture->setStartDate(new \DateTime());
+        $this->importFixture($fixture);
+    }
+
+    protected function importRevenueFixture(User $user): void
+    {
+        $counter = 0;
+        $fixture = new TimesheetFixtures();
+        $fixture->setAmount(2);
+        $fixture->setUser($user);
+        $fixture->setFixedStartDate(new \DateTime('today 10:00'));
+        $fixture->setCallback(static function (Timesheet $timesheet) use (&$counter): void {
+            $timesheet->setRate($counter === 0 ? 100.0 : 40.0);
+            $timesheet->setBillable($counter === 0);
+            $counter++;
+        });
         $this->importFixture($fixture);
     }
 
@@ -85,5 +101,22 @@ abstract class AbstractUsersPeriodControllerTestCase extends AbstractControllerB
         self::assertEquals('application/vnd.openxmlformats-officedocument.spreadsheetml.sheet', $response->headers->get('Content-Type'));
         self::assertStringContainsString('attachment; filename=kimai-export-users-', $response->headers->get('Content-Disposition'));
         self::assertStringContainsString('.xlsx', $response->headers->get('Content-Disposition'));
+    }
+
+    public function testRevenueExcludesNonBillableEntries(): void
+    {
+        $client = $this->getClientForAuthenticatedUser(User::ROLE_SUPER_ADMIN);
+        $this->importRevenueFixture($this->getUserByRole(User::ROLE_SUPER_ADMIN));
+
+        $this->assertAccessIsGranted($client, \sprintf(
+            '%s?date=%s&sumType=rate',
+            $this->getReportUrl(),
+            (new \DateTime())->format('Y-m-d')
+        ));
+
+        $content = $client->getResponse()->getContent();
+        self::assertIsString($content);
+        self::assertStringContainsString('100', $content);
+        self::assertStringNotContainsString('140', $content);
     }
 }

--- a/tests/Controller/Reporting/CustomerMonthlyProjectsControllerTest.php
+++ b/tests/Controller/Reporting/CustomerMonthlyProjectsControllerTest.php
@@ -10,6 +10,7 @@
 namespace App\Tests\Controller\Reporting;
 
 use App\Entity\Project;
+use App\Entity\Timesheet;
 use App\Entity\User;
 use App\Tests\Controller\AbstractControllerBaseTestCase;
 use App\Tests\DataFixtures\ActivityFixtures;
@@ -98,5 +99,55 @@ class CustomerMonthlyProjectsControllerTest extends AbstractControllerBaseTestCa
 
         self::assertEquals('application/vnd.openxmlformats-officedocument.spreadsheetml.sheet', $response->headers->get('Content-Type'));
         self::assertStringContainsString('attachment; filename=kimai-export-users-', $response->headers->get('Content-Disposition'));
+    }
+
+    public function testRevenueExcludesNonBillableEntries(): void
+    {
+        $client = $this->getClientForAuthenticatedUser(User::ROLE_ADMIN);
+
+        $customers = new CustomerFixtures();
+        $customers->setIsVisible(true);
+        $customers->setAmount(1);
+        $customers = $this->importFixture($customers);
+
+        $projects = new ProjectFixtures();
+        $projects->setCustomers($customers);
+        $projects->setAmount(1);
+        $projects->setIsVisible(true);
+        $projects->setCallback(static function (Project $project): void {
+            $project->setIsMonthlyBudget();
+        });
+        $projects = $this->importFixture($projects);
+
+        $activities = new ActivityFixtures();
+        $activities->setAmount(1);
+        $activities->setProjects($projects);
+        $activities->setIsVisible(true);
+        $activities = $this->importFixture($activities);
+
+        $counter = 0;
+        $timesheets = new TimesheetFixtures();
+        $timesheets->setAmount(2);
+        $timesheets->setActivities($activities);
+        $timesheets->setFixedStartDate(new \DateTime('today 10:00'));
+        $timesheets->setUser($this->getUserByRole(User::ROLE_TEAMLEAD));
+        $timesheets->setCallback(static function (Timesheet $timesheet) use (&$counter): void {
+            $timesheet->setRate($counter === 0 ? 100.0 : 40.0);
+            $timesheet->setBillable($counter === 0);
+            $counter++;
+        });
+        $this->importFixture($timesheets);
+
+        $customer = $customers[0];
+        self::assertNotNull($customer->getId());
+
+        $this->assertAccessIsGranted($client, \sprintf(
+            '/reporting/customer/monthly_projects/view?sumType=rate&customer=%s',
+            $customer->getId()
+        ));
+        $content = $client->getResponse()->getContent();
+        self::assertIsString($content);
+        self::assertStringContainsString('100', $content);
+        self::assertStringNotContainsString('140', $content);
     }
 }

--- a/tests/Controller/Reporting/CustomerMonthlyProjectsControllerTest.php
+++ b/tests/Controller/Reporting/CustomerMonthlyProjectsControllerTest.php
@@ -132,7 +132,9 @@ class CustomerMonthlyProjectsControllerTest extends AbstractControllerBaseTestCa
         $timesheets->setFixedStartDate(new \DateTime('today 10:00'));
         $timesheets->setUser($this->getUserByRole(User::ROLE_TEAMLEAD));
         $timesheets->setCallback(static function (Timesheet $timesheet) use (&$counter): void {
-            $timesheet->setRate($counter === 0 ? 100.0 : 40.0);
+            $rate = $counter === 0 ? 100.0 : 40.0;
+            $timesheet->setFixedRate($rate);
+            $timesheet->setRate($rate);
             $timesheet->setBillable($counter === 0);
             $counter++;
         });
@@ -145,9 +147,9 @@ class CustomerMonthlyProjectsControllerTest extends AbstractControllerBaseTestCa
             '/reporting/customer/monthly_projects/view?sumType=rate&customer=%s',
             $customer->getId()
         ));
-        $content = $client->getResponse()->getContent();
-        self::assertIsString($content);
-        self::assertStringContainsString('100', $content);
-        self::assertStringNotContainsString('140', $content);
+        $total = $client->getCrawler()->filterXPath("//table[contains(@class, 'dataTable')]/tbody/tr[not(@class='summary')][1]/th[last()]");
+        self::assertCount(1, $total);
+        self::assertMatchesRegularExpression('/\\b100(?:[.,]00)?\\b/u', $total->text());
+        self::assertDoesNotMatchRegularExpression('/\\b140(?:[.,]00)?\\b/u', $total->text());
     }
 }


### PR DESCRIPTION
## Description
Non-billable timesheet entries were included in values labeled as Revenue, even though the same reports correctly tracked their billable duration separately.

This change uses the existing billable revenue aggregation throughout the single-user and all-user week, month, and year reports, including their XLSX exports. Customer monthly projects now calculates rate with a conditional SQL sum, so project, activity, user, and export totals all exclude entries where `billable = false`.

Duration and internal price continue to include all entries.

Fixes #5920

## Visual comparison
The same report contains one billable entry worth EUR 100 and one non-billable entry worth EUR 40.

| Before | After |
| --- | --- |
| <img width="1280" alt="Revenue before: non-billable entry included in EUR 140 total" src="https://github.com/user-attachments/assets/a6e6d33d-2f48-480d-880b-b5df305ca8d0" /> | <img width="1280" alt="Revenue after: only billable EUR 100 is included" src="https://github.com/user-attachments/assets/71fbe5eb-19ec-424f-a965-7acab980afa3" /> |

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Validation
- [x] Focused PHPUnit: 65 tests, 290 assertions
- [x] Revenue regression tests: 7 tests, 29 assertions
- [x] `./php-cs-fixer.sh core`
- [x] `./phpstan.sh core`
- [x] `./phpstan.sh test`
- [x] Browser verification with billable EUR 100 and non-billable EUR 40 entries

## Checklist
- [x] I verified that my code applies to the guidelines (`composer code-check` equivalent checks listed above)
- [x] Documentation is not required because this fixes existing report calculations without changing public behavior or configuration
- [x] I agree that this code is used in Kimai (see [license](https://github.com/kimai/kimai/blob/main/LICENSE))