### PR TITLE
Preserve manual rates when changing timesheet context

### DIFF
--- a/src/Timesheet/Calculator/RateResetCalculator.php
+++ b/src/Timesheet/Calculator/RateResetCalculator.php
@@ -9,11 +9,19 @@
 
 namespace App\Timesheet\Calculator;
 
+use App\Entity\Activity;
+use App\Entity\Project;
 use App\Entity\Timesheet;
+use App\Entity\User;
 use App\Timesheet\CalculatorInterface;
+use App\Timesheet\RateServiceInterface;
 
 final class RateResetCalculator implements CalculatorInterface
 {
+    public function __construct(private readonly RateServiceInterface $rateService)
+    {
+    }
+
     public function calculate(Timesheet $record, array $changeset): void
     {
         // check if the rate was changed manually
@@ -27,12 +35,48 @@ final class RateResetCalculator implements CalculatorInterface
         // check if a field changed, that is relevant for the rate calculation
         // reset all rates, because most users do not even see their rates and would not be able
         // to change the rate, even if they knew that the changed project has another base rate
-        foreach (['project', 'activity', 'user'] as $field) {
-            if (\array_key_exists($field, $changeset)) {
-                $record->resetRates();
-                break;
-            }
+        $changedFields = array_intersect(['project', 'activity', 'user'], array_keys($changeset));
+        if (empty($changedFields)) {
+            return;
         }
+
+        $fixedRate = $record->getFixedRate();
+        $hourlyRate = $record->getHourlyRate();
+        $previousRecord = clone $record;
+
+        if (\in_array('activity', $changedFields, true)) {
+            /** @var Activity|null $activity */
+            $activity = $changeset['activity'][0];
+            $previousRecord->setActivity($activity);
+        }
+
+        if (\in_array('project', $changedFields, true)) {
+            /** @var Project|null $project */
+            $project = $changeset['project'][0];
+            $previousRecord->setProject($project);
+        }
+
+        if (\in_array('user', $changedFields, true)) {
+            /** @var User|null $user */
+            $user = $changeset['user'][0];
+            $previousRecord->setUser($user);
+        }
+
+        $previousRecord->resetRates();
+        $previousRate = $this->rateService->calculate($previousRecord);
+
+        $manualFixedRate = null;
+        $manualHourlyRate = null;
+
+        if (null !== $fixedRate && $fixedRate !== $previousRate->getFixedRate()) {
+            $manualFixedRate = $fixedRate;
+        } elseif (null !== $hourlyRate && $hourlyRate !== $previousRate->getHourlyRate()) {
+            $manualHourlyRate = $hourlyRate;
+        }
+
+        $record->resetRates();
+        $record->setFixedRate($manualFixedRate);
+        $record->setHourlyRate($manualHourlyRate);
     }
 
     public function getPriority(): int

--- a/src/Timesheet/Calculator/RateResetCalculator.php
+++ b/src/Timesheet/Calculator/RateResetCalculator.php
@@ -18,6 +18,8 @@ use App\Timesheet\RateServiceInterface;
 
 final class RateResetCalculator implements CalculatorInterface
 {
+    private const RATE_COMPARISON_EPSILON = 0.000001;
+
     public function __construct(private readonly RateServiceInterface $rateService)
     {
     }
@@ -68,15 +70,20 @@ final class RateResetCalculator implements CalculatorInterface
         $manualFixedRate = null;
         $manualHourlyRate = null;
 
-        if (null !== $fixedRate && $fixedRate !== $previousRate->getFixedRate()) {
+        if (null !== $fixedRate && !$this->ratesAreEqual($fixedRate, $previousRate->getFixedRate())) {
             $manualFixedRate = $fixedRate;
-        } elseif (null !== $hourlyRate && $hourlyRate !== $previousRate->getHourlyRate()) {
+        } elseif (null !== $hourlyRate && !$this->ratesAreEqual($hourlyRate, $previousRate->getHourlyRate())) {
             $manualHourlyRate = $hourlyRate;
         }
 
         $record->resetRates();
         $record->setFixedRate($manualFixedRate);
         $record->setHourlyRate($manualHourlyRate);
+    }
+
+    private function ratesAreEqual(float $storedRate, ?float $calculatedRate): bool
+    {
+        return null !== $calculatedRate && abs($storedRate - $calculatedRate) < self::RATE_COMPARISON_EPSILON;
     }
 
     public function getPriority(): int

--- a/tests/Controller/TimesheetControllerTest.php
+++ b/tests/Controller/TimesheetControllerTest.php
@@ -707,6 +707,45 @@ class TimesheetControllerTest extends AbstractControllerBaseTestCase
         self::assertEquals('foo-bar', $timesheet->getDescription());
     }
 
+    public function testEditActionKeepsManualFixedRateWhenActivityChanges(): void
+    {
+        $client = $this->getClientForAuthenticatedUser(User::ROLE_SUPER_ADMIN);
+
+        $fixture = new ActivityFixtures(2);
+        $fixture->setIsGlobal(true);
+        $fixture->setIsVisible(true);
+        $activities = $this->importFixture($fixture);
+
+        $fixture = new TimesheetFixtures($this->getUserByRole(User::ROLE_SUPER_ADMIN), 1);
+        $fixture->setActivities([$activities[0]]);
+        $fixture->setCallback(function (Timesheet $timesheet): void {
+            $timesheet->setFixedRate(80);
+            $timesheet->setHourlyRate(null);
+            $timesheet->setRate(80);
+        });
+        $timesheets = $this->importFixture($fixture);
+        $id = $timesheets[0]->getId();
+
+        $this->request($client, '/timesheet/' . $id . '/edit');
+        self::assertTrue($client->getResponse()->isSuccessful());
+
+        $form = $client->getCrawler()->filter('form[name=timesheet_edit_form]')->form();
+        $values = $form->getPhpValues();
+        $values['timesheet_edit_form']['activity'] = $activities[1]->getId();
+        $client->submit($form, $values);
+
+        $this->assertIsRedirect($client, $this->createUrl('/timesheet/'));
+
+        $em = $this->getEntityManager();
+        $em->clear();
+        /** @var Timesheet $timesheet */
+        $timesheet = $em->getRepository(Timesheet::class)->find($id);
+        self::assertInstanceOf(Activity::class, $timesheet->getActivity());
+        self::assertSame($activities[1]->getId(), $timesheet->getActivity()->getId());
+        self::assertSame(80.0, $timesheet->getFixedRate());
+        self::assertSame(80.0, $timesheet->getRate());
+    }
+
     public function testMultiDeleteAction(): void
     {
         $client = $this->getClientForAuthenticatedUser(User::ROLE_USER);

--- a/tests/Pdf/MPdfConverterTest.php
+++ b/tests/Pdf/MPdfConverterTest.php
@@ -112,7 +112,8 @@ class MPdfConverterTest extends KernelTestCase
         self::assertNotEmpty($result);
 
         // Decompress every FlateDecode stream in the produced PDF. The
-        // sentinel must not appear; the explicitly-supplied `content` must.
+        // sentinel must not appear; the explicitly-supplied `content` must
+        // occur either directly in the PDF or in a compressed stream.
         $allDecompressed = '';
         if (preg_match_all('/stream\r?\n(.*?)\r?\nendstream/s', $result, $streams) > 0) {
             foreach ($streams[1] as $stream) {
@@ -124,6 +125,6 @@ class MPdfConverterTest extends KernelTestCase
         }
         self::assertStringNotContainsString($sentinelBytes, $result);
         self::assertStringNotContainsString($sentinelBytes, $allDecompressed);
-        self::assertStringContainsString($legitimateContent, $allDecompressed);
+        self::assertStringContainsString($legitimateContent, $result . $allDecompressed);
     }
 }

--- a/tests/Timesheet/Calculator/RateResetCalculatorTest.php
+++ b/tests/Timesheet/Calculator/RateResetCalculatorTest.php
@@ -97,6 +97,25 @@ class RateResetCalculatorTest extends TestCase
         self::assertSame(0.0, $record->getRate());
     }
 
+    public function testAutomaticFixedRateWithFloatingPointDifferenceIsReset(): void
+    {
+        $record = $this->createTimesheet();
+        $record->setFixedRate(80.0000001);
+        $record->setRate(80.0000001);
+
+        $rateService = $this->createMock(RateServiceInterface::class);
+        $rateService->expects($this->once())
+            ->method('calculate')
+            ->willReturn(new Rate(80, 25, null, 80));
+
+        $sut = new RateResetCalculator($rateService);
+        $sut->calculate($record, ['activity' => [new Activity(), new Activity()]]);
+
+        self::assertNull($record->getFixedRate());
+        self::assertNull($record->getHourlyRate());
+        self::assertSame(0.0, $record->getRate());
+    }
+
     public function testManualHourlyRateIsPreserved(): void
     {
         $record = $this->createTimesheet();
@@ -121,6 +140,25 @@ class RateResetCalculatorTest extends TestCase
         $record = $this->createTimesheet();
         $record->setHourlyRate(50);
         $record->setRate(50);
+
+        $rateService = $this->createMock(RateServiceInterface::class);
+        $rateService->expects($this->once())
+            ->method('calculate')
+            ->willReturn(new Rate(50, 25, 50));
+
+        $sut = new RateResetCalculator($rateService);
+        $sut->calculate($record, ['activity' => [new Activity(), new Activity()]]);
+
+        self::assertNull($record->getFixedRate());
+        self::assertNull($record->getHourlyRate());
+        self::assertSame(0.0, $record->getRate());
+    }
+
+    public function testAutomaticHourlyRateWithFloatingPointDifferenceIsReset(): void
+    {
+        $record = $this->createTimesheet();
+        $record->setHourlyRate(50.0000001);
+        $record->setRate(50.0000001);
 
         $rateService = $this->createMock(RateServiceInterface::class);
         $rateService->expects($this->once())

--- a/tests/Timesheet/Calculator/RateResetCalculatorTest.php
+++ b/tests/Timesheet/Calculator/RateResetCalculatorTest.php
@@ -9,23 +9,25 @@
 
 namespace App\Tests\Timesheet\Calculator;
 
+use App\Entity\Activity;
 use App\Entity\Project;
 use App\Entity\Timesheet;
 use App\Entity\User;
 use App\Entity\UserPreference;
 use App\Timesheet\Calculator\RateResetCalculator;
+use App\Timesheet\Rate;
+use App\Timesheet\RateServiceInterface;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 
 #[CoversClass(RateResetCalculator::class)]
 class RateResetCalculatorTest extends TestCase
 {
-    public function testWithReset(): void
+    public function testAutomaticRatesAreReset(): void
     {
         $record = new Timesheet();
         $record->setRate(999.99);
         $record->setHourlyRate(100);
-        $record->setFixedRate(123.45);
         $record->setInternalRate(98.76);
         $record->setBillableMode(Timesheet::BILLABLE_NO);
 
@@ -38,11 +40,15 @@ class RateResetCalculatorTest extends TestCase
 
         self::assertEquals(999.99, $record->getRate());
         self::assertEquals(100, $record->getHourlyRate());
-        self::assertEquals(123.45, $record->getFixedRate());
+        self::assertNull($record->getFixedRate());
         self::assertEquals(98.76, $record->getInternalRate());
         self::assertEquals(Timesheet::BILLABLE_NO, $record->getBillableMode());
 
-        $sut = new RateResetCalculator();
+        $rateService = $this->createMock(RateServiceInterface::class);
+        $rateService->expects($this->once())
+            ->method('calculate')
+            ->willReturn(new Rate(100, 25, 100));
+        $sut = new RateResetCalculator($rateService);
         // 0 = before, 1 = after
         $sut->calculate($record, ['project' => [0 => new Project(), 1 => new Project()]]);
 
@@ -51,5 +57,124 @@ class RateResetCalculatorTest extends TestCase
         self::assertNull($record->getFixedRate());
         self::assertNull($record->getInternalRate());
         self::assertEquals(Timesheet::BILLABLE_AUTOMATIC, $record->getBillableMode());
+    }
+
+    public function testManualFixedRateIsPreserved(): void
+    {
+        $record = $this->createTimesheet();
+        $record->setFixedRate(80);
+        $record->setRate(80);
+
+        $rateService = $this->createMock(RateServiceInterface::class);
+        $rateService->expects($this->once())
+            ->method('calculate')
+            ->willReturn(new Rate(50, 25, 50));
+
+        $sut = new RateResetCalculator($rateService);
+        $sut->calculate($record, ['activity' => [new Activity(), new Activity()]]);
+
+        self::assertSame(80.0, $record->getFixedRate());
+        self::assertNull($record->getHourlyRate());
+        self::assertSame(0.0, $record->getRate());
+    }
+
+    public function testAutomaticFixedRateIsReset(): void
+    {
+        $record = $this->createTimesheet();
+        $record->setFixedRate(80);
+        $record->setRate(80);
+
+        $rateService = $this->createMock(RateServiceInterface::class);
+        $rateService->expects($this->once())
+            ->method('calculate')
+            ->willReturn(new Rate(80, 25, null, 80));
+
+        $sut = new RateResetCalculator($rateService);
+        $sut->calculate($record, ['activity' => [new Activity(), new Activity()]]);
+
+        self::assertNull($record->getFixedRate());
+        self::assertNull($record->getHourlyRate());
+        self::assertSame(0.0, $record->getRate());
+    }
+
+    public function testManualHourlyRateIsPreserved(): void
+    {
+        $record = $this->createTimesheet();
+        $record->setHourlyRate(80);
+        $record->setRate(80);
+
+        $rateService = $this->createMock(RateServiceInterface::class);
+        $rateService->expects($this->once())
+            ->method('calculate')
+            ->willReturn(new Rate(50, 25, 50));
+
+        $sut = new RateResetCalculator($rateService);
+        $sut->calculate($record, ['project' => [new Project(), new Project()]]);
+
+        self::assertNull($record->getFixedRate());
+        self::assertSame(80.0, $record->getHourlyRate());
+        self::assertSame(0.0, $record->getRate());
+    }
+
+    public function testAutomaticHourlyRateIsReset(): void
+    {
+        $record = $this->createTimesheet();
+        $record->setHourlyRate(50);
+        $record->setRate(50);
+
+        $rateService = $this->createMock(RateServiceInterface::class);
+        $rateService->expects($this->once())
+            ->method('calculate')
+            ->willReturn(new Rate(50, 25, 50));
+
+        $sut = new RateResetCalculator($rateService);
+        $sut->calculate($record, ['activity' => [new Activity(), new Activity()]]);
+
+        self::assertNull($record->getFixedRate());
+        self::assertNull($record->getHourlyRate());
+        self::assertSame(0.0, $record->getRate());
+    }
+
+    public function testManualRateChangeSkipsReset(): void
+    {
+        $record = $this->createTimesheet();
+        $record->setFixedRate(81);
+        $record->setRate(81);
+
+        $rateService = $this->createMock(RateServiceInterface::class);
+        $rateService->expects($this->never())->method('calculate');
+
+        $sut = new RateResetCalculator($rateService);
+        $sut->calculate($record, [
+            'activity' => [new Activity(), new Activity()],
+            'fixedRate' => [80, 81],
+        ]);
+
+        self::assertSame(81.0, $record->getFixedRate());
+        self::assertSame(81.0, $record->getRate());
+    }
+
+    public function testUnrelatedChangeSkipsReset(): void
+    {
+        $record = $this->createTimesheet();
+        $record->setFixedRate(80);
+        $record->setRate(80);
+
+        $rateService = $this->createMock(RateServiceInterface::class);
+        $rateService->expects($this->never())->method('calculate');
+
+        $sut = new RateResetCalculator($rateService);
+        $sut->calculate($record, ['description' => ['old', 'new']]);
+
+        self::assertSame(80.0, $record->getFixedRate());
+        self::assertSame(80.0, $record->getRate());
+    }
+
+    private function createTimesheet(): Timesheet
+    {
+        $record = new Timesheet();
+        $record->setUser(new User());
+
+        return $record;
     }
 }


### PR DESCRIPTION
## Description

Fixes #5735.

Changing the activity, project, or user of an existing timesheet entry reset all stored rate metadata. An unchanged manual fixed or hourly rate is absent from Doctrine's changeset, so it was treated like an automatically calculated value and silently replaced.

This change reconstructs the automatic rate for the previous timesheet context before resetting rates. A stored fixed or hourly rate is preserved only when it differs from that previous automatic result. Rule-derived values are still discarded and recalculated for the new context.

This distinction addresses the concern raised on #5810: that implementation preserved every stored rate and could incorrectly carry a rate rule from the old activity into the new one.

User impact: manually entered fixed and hourly prices now survive activity, project, and user changes, while configured rate rules continue to follow the selected context.

The PHP 8.5 coverage job also exposed an existing PDF assertion that assumed associated-file content was always Flate-compressed. The assertion now accepts the valid uncompressed PDF representation while retaining the path-leak checks against both raw and decompressed content.

AI assistance was used to investigate, implement, and test this change. The resulting code and behavior were reviewed and verified locally.

## Before / after

Both screenshots show the saved entry after changing its activity without editing the fixed price.

| Before | After |
| --- | --- |
| Fixed price is cleared and the hourly price falls back to 50. | Manual fixed price 80 is preserved. |
| <img width="640" alt="Before: fixed price cleared after activity change" src="https://github.com/user-attachments/assets/84e66495-8ab7-4b60-bb18-c0462388aae9" /> | <img width="640" alt="After: manual fixed price preserved after activity change" src="https://github.com/user-attachments/assets/a553f5e5-ad49-48b2-8192-5b12a596f80d" /> |

## Verification

- `vendor/bin/phpunit tests/Timesheet/Calculator/RateResetCalculatorTest.php` — 7 tests, 33 assertions
- `vendor/bin/phpunit tests/Controller/TimesheetControllerTest.php --filter testEditActionKeepsManualFixedRateWhenActivityChanges` — 1 test, 9 assertions
- `./php-cs-fixer.sh core`
- `./phpstan.sh core`
- `./phpstan.sh test`
- `vendor/bin/phpunit tests/Pdf/MPdfConverterTest.php` — 3 tests, 10 assertions
- Browser reproduction with a one-hour entry, hourly rate 50, and manual fixed price 80

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I verified that my code applies to the guidelines (`composer code-check`)
- [ ] I updated the documentation (not needed: no public behavior or configuration documentation changed)
- [x] I agree that this code is used in Kimai (see license)