### PR TITLE
Expose API pagination headers via CORS

### DIFF
--- a/config/packages/nelmio_cors.yaml
+++ b/config/packages/nelmio_cors.yaml
@@ -19,7 +19,7 @@ nelmio_cors:
             allow_origin: ['*']
             allow_headers: ['Content-Type', 'Authorization', 'X-AUTH-USER', 'X-AUTH-TOKEN']
             allow_methods: ['GET', 'OPTIONS', 'POST', 'PUT', 'PATCH', 'DELETE']
-            # expose_headers: ['Link']
+            expose_headers: ['X-Page', 'X-Total-Count', 'X-Total-Pages', 'X-Per-Page']
             max_age: 3600
 
 when@dev:

--- a/tests/API/StatusControllerTest.php
+++ b/tests/API/StatusControllerTest.php
@@ -70,4 +70,26 @@ class StatusControllerTest extends APIControllerBaseTestCase
         self::assertIsArray($result);
         // no asserts, as plugins are disabled in tests
     }
+
+    public function testCorsExposesPaginationHeaders(): void
+    {
+        $client = $this->getClientForAuthenticatedUser(User::ROLE_USER);
+        $client->request('GET', '/api/ping', [], [], ['HTTP_ORIGIN' => 'http://example.com']);
+
+        $response = $client->getResponse();
+        self::assertTrue($response->isSuccessful());
+
+        $expose = $response->headers->get('Access-Control-Expose-Headers');
+        self::assertNotNull($expose, 'Missing "Access-Control-Expose-Headers" response header');
+
+        // Header values are case-insensitive; the test client lowercases them
+        $exposeLower = strtolower($expose);
+        foreach (['x-page', 'x-total-count', 'x-total-pages', 'x-per-page'] as $header) {
+            self::assertStringContainsString(
+                $header,
+                $exposeLower,
+                \sprintf('Pagination header "%s" is not exposed via CORS', $header)
+            );
+        }
+    }
 }


### PR DESCRIPTION
Fixes #6073.

## Description

The API pagination headers (`X-Page`, `X-Total-Count`, `X-Total-Pages`, `X-Per-Page`) were not exposed via CORS, so browser-based clients reading the API cross-origin could not see them and could not implement pagination correctly. `expose_headers` was commented out in `config/packages/nelmio_cors.yaml`.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] I verified that my code applies to the guidelines (`composer code-check`)
- [ ] I updated the documentation (see [here](https://github.com/kimai/www.kimai.org/tree/master/_documentation))
- [x] I agree that this code is used in Kimai (see [license](https://github.com/kimai/kimai/blob/main/LICENSE))