### PR TITLE
Rename customer "Contact" field to "Contact person"

### DIFF
--- a/src/Controller/CustomerController.php
+++ b/src/Controller/CustomerController.php
@@ -85,7 +85,7 @@ final class CustomerController extends AbstractController
         $table->addColumn('number', ['class' => 'd-none w-min']);
         $table->addColumn('company', ['class' => 'd-none']);
         $table->addColumn('vat_id', ['class' => 'd-none w-min']);
-        $table->addColumn('contact', ['class' => 'd-none']);
+        $table->addColumn('contact', ['class' => 'd-none', 'title' => 'contact_person']);
         $table->addColumn('city', ['class' => 'd-none']);
         $table->addColumn('country', ['class' => 'd-none w-min']);
         $table->addColumn('language', ['class' => 'd-none w-min']);

--- a/src/Entity/Customer.php
+++ b/src/Entity/Customer.php
@@ -96,7 +96,7 @@ class Customer implements EntityWithMetaFields, EntityWithBudget, CreatedAt
     #[Assert\Length(max: 100)]
     #[Serializer\Expose]
     #[Serializer\Groups(['Customer_Entity'])]
-    #[Exporter\Expose(label: 'contact')]
+    #[Exporter\Expose(label: 'contact_person')]
     private ?string $contact = null;
     /**
      * Unstructured address, better use the fields: addressLine1-3, postcode, city, country

--- a/src/Form/CustomerEditForm.php
+++ b/src/Form/CustomerEditForm.php
@@ -72,7 +72,7 @@ class CustomerEditForm extends AbstractType
                 'required' => false,
             ])
             ->add('contact', TextType::class, [
-                'label' => 'contact',
+                'label' => 'contact_person',
                 'required' => false,
             ])
         ;

--- a/src/Form/InvoiceTemplateForm.php
+++ b/src/Form/InvoiceTemplateForm.php
@@ -39,7 +39,7 @@ final class InvoiceTemplateForm extends AbstractType
                 'label' => 'title',
             ])
             ->add('contact', TextareaType::class, [
-                'label' => 'contact',
+                'label' => 'contact_info',
                 'required' => false,
             ])
             ->add('paymentTerms', TextareaType::class, [

--- a/templates/customer/details.html.twig
+++ b/templates/customer/details.html.twig
@@ -72,7 +72,7 @@
                 {% endif %}
                 {% if customer.contact is not empty %}
                     <tr>
-                        <th>{{ 'contact'|trans }}</th>
+                        <th>{{ 'contact_person'|trans }}</th>
                         <td>{{ customer.contact }}</td>
                     </tr>
                 {% endif %}

--- a/templates/invoice/renderer/default.pdf.twig
+++ b/templates/invoice/renderer/default.pdf.twig
@@ -26,7 +26,7 @@
     <table class="footer">
         <tr>
             <td>
-                <strong>{{ 'contact'|trans }}</strong>:
+                <strong>{{ 'contact_info'|trans }}</strong>:
                 {{ invoice['template.contact']|nl2str(' – ') }}
                 <br>
                 <strong>{{ 'invoice_bank_account'|trans }}</strong>:

--- a/templates/invoice/renderer/invoice.html.twig
+++ b/templates/invoice/renderer/invoice.html.twig
@@ -169,7 +169,7 @@
                     <br>
                     <strong>{{ 'invoice_bank_account'|trans }}</strong>: {{ invoice['template.payment_details']|nl2str(' – ') }}
                     <br>
-                    <strong>{{ 'contact'|trans }}</strong>: {{ invoice['template.contact']|nl2str(' – ') }}
+                    <strong>{{ 'contact_info'|trans }}</strong>: {{ invoice['template.contact']|nl2str(' – ') }}
                 </p>
             </footer>
 

--- a/templates/invoice/renderer/service-date.pdf.twig
+++ b/templates/invoice/renderer/service-date.pdf.twig
@@ -52,7 +52,7 @@
                 {{ invoice['template.payment_details']|nl2br }}
             </td>
             <td class="text-right" style="width: 33%">
-                <strong>{{ 'contact'|trans }}</strong>
+                <strong>{{ 'contact_info'|trans }}</strong>
                 <br>
                 {{ invoice['template.contact']|nl2br }}
             </td>

--- a/tests/Entity/CustomerTest.php
+++ b/tests/Entity/CustomerTest.php
@@ -270,7 +270,7 @@ zip 12345 looney toon', $sut->getFormattedAddress());
             ['number', 'string'],
             ['vat_id', 'string'],
             ['address', 'string'],
-            ['contact', 'string'],
+            ['contact_person', 'string'],
             ['email', 'string'],
             ['phone', 'string'],
             ['mobile', 'string'],

--- a/translations/messages.ar.xlf
+++ b/translations/messages.ar.xlf
@@ -2110,6 +2110,10 @@
         <source>assign_timesheets</source>
         <target state="translated">أسنِد جداول الزمنية</target>
       </trans-unit>
+      <trans-unit id="ZwBNTZ." resname="contact_info">
+        <source>contact_info</source>
+        <target state="translated">للاتصال</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/translations/messages.bg.xlf
+++ b/translations/messages.bg.xlf
@@ -1970,6 +1970,10 @@
         <source>Timesheet</source>
         <target state="translated">Работно време</target>
       </trans-unit>
+      <trans-unit id="ZwBNTZ." resname="contact_info" approved="no" xml:space="preserve">
+        <source>contact_info</source>
+        <target state="translated">Контакт</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/translations/messages.ca.xlf
+++ b/translations/messages.ca.xlf
@@ -2110,6 +2110,10 @@
         <source>reopen</source>
         <target state="final">Reobrir</target>
       </trans-unit>
+      <trans-unit id="ZwBNTZ." resname="contact_info" approved="no" xml:space="preserve">
+        <source>contact_info</source>
+        <target state="translated">Contacte</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/translations/messages.cs.xlf
+++ b/translations/messages.cs.xlf
@@ -2110,6 +2110,10 @@
         <source>reopen</source>
         <target state="needs-translation">Znovuotevřít</target>
       </trans-unit>
+      <trans-unit id="ZwBNTZ." resname="contact_info">
+        <source>contact_info</source>
+        <target state="translated">Kontakt</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/translations/messages.da.xlf
+++ b/translations/messages.da.xlf
@@ -1962,6 +1962,10 @@
         <source>Portrait</source>
         <target state="translated">Portræt</target>
       </trans-unit>
+      <trans-unit id="ZwBNTZ." resname="contact_info">
+        <source>contact_info</source>
+        <target state="translated">Kontakt</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/translations/messages.de.xlf
+++ b/translations/messages.de.xlf
@@ -780,7 +780,7 @@
       </trans-unit>
       <trans-unit id="CT59X9u" resname="contact">
         <source>contact</source>
-        <target>Kontakt</target>
+        <target>Kontaktperson</target>
       </trans-unit>
       <trans-unit id="2Ayb_RD" resname="address">
         <source>address</source>
@@ -2113,6 +2113,10 @@
       <trans-unit id="LfO_otF" resname="reopen">
         <source>reopen</source>
         <target>Wieder öffnen</target>
+      </trans-unit>
+      <trans-unit id="ZwBNTZ." resname="contact_info">
+        <source>contact_info</source>
+        <target>Kontakt</target>
       </trans-unit>
     </body>
   </file>

--- a/translations/messages.de_CH.xlf
+++ b/translations/messages.de_CH.xlf
@@ -1970,6 +1970,10 @@
         <source>Timesheet</source>
         <target state="translated">Stundenzettel</target>
       </trans-unit>
+      <trans-unit id="ZwBNTZ." resname="contact_info" approved="yes">
+        <source>contact_info</source>
+        <target state="final">Kontakt</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/translations/messages.el.xlf
+++ b/translations/messages.el.xlf
@@ -1994,6 +1994,10 @@
         <source>Beta</source>
         <target state="translated">Ενεργοποιεί μία λειτουργεία προεπισκόπησης που είναι ακόμα σε ανάπτυξη.</target>
       </trans-unit>
+      <trans-unit id="ZwBNTZ." resname="contact_info">
+        <source>contact_info</source>
+        <target state="translated">Επικοινωνία</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/translations/messages.en.xlf
+++ b/translations/messages.en.xlf
@@ -780,7 +780,7 @@
       </trans-unit>
       <trans-unit id="CT59X9u" resname="contact" approved="yes">
         <source>Contact</source>
-        <target state="final">Contact</target>
+        <target state="final">Contact person</target>
       </trans-unit>
       <trans-unit id="2Ayb_RD" resname="address">
         <source>address</source>
@@ -2113,6 +2113,10 @@
       <trans-unit id="LfO_otF" resname="reopen">
         <source>reopen</source>
         <target>Reopen</target>
+      </trans-unit>
+      <trans-unit id="ZwBNTZ." resname="contact_info" approved="yes">
+        <source>contact_info</source>
+        <target state="final">Contact</target>
       </trans-unit>
     </body>
   </file>

--- a/translations/messages.eo.xlf
+++ b/translations/messages.eo.xlf
@@ -1238,6 +1238,10 @@
         <source>invoice.cancel</source>
         <target>Nuligita fakturo</target>
       </trans-unit>
+      <trans-unit id="ZwBNTZ." resname="contact_info">
+        <source>contact_info</source>
+        <target state="translated">Kontakto</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/translations/messages.es.xlf
+++ b/translations/messages.es.xlf
@@ -2110,6 +2110,10 @@
         <source>reopen</source>
         <target state="translated">Reabrir</target>
       </trans-unit>
+      <trans-unit id="ZwBNTZ." resname="contact_info" approved="yes">
+        <source>contact_info</source>
+        <target state="final">Contacto</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/translations/messages.et.xlf
+++ b/translations/messages.et.xlf
@@ -1426,6 +1426,10 @@
         <source>Timesheet</source>
         <target state="translated">Tööajatabel</target>
       </trans-unit>
+      <trans-unit id="ZwBNTZ." resname="contact_info" approved="no" xml:space="preserve">
+        <source>contact_info</source>
+        <target state="translated">Kontakt</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/translations/messages.eu.xlf
+++ b/translations/messages.eu.xlf
@@ -1050,6 +1050,10 @@
         <source>create-timesheet-multiuser</source>
         <target>Erabiltzaile anitzentzat</target>
       </trans-unit>
+      <trans-unit id="ZwBNTZ." resname="contact_info">
+        <source>contact_info</source>
+        <target state="translated">Kontaktua</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/translations/messages.fa.xlf
+++ b/translations/messages.fa.xlf
@@ -2058,6 +2058,10 @@
         <source>Timesheet</source>
         <target state="translated">تایم شیت</target>
       </trans-unit>
+      <trans-unit id="ZwBNTZ." resname="contact_info">
+        <source>contact_info</source>
+        <target state="translated">مخاطب</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/translations/messages.fi.xlf
+++ b/translations/messages.fi.xlf
@@ -1958,6 +1958,10 @@
         <source>Timesheet</source>
         <target state="translated">Kellokortti</target>
       </trans-unit>
+      <trans-unit id="ZwBNTZ." resname="contact_info">
+        <source>contact_info</source>
+        <target state="translated">Yhteystiedot</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/translations/messages.fo.xlf
+++ b/translations/messages.fo.xlf
@@ -1038,6 +1038,10 @@
         <source>invoice.paid</source>
         <target state="translated">Goldið</target>
       </trans-unit>
+      <trans-unit id="ZwBNTZ." resname="contact_info">
+        <source>contact_info</source>
+        <target state="translated">Samband</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/translations/messages.fr.xlf
+++ b/translations/messages.fr.xlf
@@ -2110,6 +2110,10 @@
         <source>reopen</source>
         <target state="translated">Réouvrir</target>
       </trans-unit>
+      <trans-unit id="ZwBNTZ." resname="contact_info">
+        <source>contact_info</source>
+        <target>Contact</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/translations/messages.he.xlf
+++ b/translations/messages.he.xlf
@@ -2082,6 +2082,10 @@
         <source>count_as_expected_time_help</source>
         <target state="final">כשהאפשרות פעילה, %type% תחושבנה כשעות עבודה כחלק משעות צפי העבודה היומיות. כשהאפשרות כבויה, שעות הצפי לימים האלה תוגדרנה ל־0. שתי ההגדרות מחזיקות מאזן נייטרלי אבל משפיעות על הסכומים החודשיים בצורות שונות.</target>
       </trans-unit>
+      <trans-unit id="ZwBNTZ." resname="contact_info">
+        <source>contact_info</source>
+        <target>איש קשר</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/translations/messages.hr.xlf
+++ b/translations/messages.hr.xlf
@@ -2110,6 +2110,10 @@
         <source>reopen</source>
         <target state="translated">Otvori ponovo</target>
       </trans-unit>
+      <trans-unit id="ZwBNTZ." resname="contact_info">
+        <source>contact_info</source>
+        <target>Kontakt</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/translations/messages.hu.xlf
+++ b/translations/messages.hu.xlf
@@ -1970,6 +1970,10 @@
         <source>user_access_all</source>
         <target state="translated">Hozzáférés engedélyezése minden felhasználónak</target>
       </trans-unit>
+      <trans-unit id="ZwBNTZ." resname="contact_info" xml:space="preserve">
+        <source>contact_info</source>
+        <target state="translated">Kapcsolattartó</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/translations/messages.id.xlf
+++ b/translations/messages.id.xlf
@@ -2110,6 +2110,10 @@
         <source>reopen</source>
         <target state="translated">Buka kembali</target>
       </trans-unit>
+      <trans-unit id="ZwBNTZ." resname="contact_info" approved="no" xml:space="preserve">
+        <source>contact_info</source>
+        <target state="translated">Kontak</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/translations/messages.it.xlf
+++ b/translations/messages.it.xlf
@@ -2082,6 +2082,10 @@
         <source>count_as_expected_time_help</source>
         <target state="final">Se abilitato, %type% verrà conteggiato come ore lavorate ai fini delle ore giornaliere previste. Se disabilitato, le ore previste per questi giorni saranno impostate su 0. Entrambe le impostazioni mantengono un saldo neutro, ma influiscono sui totali mensili in modo diverso.</target>
       </trans-unit>
+      <trans-unit id="ZwBNTZ." resname="contact_info" approved="yes">
+        <source>contact_info</source>
+        <target state="final">Contatto</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/translations/messages.ja.xlf
+++ b/translations/messages.ja.xlf
@@ -910,6 +910,10 @@
         <source>Timesheet</source>
         <target state="translated">タイムシート</target>
       </trans-unit>
+      <trans-unit id="ZwBNTZ." resname="contact_info">
+        <source>contact_info</source>
+        <target state="translated">コンタクト</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/translations/messages.ko.xlf
+++ b/translations/messages.ko.xlf
@@ -1526,6 +1526,10 @@
         <source>replace</source>
         <target state="translated">바꾸기</target>
       </trans-unit>
+      <trans-unit id="ZwBNTZ." resname="contact_info">
+        <source>contact_info</source>
+        <target state="translated">연락</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/translations/messages.mk.xlf
+++ b/translations/messages.mk.xlf
@@ -2050,6 +2050,10 @@
         <source>Timesheet</source>
         <target state="translated">Временски лист</target>
       </trans-unit>
+      <trans-unit id="ZwBNTZ." resname="contact_info" approved="no" xml:space="preserve">
+        <source>contact_info</source>
+        <target state="translated">Контакт</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/translations/messages.nb_NO.xlf
+++ b/translations/messages.nb_NO.xlf
@@ -2046,6 +2046,10 @@
         <source>Timesheet</source>
         <target>Timeseddel</target>
       </trans-unit>
+      <trans-unit id="ZwBNTZ." resname="contact_info">
+        <source>contact_info</source>
+        <target state="translated">Kontakt</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/translations/messages.nl.xlf
+++ b/translations/messages.nl.xlf
@@ -2002,6 +2002,10 @@
         <source>release</source>
         <target state="needs-translation">Uitgave</target>
       </trans-unit>
+      <trans-unit id="ZwBNTZ." resname="contact_info" approved="no">
+        <source>contact_info</source>
+        <target state="translated">Contact</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/translations/messages.pa.xlf
+++ b/translations/messages.pa.xlf
@@ -306,6 +306,10 @@
         <source>modal.dirty</source>
         <target state="translated">ਫਾਰਮ ਬਦਲ ਗਿਆ ਹੈ। ਕਿਰਪਾ ਕਰਕੇ ਬਦਲਾਵਾਂ ਨੂੰ ਸੁਰੱਖਿਅਤ ਕਰਨ ਲਈ "ਸੇਵ" 'ਤੇ ਕਲਿੱਕ ਕਰੋ ਜਾਂ ਰੱਦ ਕਰਨ ਲਈ "ਬੰਦ ਕਰੋ" 'ਤੇ ਕਲਿੱਕ ਕਰੋ।</target>
       </trans-unit>
+      <trans-unit id="ZwBNTZ." resname="contact_info" approved="no">
+        <source>contact_info</source>
+        <target state="needs-translation">Contact</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/translations/messages.pl.xlf
+++ b/translations/messages.pl.xlf
@@ -2082,6 +2082,10 @@
         <source>count_as_expected_time_help</source>
         <target state="translated">Gdy włączone, %type% liczy się do przepracowanych godzin. Gdy wyłączone, oczekiwane godziny ustawiane są na 0. Obie opcje neutralne, różnią się wpływem na sumę miesięczną.</target>
       </trans-unit>
+      <trans-unit id="ZwBNTZ." resname="contact_info">
+        <source>contact_info</source>
+        <target state="translated">Kontakt</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/translations/messages.pt.xlf
+++ b/translations/messages.pt.xlf
@@ -2110,6 +2110,10 @@
         <source>reopen</source>
         <target state="translated">Reabrir</target>
       </trans-unit>
+      <trans-unit id="ZwBNTZ." resname="contact_info">
+        <source>contact_info</source>
+        <target state="translated">Contato</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/translations/messages.pt_BR.xlf
+++ b/translations/messages.pt_BR.xlf
@@ -2110,6 +2110,10 @@
         <source>assign_timesheets</source>
         <target state="translated">Atribuir folhas de horas</target>
       </trans-unit>
+      <trans-unit id="ZwBNTZ." resname="contact_info">
+        <source>contact_info</source>
+        <target state="translated">Contato</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/translations/messages.ro.xlf
+++ b/translations/messages.ro.xlf
@@ -2022,6 +2022,10 @@
         <source>Timesheet</source>
         <target>Fișă de pontaj</target>
       </trans-unit>
+      <trans-unit id="ZwBNTZ." resname="contact_info" approved="no" xml:space="preserve">
+        <source>contact_info</source>
+        <target state="translated">Contact</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/translations/messages.ru.xlf
+++ b/translations/messages.ru.xlf
@@ -2110,6 +2110,10 @@
         <source>assign_self</source>
         <target state="translated">Назначить мне</target>
       </trans-unit>
+      <trans-unit id="ZwBNTZ." resname="contact_info" approved="yes">
+        <source>contact_info</source>
+        <target state="final">Контакт</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/translations/messages.sk.xlf
+++ b/translations/messages.sk.xlf
@@ -1654,6 +1654,10 @@
         <source>Timesheet</source>
         <target state="translated">Pracovný výkaz</target>
       </trans-unit>
+      <trans-unit id="ZwBNTZ." resname="contact_info">
+        <source>contact_info</source>
+        <target state="translated">Kontakt</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/translations/messages.sl.xlf
+++ b/translations/messages.sl.xlf
@@ -558,6 +558,10 @@
         <source>replace</source>
         <target state="translated">Zamenjaj</target>
       </trans-unit>
+      <trans-unit id="ZwBNTZ." resname="contact_info" approved="no">
+        <source>contact_info</source>
+        <target state="needs-translation">Contact</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/translations/messages.sv.xlf
+++ b/translations/messages.sv.xlf
@@ -2082,6 +2082,10 @@
         <source>count_as_expected_time_help</source>
         <target state="translated">När det är aktiverat räknas %type% som arbetade timmar mot de förväntade dagliga timmarna. När det är inaktiverat sätts de förväntade timmarna för dessa dagar till 0. Båda inställningarna ger ett neutralt saldo men påverkar månadssummorna på olika sätt.</target>
       </trans-unit>
+      <trans-unit id="ZwBNTZ." resname="contact_info">
+        <source>contact_info</source>
+        <target state="translated">Kontakt</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/translations/messages.ta.xlf
+++ b/translations/messages.ta.xlf
@@ -2082,6 +2082,10 @@
         <source>count_as_expected_time_help</source>
         <target state="translated">இயக்கப்பட்டால், %type% என்பது எதிர்பார்க்கப்படும் நாள்தோறும் மணிநேரத்தை நோக்கி வேலை நேரமாக கணக்கிடப்படும். முடக்கப்பட்டால், இந்த நாட்களில் எதிர்பார்க்கப்படும் மணிநேரம் 0 ஆக அமைக்கப்படும். இரண்டு அமைப்புகளும் நடுநிலை சமநிலையை பராமரிக்கின்றன, ஆனால் மாதாந்திர மொத்தத்தை வித்தியாசமாக பாதிக்கும்.</target>
       </trans-unit>
+      <trans-unit id="ZwBNTZ." resname="contact_info" approved="yes" xml:space="preserve">
+        <source>contact_info</source>
+        <target state="final">தொடர்பு</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/translations/messages.tr.xlf
+++ b/translations/messages.tr.xlf
@@ -2110,6 +2110,10 @@
         <source>reopen</source>
         <target state="translated">Yeniden aç</target>
       </trans-unit>
+      <trans-unit id="ZwBNTZ." resname="contact_info">
+        <source>contact_info</source>
+        <target state="translated">İletişim</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/translations/messages.uk.xlf
+++ b/translations/messages.uk.xlf
@@ -2082,6 +2082,10 @@
         <source>count_as_expected_time_help</source>
         <target state="translated">Якщо ввімкнено, %type% зараховуватиметься як відпрацьовані години в межах очікуваної денної норми. Якщо вимкнено - очікувані години для цих днів буде встановлено в 0. Обидва варіанти зберігають нейтральний баланс, але по‑різному впливають на місячні підсумки.</target>
       </trans-unit>
+      <trans-unit id="ZwBNTZ." resname="contact_info" approved="yes">
+        <source>contact_info</source>
+        <target state="final">Контакт</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/translations/messages.vi.xlf
+++ b/translations/messages.vi.xlf
@@ -1862,6 +1862,10 @@
         <source>manual_bookings</source>
         <target state="translated">Đặt lịch thủ công</target>
       </trans-unit>
+      <trans-unit id="ZwBNTZ." resname="contact_info">
+        <source>contact_info</source>
+        <target>Liên hệ</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/translations/messages.zh_CN.xlf
+++ b/translations/messages.zh_CN.xlf
@@ -2042,6 +2042,10 @@
         <source>SEPA Direct Debit</source>
         <target state="translated">SEPA直接扣款</target>
       </trans-unit>
+      <trans-unit id="ZwBNTZ." resname="contact_info">
+        <source>contact_info</source>
+        <target>联系人</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/translations/messages.zh_Hant.xlf
+++ b/translations/messages.zh_Hant.xlf
@@ -1910,6 +1910,10 @@
         <source>Unlock month</source>
         <target state="translated">解鎖月份</target>
       </trans-unit>
+      <trans-unit id="ZwBNTZ." resname="contact_info" xml:space="preserve" approved="yes">
+        <source>contact_info</source>
+        <target state="final">聯繫</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>


### PR DESCRIPTION
Fixes #5770.

## Description

The customer `contact` field stores a person name, but the label "Contact" was ambiguous and could be read as a contact method (email/phone). The same translation key was shared with the InvoiceTemplate `contact` field, which is a free-text textarea with different semantics.

Adds a dedicated `contact_person` translation key for the customer field (form label, detail view, list column header, export column header) while keeping the original `contact` key for InvoiceTemplate, per the maintainer's plan in #5770.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] I verified that my code applies to the guidelines (`composer code-check`)
- [ ] I updated the documentation (see [here](https://github.com/kimai/www.kimai.org/tree/master/_documentation))
- [x] I agree that this code is used in Kimai (see [license](https://github.com/kimai/kimai/blob/main/LICENSE))
<img width="1863" height="864" alt="screenshot-2026-07-26_21-50-08" src="https://github.com/user-attachments/assets/d0cfa005-ac9c-4623-8477-a0fc4e5dea82" />
<img width="1864" height="874" alt="screenshot-2026-07-26_21-50-22" src="https://github.com/user-attachments/assets/12c24456-35fe-4d44-964f-d15f44415bee" />
<img width="1852" height="879" alt="screenshot-2026-07-26_21-50-33" src="https://github.com/user-attachments/assets/e42fe560-c857-4e53-889b-edf117c570b8" />
<img width="1080" height="769" alt="screenshot-2026-07-26_21-50-51" src="https://github.com/user-attachments/assets/ed0660ad-1d0e-4547-89ab-2a1df00e56ef" />