### PR TITLE
set users last login via dbal directly

### DIFF
--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -478,6 +478,11 @@ class User implements UserInterface, EquatableInterface, ThemeUserInterface, Pas
         return $this->getPreferenceValue(UserPreference::TIMEZONE, date_default_timezone_get(), false);
     }
 
+    public function getDateTimezone(): \DateTimeZone
+    {
+        return new \DateTimeZone($this->getTimezone());
+    }
+
     /**
      * The locale used for translating the UI
      */
@@ -713,7 +718,7 @@ class User implements UserInterface, EquatableInterface, ThemeUserInterface, Pas
      */
     public function resetSecuritySignature(): void
     {
-        $this->signatureDate = new \DateTimeImmutable('now', new \DateTimeZone($this->getTimezone()));
+        $this->signatureDate = new \DateTimeImmutable('now', $this->getDateTimezone());
     }
 
     /**
@@ -933,7 +938,7 @@ class User implements UserInterface, EquatableInterface, ThemeUserInterface, Pas
     {
         if ($this->lastLogin !== null) {
             // make sure to use the users own timezone
-            $this->lastLogin->setTimezone(new \DateTimeZone($this->getTimezone()));
+            $this->lastLogin->setTimezone($this->getDateTimezone());
         }
 
         return $this->lastLogin;
@@ -1031,6 +1036,10 @@ class User implements UserInterface, EquatableInterface, ThemeUserInterface, Pas
         return $this;
     }
 
+    /**
+     * @internal
+     * @deprecated since 2.63 - internal field - method will be remove in 3.0
+     */
     public function setLastLogin(?\DateTime $time = null): User
     {
         $this->lastLogin = $time;
@@ -1045,7 +1054,7 @@ class User implements UserInterface, EquatableInterface, ThemeUserInterface, Pas
 
     public function markPasswordRequested(): void
     {
-        $this->passwordRequestedAt = new \DateTimeImmutable('now', new \DateTimeZone($this->getTimezone()));
+        $this->passwordRequestedAt = new \DateTimeImmutable('now', $this->getDateTimezone());
     }
 
     public function isPasswordRequestNonExpired(int $seconds): bool
@@ -1352,7 +1361,7 @@ class User implements UserInterface, EquatableInterface, ThemeUserInterface, Pas
         }
 
         try {
-            $date = \DateTimeImmutable::createFromFormat('Y-m-d h:i:s', $date . ' 00:00:00', new \DateTimeZone($this->getTimezone()));
+            $date = \DateTimeImmutable::createFromFormat('Y-m-d h:i:s', $date . ' 00:00:00', $this->getDateTimezone());
         } catch (Exception $e) {
         }
 

--- a/src/EventSubscriber/LastLoginSubscriber.php
+++ b/src/EventSubscriber/LastLoginSubscriber.php
@@ -17,7 +17,7 @@ use Symfony\Component\Security\Http\Event\LoginSuccessEvent;
 
 final class LastLoginSubscriber implements EventSubscriberInterface
 {
-    public function __construct(private UserRepository $repository)
+    public function __construct(private readonly UserRepository $repository)
     {
     }
 
@@ -26,7 +26,7 @@ final class LastLoginSubscriber implements EventSubscriberInterface
         return [
             // triggered for programmatic logins like "password reset" or "registration"
             UserInteractiveLoginEvent::class => 'onImplicitLogin',
-            // We do not use the InteractiveLoginEvent because it is not triggered e.g. for SAML
+            // the InteractiveLoginEvent is not triggered e.g. for SAML
             LoginSuccessEvent::class => 'onFormLogin',
         ];
     }
@@ -35,8 +35,7 @@ final class LastLoginSubscriber implements EventSubscriberInterface
     {
         $user = $event->getUser();
 
-        $user->setLastLogin(new \DateTime('now', new \DateTimeZone($user->getTimezone())));
-        $this->repository->saveUser($user);
+        $this->repository->updateLastLogin($user);
     }
 
     public function onFormLogin(LoginSuccessEvent $event): void
@@ -44,8 +43,7 @@ final class LastLoginSubscriber implements EventSubscriberInterface
         $user = $event->getUser();
 
         if ($user instanceof User) {
-            $user->setLastLogin(new \DateTime('now', new \DateTimeZone($user->getTimezone())));
-            $this->repository->saveUser($user);
+            $this->repository->updateLastLogin($user);
         }
     }
 }

--- a/src/Repository/UserRepository.php
+++ b/src/Repository/UserRepository.php
@@ -50,6 +50,28 @@ class UserRepository extends EntityRepository implements UserLoaderInterface, Us
         }
     }
 
+    public function updateLastLogin(User $user): void
+    {
+        if ($user->getId() === null) {
+            return;
+        }
+
+        // the exact moment is not relevant (e.g. each API call)
+        // we just want to know roughly when the user was last seen in the auth process
+        $minWindow = new \DateTime('-15 minute', $user->getDateTimezone());
+        $lastLogin = $user->getLastLogin();
+        if ($lastLogin !== null && $lastLogin >= $minWindow) {
+            return;
+        }
+
+        // prevent using entity manager and calculating changesets
+        $this->getEntityManager()->getConnection()->executeStatement(
+            'UPDATE kimai2_users SET last_login = ? WHERE id = ?',
+            [new \DateTime('now', $user->getDateTimezone()), $user->getId()],
+            [Types::DATETIME_MUTABLE, Types::INTEGER],
+        );
+    }
+
     public function saveUser(User $user): void
     {
         $entityManager = $this->getEntityManager();

--- a/tests/Entity/UserTest.php
+++ b/tests/Entity/UserTest.php
@@ -745,6 +745,7 @@ class UserTest extends TestCase
         self::assertSame($supervisor, $user->getSupervisor());
     }
 
+    #[Group('legacy')]
     public function testLastLogin(): void
     {
         $dateTime = new \DateTime('now', new \DateTimeZone('UTC'));

--- a/tests/Entity/UserTest.php
+++ b/tests/Entity/UserTest.php
@@ -755,7 +755,7 @@ class UserTest extends TestCase
 
         $lastLogin = $user->getLastLogin();
         self::assertNull($lastLogin);
-        $user->setLastLogin($dateTime);
+        $user->setLastLogin($dateTime); // @phpstan-ignore method.deprecated
 
         $lastLogin = $user->getLastLogin();
         self::assertNotNull($lastLogin);

--- a/tests/EventSubscriber/LastLoginSubscriberTest.php
+++ b/tests/EventSubscriber/LastLoginSubscriberTest.php
@@ -41,33 +41,59 @@ class LastLoginSubscriberTest extends TestCase
 
     public function testOnImplicitLogin(): void
     {
+        $user = new User();
+
         $repository = $this->createMock(UserRepository::class);
-        $repository->expects($this->once())->method('saveUser');
+        // the user entity is no longer modified directly, to prevent excessive writes and
+        // Doctrine changeset computes (e.g. on each API request); the "last_login" field is
+        // updated by the repository and only becomes visible on subsequent requests
+        $repository->expects($this->once())->method('updateLastLogin')->with($user);
+        $repository->expects($this->never())->method('saveUser');
 
         $sut = new LastLoginSubscriber($repository);
 
-        $user = new User();
         self::assertNull($user->getLastLogin());
 
         $event = new UserInteractiveLoginEvent($user);
         $sut->onImplicitLogin($event);
-        self::assertNotNull($user->getLastLogin());
+
+        // the in-memory entity stays untouched, the field is only persisted via the repository
+        self::assertNull($user->getLastLogin());
     }
 
     public function testOnLoginSuccessWithUser(): void
     {
+        $user = new User();
+
         $repository = $this->createMock(UserRepository::class);
-        $repository->expects($this->once())->method('saveUser');
+        $repository->expects($this->once())->method('updateLastLogin')->with($user);
+        $repository->expects($this->never())->method('saveUser');
 
         $sut = new LastLoginSubscriber($repository);
 
-        $user = new User();
         self::assertNull($user->getLastLogin());
         $authenticator = $this->createMock(AuthenticatorInterface::class);
         $passport = $this->createMock(Passport::class);
         $passport->method('getUser')->willReturn($user);
         $event = new LoginSuccessEvent($authenticator, $passport, new UsernamePasswordToken($user, 'sdf'), new Request(), null, 'xyz');
         $sut->onFormLogin($event);
-        self::assertNotNull($user->getLastLogin());
+
+        self::assertNull($user->getLastLogin());
+    }
+
+    public function testOnLoginSuccessWithNonUser(): void
+    {
+        $repository = $this->createMock(UserRepository::class);
+        $repository->expects($this->never())->method('updateLastLogin');
+        $repository->expects($this->never())->method('saveUser');
+
+        $sut = new LastLoginSubscriber($repository);
+
+        $nonUser = $this->createMock(\Symfony\Component\Security\Core\User\UserInterface::class);
+        $authenticator = $this->createMock(AuthenticatorInterface::class);
+        $passport = $this->createMock(Passport::class);
+        $passport->method('getUser')->willReturn($nonUser);
+        $event = new LoginSuccessEvent($authenticator, $passport, new UsernamePasswordToken($nonUser, 'sdf'), new Request(), null, 'xyz');
+        $sut->onFormLogin($event);
     }
 }

--- a/tests/Repository/AbstractRepositoryTestCase.php
+++ b/tests/Repository/AbstractRepositoryTestCase.php
@@ -12,7 +12,6 @@ namespace App\Tests\Repository;
 use App\Tests\KernelTestTrait;
 use Doctrine\Bundle\DoctrineBundle\Registry;
 use Doctrine\ORM\EntityManagerInterface;
-use Doctrine\Persistence\ObjectManager;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 
 /**
@@ -22,7 +21,7 @@ abstract class AbstractRepositoryTestCase extends KernelTestCase
 {
     use KernelTestTrait;
 
-    private ?ObjectManager $entityManager = null;
+    private ?EntityManagerInterface $entityManager = null;
 
     protected function setUp(): void
     {
@@ -32,11 +31,17 @@ abstract class AbstractRepositoryTestCase extends KernelTestCase
         /** @var Registry $doctrine */
         $doctrine = $kernel->getContainer()->get('doctrine');
 
-        $this->entityManager = $doctrine->getManager();
+        $manager = $doctrine->getManager();
+        self::assertInstanceOf(EntityManagerInterface::class, $manager);
+        $this->entityManager = $manager;
     }
 
-    protected function getEntityManager(): ObjectManager
+    protected function getEntityManager(): EntityManagerInterface
     {
+        if ($this->entityManager === null) {
+            throw new \RuntimeException('setup() needs to be called first');
+        }
+
         return $this->entityManager;
     }
 
@@ -44,7 +49,7 @@ abstract class AbstractRepositoryTestCase extends KernelTestCase
     {
         parent::tearDown();
 
-        if ($this->entityManager instanceof EntityManagerInterface) {
+        if ($this->entityManager !== null) {
             $this->entityManager->close();
         }
         $this->entityManager = null; // avoid memory leaks

--- a/tests/Repository/UserRepositoryTest.php
+++ b/tests/Repository/UserRepositoryTest.php
@@ -1,0 +1,149 @@
+<?php
+
+/*
+ * This file is part of the Kimai time-tracking app.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Tests\Repository;
+
+use App\Entity\User;
+use App\Event\UserInteractiveLoginEvent;
+use App\EventSubscriber\LastLoginSubscriber;
+use App\Repository\UserRepository;
+use Doctrine\DBAL\Types\Types;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
+
+#[CoversClass(UserRepository::class)]
+#[CoversClass(LastLoginSubscriber::class)]
+#[Group('integration')]
+class UserRepositoryTest extends AbstractRepositoryTestCase
+{
+    private function createUser(string $username): User
+    {
+        $user = new User();
+        $user->setUserIdentifier($username);
+        $user->setEmail($username . '@example.com');
+        $user->setPassword('foo');
+
+        /** @var UserRepository $repository */
+        $repository = $this->getEntityManager()->getRepository(User::class);
+        $repository->saveUser($user);
+
+        return $user;
+    }
+
+    /**
+     * @phpstan-impure
+     */
+    private function getRawLastLogin(int $id): ?string
+    {
+        $result = $this->getEntityManager()->getConnection()->fetchOne(
+            'SELECT last_login FROM kimai2_users WHERE id = ?',
+            [$id],
+            [Types::INTEGER]
+        );
+
+        return !\is_string($result) ? null : $result;
+    }
+
+    private function setRawLastLogin(int $id, \DateTime $date): void
+    {
+        $this->getEntityManager()->getConnection()->executeStatement(
+            'UPDATE kimai2_users SET last_login = ? WHERE id = ?',
+            [$date, $id],
+            [Types::DATETIME_MUTABLE, Types::INTEGER]
+        );
+    }
+
+    /**
+     * Reloads the user from the database, simulating a fresh request (e.g. a new API call),
+     * where the entity is hydrated from the current database state instead of the in-memory object.
+     */
+    private function reloadUser(int $id): User
+    {
+        $em = $this->getEntityManager();
+        $em->clear();
+
+        /** @var UserRepository $repository */
+        $repository = $em->getRepository(User::class);
+        $user = $repository->getUserById($id);
+        self::assertInstanceOf(User::class, $user);
+
+        return $user;
+    }
+
+    /**
+     * Full flow: two subsequent "API calls" for the same user.
+     * The first login writes the "last_login" field, the second one happens within the
+     * 15 minute window and must NOT trigger another write.
+     */
+    public function testLastLoginIsWrittenOnceWithinTimeWindow(): void
+    {
+        $user = $this->createUser('john_flow');
+        $id = $user->getId();
+        self::assertIsInt($id);
+        self::assertNull($user->getLastLogin());
+        self::assertNull($this->getRawLastLogin($id));
+
+        $subscriber = new LastLoginSubscriber($this->getEntityManager()->getRepository(User::class));
+
+        // first request: the field is empty, so it gets written to the database
+        $firstUser = $this->reloadUser($id);
+        $subscriber->onImplicitLogin(new UserInteractiveLoginEvent($firstUser));
+
+        $firstLogin = $this->getRawLastLogin($id);
+        self::assertNotNull($firstLogin);
+
+        // the in-memory entity is intentionally NOT modified (no changeset computation)
+        self::assertNull($firstUser->getLastLogin());
+
+        // second request: the freshly loaded user has a recent "last_login" (< 15 minutes),
+        // so the repository must skip the write and the stored value stays untouched
+        $secondUser = $this->reloadUser($id);
+        self::assertNotNull($secondUser->getLastLogin());
+        $subscriber->onImplicitLogin(new UserInteractiveLoginEvent($secondUser));
+
+        self::assertSame($firstLogin, $this->getRawLastLogin($id));
+    }
+
+    /**
+     * Full flow: a user whose last login is older than the time window.
+     * The "last_login" was set to 20 minutes in the past directly in the database,
+     * so the next login must update it.
+     */
+    public function testLastLoginIsUpdatedWhenOutdated(): void
+    {
+        $user = $this->createUser('jane_flow');
+        $id = $user->getId();
+        self::assertIsInt($id);
+
+        // simulate a login that happened 20 minutes ago (outside the 15 minute window)
+        $twentyMinutesAgo = new \DateTime('-20 minute', $user->getDateTimezone());
+        $this->setRawLastLogin($id, $twentyMinutesAgo);
+        $storedBefore = $this->getRawLastLogin($id);
+        self::assertNotNull($storedBefore);
+
+        $subscriber = new LastLoginSubscriber($this->getEntityManager()->getRepository(User::class));
+
+        $freshUser = $this->reloadUser($id);
+        $lastLogin = $freshUser->getLastLogin();
+        self::assertNotNull($lastLogin);
+        self::assertEqualsWithDelta($twentyMinutesAgo->getTimestamp(), $lastLogin->getTimestamp(), 5);
+
+        $subscriber->onImplicitLogin(new UserInteractiveLoginEvent($freshUser));
+
+        // the outdated value was replaced with a recent one
+        $storedAfter = $this->getRawLastLogin($id);
+        self::assertNotNull($storedAfter);
+        self::assertNotSame($storedBefore, $storedAfter);
+
+        $updated = $this->reloadUser($id)->getLastLogin();
+        self::assertNotNull($updated);
+        self::assertGreaterThan($twentyMinutesAgo, $updated);
+        self::assertEqualsWithDelta((new \DateTime())->getTimestamp(), $updated->getTimestamp(), 60);
+    }
+}

--- a/tests/phpstan.neon
+++ b/tests/phpstan.neon
@@ -1657,11 +1657,6 @@ parameters:
             path: Reporting/ProjectDateRange/ProjectDateRangeQueryTest.php
 
         -
-            message: "#^Method App\\\\Tests\\\\Repository\\\\AbstractRepositoryTestCase\\:\\:getEntityManager\\(\\) should return Doctrine\\\\Persistence\\\\ObjectManager but returns Doctrine\\\\Persistence\\\\ObjectManager\\|null\\.$#"
-            count: 1
-            path: Repository/AbstractRepositoryTestCase.php
-
-        -
             message: "#^Parameter \\#1 \\$directory of method App\\\\Repository\\\\InvoiceDocumentRepository\\:\\:addDirectory\\(\\) expects string, string\\|false given\\.$#"
             count: 1
             path: Repository/InvoiceDocumentRepositoryTest.php


### PR DESCRIPTION
## Description

The user's `last_login` field is no longer written on every authenticated request.
To avoid excessive database writes and Doctrine changeset computation (e.g. on each
API call), the field is now updated via a lightweight direct query at most once per
15-minute window. As `last_login` is an internal-only field, the value now becomes
visible on a subsequent request rather than within the same request.

The field is now marked internal and the setter omn the User entity is deprecated.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] I verified that my code applies to the guidelines (`composer code-check`)
- [ ] I updated the documentation (see [here](https://github.com/kimai/www.kimai.org/tree/master/_documentation))
- [x] I agree that this code is used in Kimai (see [license](https://github.com/kimai/kimai/blob/main/LICENSE))
