### PR TITLE
User role management

### DIFF
--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -838,6 +838,24 @@ class User implements UserInterface, EquatableInterface, ThemeUserInterface, Pas
         return $explicit ? $isAdmin : $isAdmin || $this->isSuperAdmin();
     }
 
+    /**
+     * Whether this user is allowed to grant the given role to a user.
+     *
+     * This is the single source of truth for the role hierarchy used when assigning roles:
+     * a super-admin role may only be granted by a super admin, an admin role only by an admin
+     * (or above) and a teamlead role only by a teamlead (or above). Every other role (the default
+     * role and custom roles) may be granted by anyone.
+     */
+    public function canAssignRole(string $role): bool
+    {
+        return match (strtoupper($role)) {
+            static::ROLE_SUPER_ADMIN => $this->isSuperAdmin(),
+            static::ROLE_ADMIN => $this->isAdmin(false),
+            static::ROLE_TEAMLEAD => $this->hasTeamleadRole(false),
+            default => true,
+        };
+    }
+
     public function getDisplayName(): string
     {
         if (!empty($this->getAlias())) {

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -822,14 +822,20 @@ class User implements UserInterface, EquatableInterface, ThemeUserInterface, Pas
         return true;
     }
 
-    public function hasTeamleadRole(): bool
+    public function hasTeamleadRole(bool $explicit = true): bool
     {
-        return $this->hasRole(static::ROLE_TEAMLEAD);
+        $isTeamlead = $this->hasRole(static::ROLE_TEAMLEAD);
+
+        // when not asking for the explicit role, higher roles (admin, super admin) count as teamlead as well
+        return $explicit ? $isTeamlead : $isTeamlead || $this->isAdmin(false);
     }
 
-    public function isAdmin(): bool
+    public function isAdmin(bool $explicit = true): bool
     {
-        return $this->hasRole(static::ROLE_ADMIN);
+        $isAdmin = $this->hasRole(static::ROLE_ADMIN);
+
+        // when not asking for the explicit role, the higher super admin role counts as admin as well
+        return $explicit ? $isAdmin : $isAdmin || $this->isSuperAdmin();
     }
 
     public function getDisplayName(): string

--- a/src/Form/API/UserApiCreateForm.php
+++ b/src/Form/API/UserApiCreateForm.php
@@ -53,6 +53,7 @@ final class UserApiCreateForm extends UserCreateType
                 'required' => false,
                 'multiple' => true,
                 'expanded' => false,
+                'restrict_to_assignable' => true,
             ]);
         }
     }

--- a/src/Form/API/UserApiEditForm.php
+++ b/src/Form/API/UserApiEditForm.php
@@ -26,6 +26,7 @@ final class UserApiEditForm extends UserEditType
                 'required' => false,
                 'multiple' => true,
                 'expanded' => false,
+                'restrict_to_assignable' => true,
             ]);
         }
     }

--- a/src/Form/Type/UserRoleType.php
+++ b/src/Form/Type/UserRoleType.php
@@ -45,14 +45,11 @@ final class UserRoleType extends AbstractType
 
             $user = $options['user'];
             if ($user instanceof User) {
-                if (!$user->isSuperAdmin() && \array_key_exists(User::ROLE_SUPER_ADMIN, $roles)) {
-                    unset($roles[User::ROLE_SUPER_ADMIN]);
-                }
-                if (!$user->isAdmin(false) && \array_key_exists(User::ROLE_ADMIN, $roles)) {
-                    unset($roles[User::ROLE_ADMIN]);
-                }
-                if (!$user->hasTeamleadRole(false) && \array_key_exists(User::ROLE_TEAMLEAD, $roles)) {
-                    unset($roles[User::ROLE_TEAMLEAD]);
+                // only offer the roles the current user is allowed to assign
+                foreach (array_keys($roles) as $roleName) {
+                    if (!$user->canAssignRole($roleName)) {
+                        unset($roles[$roleName]);
+                    }
                 }
             }
 

--- a/src/Form/Type/UserRoleType.php
+++ b/src/Form/Type/UserRoleType.php
@@ -43,6 +43,19 @@ final class UserRoleType extends AbstractType
                 unset($roles[User::DEFAULT_ROLE]);
             }
 
+            $user = $options['user'];
+            if ($user instanceof User) {
+                if (!$user->isSuperAdmin() && \array_key_exists(User::ROLE_SUPER_ADMIN, $roles)) {
+                    unset($roles[User::ROLE_SUPER_ADMIN]);
+                }
+                if (!$user->isAdmin(false) && \array_key_exists(User::ROLE_ADMIN, $roles)) {
+                    unset($roles[User::ROLE_ADMIN]);
+                }
+                if (!$user->hasTeamleadRole(false) && \array_key_exists(User::ROLE_TEAMLEAD, $roles)) {
+                    unset($roles[User::ROLE_TEAMLEAD]);
+                }
+            }
+
             return $roles;
         });
     }

--- a/src/Form/Type/UserRoleType.php
+++ b/src/Form/Type/UserRoleType.php
@@ -31,7 +31,13 @@ final class UserRoleType extends AbstractType
         $resolver->setDefaults([
             'label' => 'roles',
             'include_default' => false,
+            // when true, the choices are limited to the roles the current user is allowed to
+            // assign - only meaningful when this field is used to assign roles (create/edit),
+            // not when it is used to filter the user list (e.g. in the toolbar)
+            'restrict_to_assignable' => false,
         ]);
+
+        $resolver->setAllowedTypes('restrict_to_assignable', 'bool');
 
         $resolver->setDefault('choices', function (Options $options): array {
             $roles = [];
@@ -44,7 +50,7 @@ final class UserRoleType extends AbstractType
             }
 
             $user = $options['user'];
-            if ($user instanceof User) {
+            if ($options['restrict_to_assignable'] === true && $user instanceof User) {
                 // only offer the roles the current user is allowed to assign
                 foreach (array_keys($roles) as $roleName) {
                     if (!$user->canAssignRole($roleName)) {

--- a/src/Form/UserCreateType.php
+++ b/src/Form/UserCreateType.php
@@ -62,6 +62,7 @@ class UserCreateType extends UserEditType
                 'multiple' => true,
                 'expanded' => false,
                 'required' => false,
+                'restrict_to_assignable' => true,
             ]);
         }
 

--- a/src/Form/UserRolesType.php
+++ b/src/Form/UserRolesType.php
@@ -29,6 +29,7 @@ final class UserRolesType extends AbstractType
             ->add('roles', UserRoleType::class, [
                 'multiple' => true,
                 'expanded' => true,
+                'restrict_to_assignable' => true,
             ])
         ;
 

--- a/src/Form/UserRolesType.php
+++ b/src/Form/UserRolesType.php
@@ -13,6 +13,8 @@ use App\Entity\User;
 use App\Form\Type\UserRoleType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormEvent;
+use Symfony\Component\Form\FormEvents;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
@@ -29,6 +31,41 @@ final class UserRolesType extends AbstractType
                 'expanded' => true,
             ])
         ;
+
+        $currentUser = $options['user'];
+        if (!$currentUser instanceof User) {
+            return;
+        }
+
+        // the roles a user is not allowed to assign are hidden from the form (see UserRoleType),
+        // so a plain submit would strip them from the edited user.
+        // remember those roles before binding and re-add them afterward, so they can never be
+        // removed by someone who is not allowed to manage them in the first place.
+        $preservedRoles = [];
+
+        $builder->addEventListener(FormEvents::PRE_SET_DATA, function (FormEvent $event) use ($currentUser, &$preservedRoles): void {
+            $user = $event->getData();
+            if (!$user instanceof User) {
+                return;
+            }
+
+            foreach ($user->getRoles() as $role) {
+                if (!$currentUser->canAssignRole($role)) {
+                    $preservedRoles[] = $role;
+                }
+            }
+        });
+
+        $builder->addEventListener(FormEvents::POST_SUBMIT, function (FormEvent $event) use (&$preservedRoles): void {
+            $user = $event->getData();
+            if (!$user instanceof User) {
+                return;
+            }
+
+            foreach ($preservedRoles as $role) {
+                $user->addRole($role);
+            }
+        });
     }
 
     public function configureOptions(OptionsResolver $resolver): void

--- a/src/User/PermissionService.php
+++ b/src/User/PermissionService.php
@@ -28,8 +28,8 @@ class PermissionService
     private ?array $cacheAll = null;
 
     public function __construct(
-        private RolePermissionRepository $repository,
-        private CacheInterface $cache
+        private readonly RolePermissionRepository $repository,
+        private readonly CacheInterface $cache
     ) {
     }
 

--- a/src/Voter/UserVoter.php
+++ b/src/Voter/UserVoter.php
@@ -127,22 +127,15 @@ final class UserVoter extends Voter
     /**
      * Whether $user is allowed to assign every role the $subject currently holds.
      *
-     * The rules mirror the assignable roles offered by {@see \App\Form\Type\UserRoleType}:
-     * a super-admin role may only be managed by a super admin, an admin role only by an
-     * admin (or above) and a teamlead role only by a teamlead (or above).
+     * Uses the same role hierarchy as the assignable roles offered by
+     * {@see \App\Form\Type\UserRoleType} via {@see User::canAssignRole()}.
      */
     private function canManageAllRolesOf(User $subject, User $user): bool
     {
-        if ($subject->isSuperAdmin() && !$user->isSuperAdmin()) {
-            return false;
-        }
-
-        if ($subject->isAdmin() && !$user->isAdmin(false)) {
-            return false;
-        }
-
-        if ($subject->hasTeamleadRole() && !$user->hasTeamleadRole(false)) {
-            return false;
+        foreach ($subject->getRoles() as $role) {
+            if (!$user->canAssignRole($role)) {
+                return false;
+            }
         }
 
         return true;

--- a/src/Voter/UserVoter.php
+++ b/src/Voter/UserVoter.php
@@ -105,6 +105,12 @@ final class UserVoter extends Voter
             return $user->isSuperAdmin();
         }
 
+        // a user must not edit the roles of someone who holds a role they are not allowed to assign
+        // themselves - otherwise a lower-privileged user could strip a higher role from the subject
+        if ($attribute === 'roles' && !$this->canManageAllRolesOf($subject, $user)) {
+            return false;
+        }
+
         $permission = $attribute;
 
         if ($subject->getId() === $user->getId()) {
@@ -116,5 +122,29 @@ final class UserVoter extends Voter
         }
 
         return $this->permissionManager->checkUserAccess($subject, $user, false);
+    }
+
+    /**
+     * Whether $user is allowed to assign every role the $subject currently holds.
+     *
+     * The rules mirror the assignable roles offered by {@see \App\Form\Type\UserRoleType}:
+     * a super-admin role may only be managed by a super admin, an admin role only by an
+     * admin (or above) and a teamlead role only by a teamlead (or above).
+     */
+    private function canManageAllRolesOf(User $subject, User $user): bool
+    {
+        if ($subject->isSuperAdmin() && !$user->isSuperAdmin()) {
+            return false;
+        }
+
+        if ($subject->isAdmin() && !$user->isAdmin(false)) {
+            return false;
+        }
+
+        if ($subject->hasTeamleadRole() && !$user->hasTeamleadRole(false)) {
+            return false;
+        }
+
+        return true;
     }
 }

--- a/tests/Controller/ProfileControllerTest.php
+++ b/tests/Controller/ProfileControllerTest.php
@@ -411,10 +411,6 @@ class ProfileControllerTest extends AbstractControllerBaseTestCase
     {
         $role = (new Role())->setName(User::ROLE_ADMIN);
         $permission = (new RolePermission())->setRole($role)->setPermission('roles_other_profile')->setAllowed(true);
-        $em = $this->getEntityManager();
-        $em->persist($role);
-        $em->persist($permission);
-        $em->flush();
         /** @var PermissionService $permissionService */
         $permissionService = $this->getPrivateService(PermissionService::class);
         $permissionService->saveRolePermission($permission);

--- a/tests/Controller/ProfileControllerTest.php
+++ b/tests/Controller/ProfileControllerTest.php
@@ -411,6 +411,9 @@ class ProfileControllerTest extends AbstractControllerBaseTestCase
     {
         $role = (new Role())->setName(User::ROLE_ADMIN);
         $permission = (new RolePermission())->setRole($role)->setPermission('roles_other_profile')->setAllowed(true);
+        $em = $this->getEntityManager();
+        $em->persist($role);
+        $em->flush();
         /** @var PermissionService $permissionService */
         $permissionService = $this->getPrivateService(PermissionService::class);
         $permissionService->saveRolePermission($permission);

--- a/tests/Controller/ProfileControllerTest.php
+++ b/tests/Controller/ProfileControllerTest.php
@@ -10,11 +10,14 @@
 namespace App\Tests\Controller;
 
 use App\DataFixtures\UserFixtures;
+use App\Entity\Role;
+use App\Entity\RolePermission;
 use App\Entity\User;
 use App\Entity\UserPreference;
 use App\Repository\AccessTokenRepository;
 use App\Tests\DataFixtures\TeamFixtures;
 use App\Tests\DataFixtures\TimesheetFixtures;
+use App\User\PermissionService;
 use App\WorkingTime\Mode\WorkingTimeModeDay;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
@@ -343,6 +346,78 @@ class ProfileControllerTest extends AbstractControllerBaseTestCase
         $client = $this->getClientForAuthenticatedUser(User::ROLE_TEAMLEAD);
         $this->request($client, '/profile/' . UserFixtures::USERNAME_USER . '/roles');
         self::assertFalse($client->getResponse()->isSuccessful());
+    }
+
+    /**
+     * A lower-privileged actor must not be able to edit the roles of a user who holds a role the
+     * actor cannot assign - otherwise they could strip that higher role from the subject.
+     *
+     * Setup mirrors an installation that granted "roles_other_profile" to ROLE_ADMIN. As ROLE_ADMIN
+     * also has "view_all_data", such an admin passes the general profile access check, but the
+     * UserVoter must still deny access to a super admin's roles form.
+     */
+    public function testRolesActionDeniesEditingHigherPrivilegedUser(): void
+    {
+        $client = $this->getClientForAuthenticatedUser(User::ROLE_ADMIN);
+        $this->grantRolesOtherProfileToAdmin();
+
+        // the target is a super admin, a role the admin may not assign
+        $target = $this->getUserByRole(User::ROLE_SUPER_ADMIN);
+        self::assertContains(User::ROLE_SUPER_ADMIN, $target->getRoles());
+
+        $this->request($client, '/profile/' . $target->getUserIdentifier() . '/roles');
+
+        $this->assertAccessDenied($client);
+    }
+
+    /**
+     * Counterpart to the test above: editing the roles of a user the admin outranks stays allowed,
+     * so the new voter guard does not over-block legitimate role management.
+     */
+    public function testRolesActionAllowsEditingLowerPrivilegedUser(): void
+    {
+        $client = $this->getClientForAuthenticatedUser(User::ROLE_ADMIN);
+        $this->grantRolesOtherProfileToAdmin();
+
+        $target = $this->getUserByRole(User::ROLE_USER);
+        $targetName = $target->getUserIdentifier();
+        self::assertEquals([User::ROLE_USER], $target->getRoles());
+
+        $this->request($client, '/profile/' . $targetName . '/roles');
+        self::assertTrue($client->getResponse()->isSuccessful());
+
+        // the admin may assign the teamlead role, but not the super admin role
+        $rendered = $client->getResponse()->getContent();
+        self::assertIsString($rendered);
+        self::assertStringNotContainsString('value="ROLE_SUPER_ADMIN"', $rendered);
+
+        $form = $client->getCrawler()->filter('form[name=user_roles]')->form();
+        $client->submit($form, [
+            'user_roles[roles]' => [
+                'ROLE_TEAMLEAD',
+            ]
+        ]);
+        $this->assertIsRedirect($client, $this->createUrl('/profile/' . urlencode($targetName) . '/roles'));
+        $client->followRedirect();
+
+        $target = $this->getUserByName($targetName);
+        self::assertContains(User::ROLE_TEAMLEAD, $target->getRoles());
+    }
+
+    /**
+     * Grants ROLE_ADMIN the (non-default) permission to edit other users' roles and busts the cache.
+     */
+    private function grantRolesOtherProfileToAdmin(): void
+    {
+        $role = (new Role())->setName(User::ROLE_ADMIN);
+        $permission = (new RolePermission())->setRole($role)->setPermission('roles_other_profile')->setAllowed(true);
+        $em = $this->getEntityManager();
+        $em->persist($role);
+        $em->persist($permission);
+        $em->flush();
+        /** @var PermissionService $permissionService */
+        $permissionService = $this->getPrivateService(PermissionService::class);
+        $permissionService->saveRolePermission($permission);
     }
 
     public function testRolesAction(): void

--- a/tests/Entity/UserTest.php
+++ b/tests/Entity/UserTest.php
@@ -432,6 +432,59 @@ class UserTest extends TestCase
         self::assertFalse($sut->isSuperAdmin());
     }
 
+    public function testIsAdminRespectsRoleHierarchy(): void
+    {
+        $sut = new User();
+
+        // a regular user is neither an explicit nor an implicit admin
+        self::assertFalse($sut->isAdmin());
+        self::assertFalse($sut->isAdmin(true));
+        self::assertFalse($sut->isAdmin(false));
+
+        // an explicit admin matches both modes
+        $sut->addRole(User::ROLE_ADMIN);
+        self::assertTrue($sut->isAdmin());
+        self::assertTrue($sut->isAdmin(true));
+        self::assertTrue($sut->isAdmin(false));
+
+        // a super admin is implicitly an admin, but not an explicit one
+        $sut->removeRole(User::ROLE_ADMIN);
+        $sut->addRole(User::ROLE_SUPER_ADMIN);
+        self::assertFalse($sut->isAdmin());
+        self::assertFalse($sut->isAdmin(true));
+        self::assertTrue($sut->isAdmin(false));
+    }
+
+    public function testHasTeamleadRoleRespectsRoleHierarchy(): void
+    {
+        $sut = new User();
+
+        // a regular user has no teamlead role in either mode
+        self::assertFalse($sut->hasTeamleadRole());
+        self::assertFalse($sut->hasTeamleadRole(true));
+        self::assertFalse($sut->hasTeamleadRole(false));
+
+        // an explicit teamlead matches both modes
+        $sut->addRole(User::ROLE_TEAMLEAD);
+        self::assertTrue($sut->hasTeamleadRole());
+        self::assertTrue($sut->hasTeamleadRole(true));
+        self::assertTrue($sut->hasTeamleadRole(false));
+
+        // an admin is implicitly a teamlead, but not an explicit one
+        $sut->removeRole(User::ROLE_TEAMLEAD);
+        $sut->addRole(User::ROLE_ADMIN);
+        self::assertFalse($sut->hasTeamleadRole());
+        self::assertFalse($sut->hasTeamleadRole(true));
+        self::assertTrue($sut->hasTeamleadRole(false));
+
+        // a super admin is implicitly a teamlead as well
+        $sut->removeRole(User::ROLE_ADMIN);
+        $sut->addRole(User::ROLE_SUPER_ADMIN);
+        self::assertFalse($sut->hasTeamleadRole());
+        self::assertFalse($sut->hasTeamleadRole(true));
+        self::assertTrue($sut->hasTeamleadRole(false));
+    }
+
     /**
      * This functionality was added, because these fields can be set via external providers (LDAP, SAML) and
      * an invalid length should not result in errors.

--- a/tests/Entity/UserTest.php
+++ b/tests/Entity/UserTest.php
@@ -485,6 +485,45 @@ class UserTest extends TestCase
         self::assertTrue($sut->hasTeamleadRole(false));
     }
 
+    public function testCanAssignRole(): void
+    {
+        $superAdmin = new User();
+        $superAdmin->addRole(User::ROLE_SUPER_ADMIN);
+        // a super admin may assign every role
+        self::assertTrue($superAdmin->canAssignRole(User::ROLE_SUPER_ADMIN));
+        self::assertTrue($superAdmin->canAssignRole(User::ROLE_ADMIN));
+        self::assertTrue($superAdmin->canAssignRole(User::ROLE_TEAMLEAD));
+        self::assertTrue($superAdmin->canAssignRole(User::ROLE_USER));
+
+        $admin = new User();
+        $admin->addRole(User::ROLE_ADMIN);
+        // an admin may assign admin and below, but not super admin
+        self::assertFalse($admin->canAssignRole(User::ROLE_SUPER_ADMIN));
+        self::assertTrue($admin->canAssignRole(User::ROLE_ADMIN));
+        self::assertTrue($admin->canAssignRole(User::ROLE_TEAMLEAD));
+        self::assertTrue($admin->canAssignRole(User::ROLE_USER));
+
+        $teamlead = new User();
+        $teamlead->addRole(User::ROLE_TEAMLEAD);
+        // a teamlead may assign teamlead and below, but not admin or super admin
+        self::assertFalse($teamlead->canAssignRole(User::ROLE_SUPER_ADMIN));
+        self::assertFalse($teamlead->canAssignRole(User::ROLE_ADMIN));
+        self::assertTrue($teamlead->canAssignRole(User::ROLE_TEAMLEAD));
+        self::assertTrue($teamlead->canAssignRole(User::ROLE_USER));
+
+        $user = new User();
+        // a regular user may not assign any of the privileged roles
+        self::assertFalse($user->canAssignRole(User::ROLE_SUPER_ADMIN));
+        self::assertFalse($user->canAssignRole(User::ROLE_ADMIN));
+        self::assertFalse($user->canAssignRole(User::ROLE_TEAMLEAD));
+        self::assertTrue($user->canAssignRole(User::ROLE_USER));
+
+        // custom roles can be assigned by anyone, and the check is case-insensitive
+        self::assertTrue($user->canAssignRole('ROLE_CUSTOM'));
+        self::assertTrue($admin->canAssignRole('role_teamlead'));
+        self::assertFalse($teamlead->canAssignRole('role_admin'));
+    }
+
     /**
      * This functionality was added, because these fields can be set via external providers (LDAP, SAML) and
      * an invalid length should not result in errors.

--- a/tests/Voter/UserVoterTest.php
+++ b/tests/Voter/UserVoterTest.php
@@ -228,6 +228,66 @@ class UserVoterTest extends AbstractVoterTestCase
     }
 
     /**
+     * A user with the "roles_other_profile" permission must not be able to edit the roles of a
+     * subject who holds a role the user cannot assign themselves (privilege escalation guard).
+     *
+     * @param string|null $actorRole the role of the acting user
+     * @param string|null $subjectRole the role held by the edited subject
+     * @param int $result expected voter result for the "roles" attribute
+     */
+    #[DataProvider('getRolesManagementTestData')]
+    public function testRolesManagementRespectsRoleHierarchy(?string $actorRole, ?string $subjectRole, int $result): void
+    {
+        $actor = self::getUser(60, $actorRole);
+        $actor->setEnabled(true);
+        // grant "see all data" so RolePermissionManager::checkUserAccess() passes and the new
+        // hierarchy guard is the only thing that can still deny access
+        $actor->initCanSeeAllData(true);
+
+        $subject = self::getUser(61, $subjectRole);
+        $subject->setEnabled(true);
+
+        $permissions = [
+            'ROLE_TEAMLEAD' => ['roles_other_profile', 'edit_other_profile'],
+            'ROLE_ADMIN' => ['roles_other_profile', 'edit_other_profile'],
+            'ROLE_SUPER_ADMIN' => ['roles_other_profile', 'edit_other_profile'],
+        ];
+        $voter = new UserVoter($this->getRolePermissionManager($permissions, true));
+
+        $token = new UsernamePasswordToken($actor, 'bar', $actor->getRoles());
+
+        self::assertEquals($result, $voter->vote($token, $subject, ['roles']));
+
+        // the "edit" attribute has no hierarchy guard, so it must stay granted in every case,
+        // proving the denial above is specific to role management
+        self::assertEquals(VoterInterface::ACCESS_GRANTED, $voter->vote($token, $subject, ['edit']));
+    }
+
+    public static function getRolesManagementTestData(): \Generator
+    {
+        $granted = VoterInterface::ACCESS_GRANTED;
+        $denied = VoterInterface::ACCESS_DENIED;
+
+        // a super admin may manage everyone
+        yield [User::ROLE_SUPER_ADMIN, User::ROLE_SUPER_ADMIN, $granted];
+        yield [User::ROLE_SUPER_ADMIN, User::ROLE_ADMIN, $granted];
+        yield [User::ROLE_SUPER_ADMIN, User::ROLE_TEAMLEAD, $granted];
+        yield [User::ROLE_SUPER_ADMIN, User::ROLE_USER, $granted];
+
+        // an admin may manage admins and below, but not super admins
+        yield [User::ROLE_ADMIN, User::ROLE_SUPER_ADMIN, $denied];
+        yield [User::ROLE_ADMIN, User::ROLE_ADMIN, $granted];
+        yield [User::ROLE_ADMIN, User::ROLE_TEAMLEAD, $granted];
+        yield [User::ROLE_ADMIN, User::ROLE_USER, $granted];
+
+        // a teamlead may manage teamleads and below, but not admins or super admins
+        yield [User::ROLE_TEAMLEAD, User::ROLE_SUPER_ADMIN, $denied];
+        yield [User::ROLE_TEAMLEAD, User::ROLE_ADMIN, $denied];
+        yield [User::ROLE_TEAMLEAD, User::ROLE_TEAMLEAD, $granted];
+        yield [User::ROLE_TEAMLEAD, User::ROLE_USER, $granted];
+    }
+
+    /**
      * Without the role permission "<attribute>_other_profile" the voter must deny,
      * regardless of any team relation between user and subject.
      */


### PR DESCRIPTION
## Description

- Role management now respects the role hierarchy. When editing a user's roles, you can only grant roles up to your own privilege level — it is no longer possible to assign a higher role (e.g. a regular admin can no longer grant super administrator).
- You can no longer open the role settings of a user who holds a role you are not allowed to manage, preventing lower-privileged users from removing a higher role from someone who outranks them.
- Added a safeguard so that roles you are not permitted to manage are always kept intact when you save another user's roles, even if they are not shown to you in the form.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] I verified that my code applies to the guidelines (`composer code-check`)
- [ ] I updated the documentation (see [here](https://github.com/kimai/www.kimai.org/tree/master/_documentation))
- [x] I agree that this code is used in Kimai (see [license](https://github.com/kimai/kimai/blob/main/LICENSE))
