### PR TITLE
Add toggle to disable default export templates

### DIFF
--- a/src/Controller/SystemConfigurationController.php
+++ b/src/Controller/SystemConfigurationController.php
@@ -630,6 +630,13 @@ final class SystemConfigurationController extends AbstractController
                         ->setType(DatePickerType::class)
                         ->setOptions(['input' => 'string']),
                 ]),
+            (new SystemConfigurationModel('export'))
+                ->setConfiguration([
+                    (new Configuration('export.show_default_templates'))
+                        ->setTranslationDomain('system-configuration')
+                        ->setRequired(false)
+                        ->setType(YesNoType::class),
+                ]),
         ];
     }
 }

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -403,6 +403,9 @@ final class Configuration implements ConfigurationInterface
                 ->integerNode('timeout')
                     ->defaultValue(60)
                 ->end()
+                ->booleanNode('show_default_templates')
+                    ->defaultValue(true)
+                ->end()
 
             ->end()
         ;

--- a/src/Export/ServiceExport.php
+++ b/src/Export/ServiceExport.php
@@ -9,6 +9,7 @@
 
 namespace App\Export;
 
+use App\Configuration\SystemConfiguration;
 use App\Entity\ExportableItem;
 use App\Entity\ExportTemplate;
 use App\Event\ExportItemsQueryEvent;
@@ -48,6 +49,7 @@ final class ServiceExport
         private readonly XlsxRendererFactory $xlsxRendererFactory,
         private readonly ExportTemplateRepository $exportTemplateRepository,
         private readonly LoggerInterface $logger,
+        private readonly SystemConfiguration $systemConfiguration,
     )
     {
     }
@@ -89,12 +91,19 @@ final class ServiceExport
      */
     public function getRenderer(): array
     {
-        $renderer = [
-            $this->csvRendererFactory->createDefault(),
-            $this->xlsxRendererFactory->createDefault(),
-            $this->pdfRendererFactory->create('pdf', 'export/pdf-layout.html.twig', 'pdf'),
-            $this->htmlRendererFactory->create('print', 'export/print.html.twig'),
-        ];
+        $renderer = [];
+
+        $showDefaults = $this->systemConfiguration->find('export.show_default_templates');
+        $showDefaults = $showDefaults === null || (bool) $showDefaults;
+
+        if ($showDefaults) {
+            $renderer = [
+                $this->csvRendererFactory->createDefault(),
+                $this->xlsxRendererFactory->createDefault(),
+                $this->pdfRendererFactory->create('pdf', 'export/pdf-layout.html.twig', 'pdf'),
+                $this->htmlRendererFactory->create('print', 'export/print.html.twig'),
+            ];
+        }
 
         foreach ($this->exportTemplateRepository->findAll() as $template) {
             try {
@@ -104,32 +113,34 @@ final class ServiceExport
             }
         }
 
-        foreach ($this->documentDirs as $exportPath) {
-            if (!is_dir($exportPath)) {
-                continue;
-            }
-
-            $htmlTemplates = glob($exportPath . '/*.html.twig');
-            if (\is_array($htmlTemplates)) {
-                foreach ($htmlTemplates as $htmlTpl) {
-                    $tplName = basename($htmlTpl);
-                    if (stripos($tplName, '-bundle') !== false) {
-                        continue;
-                    }
-
-                    $renderer[] = $this->htmlRendererFactory->create($tplName, '@export/' . $tplName, $this->filenameToTitle($tplName));
+        if ($showDefaults) {
+            foreach ($this->documentDirs as $exportPath) {
+                if (!is_dir($exportPath)) {
+                    continue;
                 }
-            }
 
-            $pdfTemplates = glob($exportPath . '/*.pdf.twig');
-            if (\is_array($pdfTemplates)) {
-                foreach ($pdfTemplates as $pdfTpl) {
-                    $tplName = basename($pdfTpl);
-                    if (stripos($tplName, '-bundle') !== false) {
-                        continue;
+                $htmlTemplates = glob($exportPath . '/*.html.twig');
+                if (\is_array($htmlTemplates)) {
+                    foreach ($htmlTemplates as $htmlTpl) {
+                        $tplName = basename($htmlTpl);
+                        if (stripos($tplName, '-bundle') !== false) {
+                            continue;
+                        }
+
+                        $renderer[] = $this->htmlRendererFactory->create($tplName, '@export/' . $tplName, $this->filenameToTitle($tplName));
                     }
+                }
 
-                    $renderer[] = $this->pdfRendererFactory->create($tplName, '@export/' . $tplName, $this->filenameToTitle($tplName));
+                $pdfTemplates = glob($exportPath . '/*.pdf.twig');
+                if (\is_array($pdfTemplates)) {
+                    foreach ($pdfTemplates as $pdfTpl) {
+                        $tplName = basename($pdfTpl);
+                        if (stripos($tplName, '-bundle') !== false) {
+                            continue;
+                        }
+
+                        $renderer[] = $this->pdfRendererFactory->create($tplName, '@export/' . $tplName, $this->filenameToTitle($tplName));
+                    }
                 }
             }
         }

--- a/templates/system-configuration/index.html.twig
+++ b/templates/system-configuration/index.html.twig
@@ -29,12 +29,16 @@
             <div class="col-12">
                 {% set formEditTemplate = kimai_context.modalRequest ? 'default/_form_modal.html.twig' : 'default/_form.html.twig' %}
         
+                {% set sortedSections = [] %}
                 {% for section in sections %}
                     {% set title = section.model.translation|trans({}, section.model.translationDomain) %}
                     {% if title == section.model.translation %}
                         {% set title = section.model.section|trans %}
                     {% endif %}
-                    {% embed formEditTemplate with {'title': title, 'form': section.form} %}
+                    {% set sortedSections = sortedSections|merge([{'model': section.model, 'form': section.form, 'title': title}]) %}
+                {% endfor %}
+                {% for section in sortedSections|sort((a, b) => a.title <=> b.title) %}
+                    {% embed formEditTemplate with {'title': section.title, 'form': section.form} %}
                         {% block form_before %}<span id="conf_{{ section.model.section }}"></span>{% endblock %}
                         {% block form_body %}
                             {% for pref in form.children.configuration %}

--- a/tests/Controller/SystemConfigurationControllerTest.php
+++ b/tests/Controller/SystemConfigurationControllerTest.php
@@ -90,6 +90,7 @@ class SystemConfigurationControllerTest extends AbstractControllerBaseTestCase
             ['form[name=system_configuration_form_theme]', $this->createUrl('/admin/system-config/update/theme')],
             ['form[name=system_configuration_form_calendar]', $this->createUrl('/admin/system-config/update/calendar')],
             ['form[name=system_configuration_form_branding]', $this->createUrl('/admin/system-config/update/branding')],
+            ['form[name=system_configuration_form_export]', $this->createUrl('/admin/system-config/update/export')],
         ];
     }
 

--- a/tests/DependencyInjection/ConfigurationTest.php
+++ b/tests/DependencyInjection/ConfigurationTest.php
@@ -464,6 +464,7 @@ class ConfigurationTest extends TestCase
                     1 => 'templates/export/renderer/',
                 ],
                 'timeout' => 60,
+                'show_default_templates' => true,
             ],
             'calendar' => [
                 'week_numbers' => true,

--- a/tests/Export/Base/DefaultRendererTest.php
+++ b/tests/Export/Base/DefaultRendererTest.php
@@ -51,6 +51,7 @@ class DefaultRendererTest extends AbstractRendererTestCase
             (new XlsxRendererFactoryMock($this))->create(),
             $repository,
             $logger,
+            \App\Tests\Mocks\SystemConfigurationFactory::createStub(['export' => ['show_default_templates' => true]]),
         );
     }
 

--- a/tests/Export/ServiceExportTest.php
+++ b/tests/Export/ServiceExportTest.php
@@ -23,6 +23,7 @@ use App\Tests\Mocks\Export\CsvRendererFactoryMock;
 use App\Tests\Mocks\Export\HtmlRendererFactoryMock;
 use App\Tests\Mocks\Export\PdfRendererFactoryMock;
 use App\Tests\Mocks\Export\XlsxRendererFactoryMock;
+use App\Tests\Mocks\SystemConfigurationFactory;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
@@ -75,6 +76,7 @@ class ServiceExportTest extends TestCase
             (new XlsxRendererFactoryMock($this))->create(),
             $repository,
             $logger,
+            SystemConfigurationFactory::createStub(['export' => ['show_default_templates' => true]]),
         );
     }
 

--- a/translations/system-configuration.en.xlf
+++ b/translations/system-configuration.en.xlf
@@ -318,6 +318,10 @@
         <source>invoice.rounding_mode</source>
         <target>Rounding mode</target>
       </trans-unit>
+      <trans-unit id="xP0rtT5" resname="export.show_default_templates">
+        <source>export.show_default_templates</source>
+        <target>Show default export templates</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>


### PR DESCRIPTION
Fixes #6026.

## Description

Adds a toggle in System → Settings → Export to show/hide the built-in export templates (CSV, XLSX, PDF, print, timesheet). When disabled, only custom templates created via the Export page appear in the dropdown.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] I verified that my code applies to the guidelines (`composer code-check`)
- [ ] I updated the documentation (see [here](https://github.com/kimai/www.kimai.org/tree/master/_documentation))
- [x] I agree that this code is used in Kimai (see [license](https://github.com/kimai/kimai/blob/main/LICENSE))
<img width="1857" height="865" alt="screenshot-2026-08-02_21-28-09" src="https://github.com/user-attachments/assets/c43e94fb-f478-4295-887d-e22b0ac3c55d" />
<img width="1879" height="943" alt="screenshot-2026-08-02_21-11-34" src="https://github.com/user-attachments/assets/6dbf3d79-5cc3-4706-8db5-2d1d1f5bf5b4" />