### PR TITLE
Increase language column length

### DIFF
--- a/migrations/Version20260802144517.php
+++ b/migrations/Version20260802144517.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of the Kimai time-tracking app.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace DoctrineMigrations;
+
+use App\Doctrine\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * @version 2.63
+ */
+final class Version20260802144517 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Increases language column length';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $schema->getTable('kimai2_export_templates')->getColumn('language')->setLength(35);
+        $schema->getTable('kimai2_invoice_templates')->getColumn('language')->setLength(35);
+    }
+
+    public function down(Schema $schema): void
+    {
+        $schema->getTable('kimai2_export_templates')->getColumn('language')->setLength(6);
+        $schema->getTable('kimai2_invoice_templates')->getColumn('language')->setLength(6);
+    }
+
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+}

--- a/src/Entity/ExportTemplate.php
+++ b/src/Entity/ExportTemplate.php
@@ -38,7 +38,7 @@ class ExportTemplate
     /**
      * Used for header column translation.
      */
-    #[ORM\Column(name: 'language', type: Types::STRING, length: 6, nullable: true)]
+    #[ORM\Column(name: 'language', type: Types::STRING, length: 35, nullable: true)]
     #[Assert\Locale]
     private ?string $language = null;
     /**

--- a/src/Entity/ExportTemplate.php
+++ b/src/Entity/ExportTemplate.php
@@ -39,6 +39,7 @@ class ExportTemplate
      * Used for header column translation.
      */
     #[ORM\Column(name: 'language', type: Types::STRING, length: 35, nullable: true)]
+    #[Assert\Length(min: 2, max: 35)]
     #[Assert\Locale]
     private ?string $language = null;
     /**

--- a/src/Entity/InvoiceTemplate.php
+++ b/src/Entity/InvoiceTemplate.php
@@ -74,6 +74,7 @@ class InvoiceTemplate implements EntityWithMetaFields
      * Used for translations and formatting money, numbers, dates and time.
      */
     #[ORM\Column(name: 'language', type: Types::STRING, length: 35, nullable: false)]
+    #[Assert\Length(min: 2, max: 35)]
     #[Assert\NotBlank]
     private ?string $language = 'en';
     /**

--- a/src/Entity/InvoiceTemplate.php
+++ b/src/Entity/InvoiceTemplate.php
@@ -73,7 +73,7 @@ class InvoiceTemplate implements EntityWithMetaFields
     /**
      * Used for translations and formatting money, numbers, dates and time.
      */
-    #[ORM\Column(name: 'language', type: Types::STRING, length: 6, nullable: false)]
+    #[ORM\Column(name: 'language', type: Types::STRING, length: 35, nullable: false)]
     #[Assert\NotBlank]
     private ?string $language = 'en';
     /**


### PR DESCRIPTION
## Description

Language column length is prone to failures, due to length restriction of 6, which fails for example with `zh_Hant_TW `.

There seems to be no clear max length recommendations. 
It would be 14 chars for ca_ES_VALENCIA which seems to be the longest "normal" locale, while BCP-47 recommends 35 chars.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] I verified that my code applies to the guidelines (`composer code-check`)
- [ ] I updated the documentation (see [here](https://github.com/kimai/www.kimai.org/tree/master/_documentation))
- [x] I agree that this code is used in Kimai (see [license](https://github.com/kimai/kimai/blob/main/LICENSE))
