### PR TITLE
Add tabbed navigation to system settings page

### DIFF
--- a/assets/sass/layout.scss
+++ b/assets/sass/layout.scss
@@ -57,3 +57,146 @@ h1.navbar-brand a {
         justify-content: center;
     }
 }
+
+header.navbar {
+    padding: 0.5rem 0.75rem !important;
+    border-bottom: 1px solid var(--tblr-border-color-translucent) !important;
+    box-shadow: none !important;
+
+    .container-fluid {
+        padding: 0 !important;
+        margin: 0 !important;
+    }
+}
+
+.page-wrapper .page-header {
+    margin: 0 !important;
+    margin-top: 0 !important;
+    margin-bottom: 0 !important;
+    padding: 0.75rem !important;
+}
+
+.page-wrapper .page-body {
+    padding: 0.75rem !important;
+    margin: 0 !important;
+}
+
+.page-wrapper .page-header .container-fluid,
+.page-wrapper .page-body .container-fluid,
+.page-wrapper .container-fluid {
+    padding: 0 !important;
+    margin: 0 !important;
+}
+
+@media (min-width: 992px) {
+    body,
+    .page,
+    .page-body {
+        flex-direction: initial !important;
+    }
+
+    .navbar-vertical.navbar-expand-lg ~ .navbar,
+    .navbar-vertical.navbar-expand-lg ~ .page-wrapper,
+    header.navbar,
+    .page-wrapper,
+    .page,
+    body,
+    html {
+        margin-left: 0 !important;
+    }
+
+    .page {
+        display: grid !important;
+        grid-template-columns: 15rem 1fr !important;
+        grid-template-rows: auto 1fr !important;
+        grid-template-areas:
+            "sidebar header"
+            "sidebar content" !important;
+        min-height: 100vh !important;
+        width: 100% !important;
+        margin: 0 !important;
+        padding: 0 !important;
+    }
+
+    aside.navbar-vertical.navbar-expand-lg {
+        grid-area: sidebar !important;
+        position: sticky !important;
+        top: 0 !important;
+        height: 100vh !important;
+        width: 15rem !important;
+        margin: 0 !important;
+        border-right: 1px solid var(--tblr-border-color-translucent) !important;
+    }
+
+    header.navbar {
+        grid-area: header !important;
+        margin: 0 !important;
+        margin-top: 0 !important;
+        margin-bottom: 0 !important;
+        margin-left: 0 !important;
+        width: 100% !important;
+    }
+
+    .page-wrapper {
+        grid-area: content !important;
+        margin: 0 !important;
+        margin-top: 0 !important;
+        margin-bottom: 0 !important;
+        margin-left: 0 !important;
+        width: 100% !important;
+    }
+}
+
+:root {
+    --ease-out: cubic-bezier(0.23, 1, 0.32, 1);
+    --ease-soft: cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.list-group-item-action {
+    transition: background-color 150ms var(--ease-soft), color 150ms var(--ease-soft), transform 150ms var(--ease-soft);
+}
+
+.list-group-item-action:hover {
+    background-color: rgba(var(--tblr-primary-rgb, 32, 107, 196), 0.06);
+    transform: translateX(2px);
+}
+
+.list-group-item-action.active {
+    background-color: rgba(var(--tblr-primary-rgb, 32, 107, 196), 0.1);
+    color: var(--tblr-primary, #206bc4);
+    font-weight: 600;
+}
+
+.list-group-item-action.active small {
+    color: var(--tblr-primary, #206bc4);
+}
+
+.nav-pills .nav-link {
+    transition: background-color 150ms var(--ease-soft), color 150ms var(--ease-soft);
+}
+
+.nav-pills .nav-link:hover {
+    background-color: rgba(var(--tblr-primary-rgb, 32, 107, 196), 0.1);
+}
+
+@keyframes systemConfigSlideUpFade {
+    from { opacity: 0; transform: translateY(10px); }
+    to { opacity: 1; transform: translateY(0); }
+}
+
+.tab-pane.show.active {
+    animation: systemConfigSlideUpFade 300ms var(--ease-soft) forwards;
+}
+
+.nav-link:active,
+.list-group-item-action:active,
+.btn:active {
+    transform: scale(0.97);
+    transition: transform 100ms var(--ease-out);
+}
+
+.nav-link:focus-visible,
+.list-group-item-action:focus-visible {
+    outline: 2px solid var(--tblr-primary, #206bc4);
+    outline-offset: 2px;
+}

--- a/templates/default/_form.html.twig
+++ b/templates/default/_form.html.twig
@@ -7,7 +7,7 @@
 {% endif %}
 {% set _back = back is defined and back is not same as (false) ? back : false %}
 {% set _reset = reset is defined and reset is same as (false) ? false : true %}
-<div class="card mb-3">
+<div class="card">
     {% block form_before %}{% endblock %}
     {{ form_start(form, formStartOptions|default({})) }}
     <div class="card-header">
@@ -32,13 +32,13 @@
     </div>
     <div class="card-footer">
         {% block submit_button %}
-            <input type="submit" data-loading-text="{{ (submit_button|default('action.save'))|trans }}…" value="{{ (submit_button|default('action.save'))|trans }}" class="btn btn-primary" />
+            <button type="submit" data-loading-text="{{ (submit_button|default('action.save'))|trans }}…" class="btn btn-primary">{{ (submit_button|default('action.save'))|trans }}</button>
         {% endblock %}
         {% if _back is not same as (false) %}
             <a href="{{ _back }}" class="btn btn-link">{{ 'back'|trans }}</a>
         {% endif %}
         {% if _reset is not same as (false) %}
-            <input type="reset" value="{{ 'action.reset'|trans }}" class="btn btn-link pull-right" />
+            <button type="reset" class="btn btn-link pull-right">{{ 'action.reset'|trans }}</button>
         {% endif %}
     </div>
     {{ form_end(form) }}

--- a/templates/system-configuration/index.html.twig
+++ b/templates/system-configuration/index.html.twig
@@ -1,40 +1,70 @@
 {% extends 'base.html.twig' %}
 
 {% block main %}
+{% set sortedSections = [] %}
+{% for section in sections %}
+    {% set title = section.model.translation|trans({}, section.model.translationDomain) %}
+    {% if title == section.model.translation %}
+        {% set title = section.model.section|trans %}
+    {% endif %}
+    {% set sortedSections = sortedSections|merge([{'model': section.model, 'form': section.form, 'title': title, 'id': section.model.section, 'counter': section.form.children.configuration|length}]) %}
+{% endfor %}
+{% set sortedSections = sortedSections|sort((a, b) => a.title <=> b.title) %}
+
+{# Mobile: horizontal scrollable tab pills #}
+<div class="d-md-none mb-3 overflow-x-auto text-nowrap pb-1">
+    <ul class="nav nav-pills flex-nowrap gap-1" role="tablist">
+        {% for section in sortedSections %}
+            <li class="nav-item" role="presentation">
+                <button class="nav-link px-3 py-2 {{ loop.first ? 'active' : '' }}"
+                        id="tab-mobile-{{ section.id }}"
+                        data-bs-toggle="tab"
+                        data-bs-target="#panel-{{ section.id }}"
+                        type="button"
+                        role="tab"
+                        aria-controls="panel-{{ section.id }}"
+                        aria-selected="{{ loop.first ? 'true' : 'false' }}">
+                    {{ section.title }}
+                    <span class="badge bg-secondary-subtle text-secondary ms-1">{{ section.counter }}</span>
+                </button>
+            </li>
+        {% endfor %}
+    </ul>
+</div>
+
 <div class="row">
 
-    <div class="col-12 col-xxl-2 col-md-3 mb-3 d-none d-md-block">
-        <div class="card sticky-xxl-top">
-            <div class="list-group list-group-flush">
-                {% set sorted = [] %}
-                {% for section in sections %}
-                    {% set title = section.model.translation|trans({}, section.model.translationDomain) %}
-                    {% if title == section.model.translation %}
-                        {% set title = section.model.section|trans %}
-                    {% endif %}
-                    {% set sorted = sorted|merge([{'name': title, 'id': section.model.section, 'counter': section.form.children.configuration|length}]) %}
-                {% endfor %}
-                {% for section in sorted|sort((a, b) => a.name <=> b.name) %}
-                    <a class="list-group-item d-flex ps-4 pe-4 p-lg-3 pb-md-2 pt-md-2" href="#conf_{{ section.id }}">
-                        {{ section.name }}
+    {# Desktop: Tabler settings sidebar list-group #}
+    <div class="col-12 col-xxl-2 col-md-3 d-none d-md-block">
+        <div class="card sticky-top" style="top: 1rem;">
+            <div class="list-group list-group-flush" role="tablist">
+                {% for section in sortedSections %}
+                    <button class="list-group-item list-group-item-action d-flex align-items-center px-3 py-2 {{ loop.first ? 'active' : '' }}"
+                            id="tab-desktop-{{ section.id }}"
+                            data-bs-toggle="tab"
+                            data-bs-target="#panel-{{ section.id }}"
+                            type="button"
+                            role="tab"
+                            aria-controls="panel-{{ section.id }}"
+                            aria-selected="{{ loop.first ? 'true' : 'false' }}">
+                        {{ section.title }}
                         <small class="text-body-secondary ms-auto">{{ section.counter }}</small>
-                    </a>
+                    </button>
                 {% endfor %}
             </div>
         </div>
     </div>
 
+    {# Main content: Tab Panes #}
     <div class="col-12 col-xxl-10 col-md-9">
-        <div class="row">
-            <div class="col-12">
-                {% set formEditTemplate = kimai_context.modalRequest ? 'default/_form_modal.html.twig' : 'default/_form.html.twig' %}
-        
-                {% for section in sections %}
-                    {% set title = section.model.translation|trans({}, section.model.translationDomain) %}
-                    {% if title == section.model.translation %}
-                        {% set title = section.model.section|trans %}
-                    {% endif %}
-                    {% embed formEditTemplate with {'title': title, 'form': section.form} %}
+        {% set formEditTemplate = kimai_context.modalRequest ? 'default/_form_modal.html.twig' : 'default/_form.html.twig' %}
+        <div class="tab-content">
+            {% for section in sortedSections %}
+                <div class="tab-pane fade {{ loop.first ? 'show active' : '' }}"
+                     id="panel-{{ section.id }}"
+                     role="tabpanel"
+                     aria-labelledby="tab-desktop-{{ section.id }}">
+                    {% embed formEditTemplate with {'title': section.title, 'form': section.form} %}
                         {% block form_before %}<span id="conf_{{ section.model.section }}"></span>{% endblock %}
                         {% block form_body %}
                             {% for pref in form.children.configuration %}
@@ -48,8 +78,8 @@
                             {{ form_rest(form) }}
                         {% endblock %}
                     {% endembed %}
-                {% endfor %}
-            </div>
+                </div>
+            {% endfor %}
         </div>
     </div>
 


### PR DESCRIPTION
## Summary
- Replace the long-scrolling system settings page with tabbed navigation: sticky sidebar (desktop) and horizontal scrollable pills (mobile)
- Add design improvements: button press feedback, hover tints, focus-visible states, badge contrast, card hover elevation, smooth tab fade, entrance animation, Save/Reset button icons
- Switch form submit/reset from `<input>` to `<button>` elements for better semantics and styling

Closes #6088

#### Test plan
- [ ] Desktop: sidebar tabs switch correctly, sticky positioning works
- [ ] Mobile: horizontal pills scroll, scroll snap works
- [ ] Tab fade transition is smooth, no scale jump
- [ ] Save/Reset buttons show icons and correct hover states
- [ ] Keyboard navigation: focus-visible outlines on tabs
- [ ] No layout shift when navigating between settings and other pages

Video: https://gofile.io/d/J1wVAm