### PR TITLE
add company to invoice entity

### DIFF
--- a/migrations/Version20260803120000.php
+++ b/migrations/Version20260803120000.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the Kimai time-tracking app.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace DoctrineMigrations;
+
+use App\Doctrine\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * @version 2.63
+ */
+final class Version20260803120000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add company to invoice';
+    }
+
+    public function up(Schema $schema): void
+    {
+        if (!$schema->getTable('kimai2_invoices')->hasColumn('company')) {
+            $this->addSql('ALTER TABLE kimai2_invoices ADD `company` VARCHAR(255) DEFAULT NULL');
+        }
+    }
+
+    public function down(Schema $schema): void
+    {
+        if ($schema->getTable('kimai2_invoices')->hasColumn('company')) {
+            $this->addSql('ALTER TABLE kimai2_invoices DROP COLUMN `company`');
+        }
+    }
+}

--- a/src/Entity/Invoice.php
+++ b/src/Entity/Invoice.php
@@ -29,7 +29,7 @@ use Symfony\Component\Validator\Constraints as Assert;
 #[UniqueEntity('invoiceNumber')]
 #[UniqueEntity('invoiceFilename')]
 #[Serializer\ExclusionPolicy('all')]
-#[Exporter\Order(['id', 'createdAt', 'invoiceNumber', 'status', 'customer', 'subtotal', 'total', 'tax', 'currency', 'vat', 'dueDays', 'dueDate', 'paymentDate', 'user', 'invoiceFilename', 'customerNumber', 'comment'])]
+#[Exporter\Order(['id', 'createdAt', 'invoiceNumber', 'status', 'customer', 'company', 'subtotal', 'total', 'tax', 'currency', 'vat', 'dueDays', 'dueDate', 'paymentDate', 'user', 'invoiceFilename', 'customerNumber', 'comment'])]
 #[Exporter\Expose(name: 'customer', label: 'customer', exp: 'object.getCustomer() === null ? null : object.getCustomer().getName()')]
 #[Exporter\Expose(name: 'customerNumber', label: 'number', exp: 'object.getCustomer() === null ? null : object.getCustomer().getNumber()')]
 #[Exporter\Expose(name: 'dueDate', label: 'invoice.due_days', type: 'datetime', exp: 'object.getDueDate() === null ? null : object.getDueDate()')]
@@ -115,6 +115,11 @@ class Invoice implements EntityWithMetaFields
     #[Serializer\Groups(['Default'])]
     #[Exporter\Expose(label: 'tax_rate', type: 'float')]
     private float $vat = 0.00;
+    #[ORM\Column(name: 'company', type: Types::STRING, length: 255, nullable: true)]
+    #[Serializer\Expose]
+    #[Serializer\Groups(['Default'])]
+    #[Exporter\Expose(label: 'company', type: 'string')]
+    private ?string $company = null;
     #[ORM\Column(name: 'status', type: Types::STRING, length: 20, nullable: false)]
     #[Assert\NotNull]
     #[Serializer\Expose]
@@ -248,6 +253,7 @@ class Invoice implements EntityWithMetaFields
         $this->setCreatedAt($model->getInvoiceDate());
         $this->setDueDays($template->getDueDays());
         $this->setVat($template->getVat());
+        $this->setCompany($template->getCompany());
 
         return $this;
     }
@@ -418,6 +424,16 @@ class Invoice implements EntityWithMetaFields
     public function setVat(float $vat): void
     {
         $this->vat = $vat;
+    }
+
+    public function getCompany(): ?string
+    {
+        return $this->company;
+    }
+
+    public function setCompany(?string $company): void
+    {
+        $this->company = $company;
     }
 
     public function setInvoiceNumber(string $invoiceNumber): void

--- a/tests/API/APIControllerBaseTestCase.php
+++ b/tests/API/APIControllerBaseTestCase.php
@@ -309,6 +309,7 @@ abstract class APIControllerBaseTestCase extends AbstractControllerBaseTestCase
                 return [
                     'id' => 'int',
                     'comment' => '@string',
+                    'company' => '@string',
                     'createdAt' => 'datetime',
                     'currency' => 'string',
                     'customer' => ['result' => 'object', 'type' => '@Customer'],

--- a/tests/Entity/InvoiceTest.php
+++ b/tests/Entity/InvoiceTest.php
@@ -54,6 +54,7 @@ class InvoiceTest extends AbstractEntityTestCase
         self::assertFalse($sut->isOverdue());
         self::assertNull($sut->getPaymentDate());
         self::assertNull($sut->getComment());
+        self::assertNull($sut->getCompany());
     }
 
     public function testSetInvalidStatus(): void
@@ -129,9 +130,22 @@ class InvoiceTest extends AbstractEntityTestCase
         self::assertEquals(348.99, $sut->getTotal());
         self::assertNotNull($sut->getUser());
         self::assertEquals(19, $sut->getVat());
+        self::assertEquals('Test Company Inc.', $sut->getCompany());
 
         $sut->setComment('foo bar');
         self::assertEquals('foo bar', $sut->getComment());
+    }
+
+    public function testCompanySetterAndGetter(): void
+    {
+        $sut = new Invoice();
+        self::assertNull($sut->getCompany());
+
+        $sut->setCompany('Acme Corp');
+        self::assertEquals('Acme Corp', $sut->getCompany());
+
+        $sut->setCompany(null);
+        self::assertNull($sut->getCompany());
     }
 
     protected function getInvoiceModel(\DateTime $created): InvoiceModel
@@ -146,6 +160,7 @@ class InvoiceTest extends AbstractEntityTestCase
 
         $customer = new Customer('customer,with/special#name');
         $customer->setCurrency('USD');
+        $customer->setCompany('Test Company Inc.');
         $customer->setMetaField((new CustomerMeta())->setName('foo-customer')->setValue('bar-customer')->setIsVisible(true));
         $customer->setVatId('kjuo8967');
 
@@ -153,6 +168,7 @@ class InvoiceTest extends AbstractEntityTestCase
         $template->setTitle('a test invoice template title');
         $template->setVat(19);
         $template->setDueDays(9);
+        $template->setCustomer($customer);
 
         $project = new Project();
         $project->setName('project name');


### PR DESCRIPTION
Closes #5838

The invoice template requires a company, but that company was never stored on the invoice itself. This adds a `company` field to the `Invoice` entity, snapshotted at creation time via `setModel()` — same as `vat`, `dueDays`, and `currency` already are. The company is then preserved for API responses and exports even if the template or customer changes later.

- new nullable `company` column on `kimai2_invoices` (migration included)
- `setModel()` copies the template company into the invoice
- exposed in the API response and export columns
- tests for the new field, getter/setter, `setModel()` integration, and API response structure