### PR TITLE
support DateTime objects in meta fields

### DIFF
--- a/src/Entity/MetaTableTypeTrait.php
+++ b/src/Entity/MetaTableTypeTrait.php
@@ -9,6 +9,8 @@
 
 namespace App\Entity;
 
+use App\Form\Type\DatePickerType;
+use App\Form\Type\DateTimePickerType;
 use App\Form\Type\YesNoType;
 use App\Validator\Constraints as Constraints;
 use Doctrine\DBAL\Types\Types;
@@ -99,6 +101,7 @@ trait MetaTableTypeTrait
             YesNoType::class, CheckboxType::class => (\is_string($value) || \is_int($value)) ? (bool) $value : $value,
             IntegerType::class => (\is_string($value) || \is_int($value)) ? (int) $value : $value,
             NumberType::class => (\is_string($value) || \is_float($value)) ? (float) $value : $value,
+            DatePickerType::class, DateTimePickerType::class => (\is_string($value) && $value !== '') ? new \DateTime($value) : $value,
             default => $value
         };
     }
@@ -125,6 +128,8 @@ trait MetaTableTypeTrait
 
         if ($value === null) {
             $this->value = $value;
+        } elseif ($value instanceof \DateTimeInterface) {
+            $this->value = $value->format('Y-m-d H:i:s');
         } elseif (\is_scalar($value)) {
             $this->value = (string) $value;
         }

--- a/tests/Entity/AbstractMetaEntityTestCase.php
+++ b/tests/Entity/AbstractMetaEntityTestCase.php
@@ -11,6 +11,7 @@ namespace App\Tests\Entity;
 
 use App\Entity\EntityWithMetaFields;
 use App\Entity\MetaTableTypeInterface;
+use App\Form\Type\DatePickerType;
 use App\Form\Type\DateTimePickerType;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Validator\Constraints\Length;
@@ -89,6 +90,42 @@ abstract class AbstractMetaEntityTestCase extends TestCase
         self::assertEquals('foo', $sut->getSection());
         $sut->setSection(null);
         self::assertNull($sut->getSection());
+    }
+
+    public function testDateTimeSetValueAndGetValue(): void
+    {
+        $sut = $this->getMetaEntity();
+        $sut->setType(DateTimePickerType::class);
+
+        $date = new \DateTime('2026-01-15 14:30:00');
+        $sut->setValue($date);
+
+        // getValue returns a DateTime instance restored from the stored string
+        $result = $sut->getValue();
+        self::assertInstanceOf(\DateTime::class, $result);
+        self::assertEquals('2026-01-15 14:30:00', $result->format('Y-m-d H:i:s'));
+    }
+
+    public function testDatePickerSetValueAndGetValue(): void
+    {
+        $sut = $this->getMetaEntity();
+        $sut->setType(DatePickerType::class);
+
+        $date = new \DateTime('2026-03-20 00:00:00');
+        $sut->setValue($date);
+
+        $result = $sut->getValue();
+        self::assertInstanceOf(\DateTime::class, $result);
+        self::assertEquals('2026-03-20 00:00:00', $result->format('Y-m-d H:i:s'));
+    }
+
+    public function testDateTimeGetValueWithNull(): void
+    {
+        $sut = $this->getMetaEntity();
+        $sut->setType(DateTimePickerType::class);
+        $sut->setValue(null);
+
+        self::assertNull($sut->getValue());
     }
 
     public function testMerge(): void


### PR DESCRIPTION
Closes #5833

Meta fields store values as TEXT strings. When a DateTime form type is used, saving a `DateTime` object silently dropped the value, and reading it back crashed because the form transformer expected a `DateTimeInterface` but got a string.

This adds DateTime handling to `MetaTableTypeTrait`, mirroring how it already converts bool, int, and float:

- `setValue()` — formats `DateTimeInterface` to `Y-m-d H:i:s` before storing
- `getValue()` — converts the stored string back to a `DateTime` for `DateTimePickerType` and `DatePickerType`

Tests added to `AbstractMetaEntityTestCase` covering set/get round-trip and null, running across all 6 meta entity types.