### PR TITLE
show weekly total in calendar week view

### DIFF
--- a/assets/js/widgets/KimaiCalendar.js
+++ b/assets/js/widgets/KimaiCalendar.js
@@ -766,11 +766,16 @@ export default class KimaiCalendar {
 
         const dailyTotals = document.querySelectorAll('.fc-dailytotal');
         dailyTotals.forEach(element => element.remove());
+        let weekTotalSeconds = 0;
         for (const dateValue in durations) {
             const durationValue = durations[dateValue];
 
             if (view === 'timeGridWeek') { // this is the week view
                 const headerCells = document.querySelectorAll(`th.fc-col-header-cell[data-date="${dateValue}"]`);
+
+                if (headerCells.length > 0) {
+                    weekTotalSeconds += durationValue;
+                }
 
                 headerCells.forEach(cell => {
                     const newElement = document.createElement('div');
@@ -778,6 +783,17 @@ export default class KimaiCalendar {
                     newElement.textContent = DATES.formatSeconds(durationValue);
                     cell.appendChild(newElement);
                 });
+            }
+        }
+
+        // show the weekly total next to the week number in the week view
+        if (view === 'timeGridWeek') {
+            const weekCushion = document.querySelector('.fc-timegrid-axis-cushion');
+            if (weekCushion !== null) {
+                const weekTotalElement = document.createElement('div');
+                weekTotalElement.classList.add('fc-dailytotal', 'fc-weektotal');
+                weekTotalElement.textContent = DATES.formatSeconds(weekTotalSeconds);
+                weekCushion.appendChild(weekTotalElement);
             }
         }
 

--- a/assets/js/widgets/KimaiCalendar.js
+++ b/assets/js/widgets/KimaiCalendar.js
@@ -773,6 +773,7 @@ export default class KimaiCalendar {
             if (view === 'timeGridWeek') { // this is the week view
                 const headerCells = document.querySelectorAll(`th.fc-col-header-cell[data-date="${dateValue}"]`);
 
+                // only count durations that have a visible column (excludes hidden weekends and out-of-range dates)
                 if (headerCells.length > 0) {
                     weekTotalSeconds += durationValue;
                 }
@@ -788,11 +789,13 @@ export default class KimaiCalendar {
 
         // show the weekly total next to the week number in the week view
         if (view === 'timeGridWeek') {
-            const weekCushion = document.querySelector('.fc-timegrid-axis-cushion');
+            // scope to the header table to avoid matching the all-day row cushion
+            const weekCushion = document.querySelector('.fc-col-header .fc-timegrid-axis-cushion') ?? document.querySelector('.fc-col-header .fc-timegrid-axis-frame');
             if (weekCushion !== null) {
                 const weekTotalElement = document.createElement('div');
                 weekTotalElement.classList.add('fc-dailytotal', 'fc-weektotal');
                 weekTotalElement.textContent = DATES.formatSeconds(weekTotalSeconds);
+                weekTotalElement.title = DATES.formatSeconds(weekTotalSeconds);
                 weekCushion.appendChild(weekTotalElement);
             }
         }

--- a/assets/sass/calendar.scss
+++ b/assets/sass/calendar.scss
@@ -20,7 +20,7 @@
 .fc-day-sat, .fc-day-sun { background-color: var(--tblr-bg-surface-secondary); }
 
 .fc-weektotal {
-    display: inline-block;
-    padding: 2px 4px;
+    display: block;
     text-align: center;
+    padding: 4px 8px;
 }

--- a/assets/sass/calendar.scss
+++ b/assets/sass/calendar.scss
@@ -18,3 +18,9 @@
 }
 
 .fc-day-sat, .fc-day-sun { background-color: var(--tblr-bg-surface-secondary); }
+
+.fc-weektotal {
+    display: inline-block;
+    padding: 2px 4px;
+    text-align: center;
+}


### PR DESCRIPTION
Closes #5841

Shows the total duration for the whole week below the week number in the first column of the calendar week view, matching the style of the existing daily totals in the column headers.

<img width="1851" height="810" alt="screenshot-2026-08-03_04-52-22" src="https://github.com/user-attachments/assets/18e251ea-f8f2-4a93-84e9-7b2baee69958" />