### PR TITLE
Fix truncation of decimal durations by one second

### DIFF
--- a/src/Utils/Duration.php
+++ b/src/Utils/Duration.php
@@ -117,7 +117,10 @@ final class Duration
         $duration = (float) $duration;
         $duration = $duration * 3600;
 
-        return (int) $duration;
+        // most decimal fractions cannot be represented exactly as float, so the multiplication
+        // above returns values like 29519.999999999996 for "8.20" hours. Casting that to int
+        // truncates and the result would be one second (and one displayed minute) short: 8:11.
+        return (int) round($duration);
     }
 
     private function parseColonFormat(string $duration): int

--- a/tests/Utils/DurationTest.php
+++ b/tests/Utils/DurationTest.php
@@ -25,6 +25,18 @@ class DurationTest extends TestCase
         self::assertEquals('2:38', $sut->format(9494));
     }
 
+    public function testDecimalFormatRoundTrip(): void
+    {
+        $sut = new Duration();
+
+        // a duration that is a multiple of three minutes can be expressed exactly with two
+        // decimal places, so formatting and re-parsing it must return the original seconds
+        for ($seconds = 180; $seconds <= 86400; $seconds += 180) {
+            $decimal = number_format($seconds / 3600, 2, '.', '');
+            self::assertSame($seconds, $sut->parseDuration($decimal, Duration::FORMAT_DECIMAL), 'Failed parsing "' . $decimal . '"');
+        }
+    }
+
     #[DataProvider('getParseDurationTestData')]
     public function testParseDurationString($expected, $duration, $mode): void
     {
@@ -49,6 +61,20 @@ class DurationTest extends TestCase
             [5400, '1,5', Duration::FORMAT_DECIMAL],
             [-5400, '-1.5', Duration::FORMAT_DECIMAL],
             [-5400, '-1,5', Duration::FORMAT_DECIMAL],
+
+            // decimal hours whose float representation is slightly below the exact value:
+            // they must not be truncated down to the previous second, which would also
+            // shift the displayed time by a full minute (e.g. 8.20 => 8:11 instead of 8:12)
+            [7380, '2.05', Duration::FORMAT_DECIMAL],
+            [14760, '4.10', Duration::FORMAT_DECIMAL],
+            [15660, '4.35', Duration::FORMAT_DECIMAL],
+            [29520, '8.20', Duration::FORMAT_DECIMAL],
+            [29520, '8,20', Duration::FORMAT_DECIMAL],
+            [-29520, '-8.20', Duration::FORMAT_DECIMAL],
+            [30420, '8.45', Duration::FORMAT_DECIMAL],
+            [31320, '8.70', Duration::FORMAT_DECIMAL],
+            [32220, '8.95', Duration::FORMAT_DECIMAL],
+            [58140, '16.15', Duration::FORMAT_DECIMAL],
 
             [0, '', Duration::FORMAT_NATURAL],
             [0, 0, Duration::FORMAT_NATURAL],

--- a/tests/Utils/DurationTest.php
+++ b/tests/Utils/DurationTest.php
@@ -32,7 +32,7 @@ class DurationTest extends TestCase
         // a duration that is a multiple of three minutes can be expressed exactly with two
         // decimal places, so formatting and re-parsing it must return the original seconds
         for ($seconds = 180; $seconds <= 86400; $seconds += 180) {
-            $decimal = number_format($seconds / 3600, 2, '.', '');
+            $decimal = (string) $sut->formatDecimal($seconds);
             self::assertSame($seconds, $sut->parseDuration($decimal, Duration::FORMAT_DECIMAL), 'Failed parsing "' . $decimal . '"');
         }
     }


### PR DESCRIPTION
## Description

Parsing a decimal duration multiplies the float by 3600 and casts the result to `int`. Because most decimal fractions have no exact binary representation, that product often lands marginally below the real value — `"8.20"` hours becomes `29519.999999999996` — and the cast truncates it to one second less than intended.

For every third minute the missing second also shifts the *displayed* time by a full minute: entering `8.20` stored 29519 seconds and rendered as `8:11` instead of `8:12`. It equally broke the round trip of the decimal duration values Kimai exports itself.

```
8.20 * 3600 = 29519.999999999996
  (int)  -> 29519  -> 8:11
  round  -> 29520  -> 8:12
```

Rounding to the nearest second removes the artefact. Values that were already exact are unaffected.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] I verified that my code applies to the guidelines (`composer code-check`)
- [ ] I updated the documentation (not needed — no behaviour beyond the corrected value)
- [x] I agree that this code is used in Kimai (see license)

Prepared with AI assistance (Claude); verified fail-before/pass-after, plus PHPStan (`tests/phpstan.neon` clean; the 7 errors under `phpstan.neon` are pre-existing in `TranslationCommand.php` and reproduce on a pristine `main`) and php-cs-fixer.
