### PR TITLE
Show QR code with new API token for app configuration

### DIFF
--- a/src/Controller/ProfileController.php
+++ b/src/Controller/ProfileController.php
@@ -257,11 +257,14 @@ final class ProfileController extends AbstractController
             $qrCodePayload = (new AppConnectPayload($baseUrl, $createdToken->getToken()))->toJson();
         }
 
+        $pageSetup = $this->getPageSetup($profile, 'api-token');
+        $pageSetup->setHelp('user-api.html');
+
         return $this->render('user/api-token.html.twig', [
             'tab' => 'api-token',
             'created_token' => $createdToken,
             'access_tokens' => $accessTokens,
-            'page_setup' => $this->getPageSetup($profile, 'api-token'),
+            'page_setup' => $pageSetup,
             'user' => $profile,
             'form' => $form->createView(),
             'api_url' => $baseUrl . '/api',

--- a/src/Controller/ProfileController.php
+++ b/src/Controller/ProfileController.php
@@ -46,6 +46,7 @@ use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
 
 /**
@@ -248,6 +249,21 @@ final class ProfileController extends AbstractController
             }
         }
 
+        $baseUrl = rtrim($this->generateUrl('home', [], UrlGeneratorInterface::ABSOLUTE_URL), '/');
+        $qrCodePayload = null;
+
+        if ($createdToken !== null) {
+            // this payload is a public contract with the mobile apps: only add fields, never rename or remove them.
+            // example: {"type":"kimai","version":1,"url":"https://127.0.0.1:8000","token":"6ccc2932be3a7e8fa1dd2c254"}
+            // "version" has to be raised, if the meaning of an existing field changes.
+            $qrCodePayload = json_encode([
+                'type' => 'kimai',
+                'version' => 1,
+                'url' => $baseUrl,
+                'token' => $createdToken->getToken(),
+            ], JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES);
+        }
+
         return $this->render('user/api-token.html.twig', [
             'tab' => 'api-token',
             'created_token' => $createdToken,
@@ -255,6 +271,8 @@ final class ProfileController extends AbstractController
             'page_setup' => $this->getPageSetup($profile, 'api-token'),
             'user' => $profile,
             'form' => $form->createView(),
+            'api_url' => $baseUrl . '/api',
+            'qr_code_payload' => $qrCodePayload,
         ]);
     }
 

--- a/src/Controller/ProfileController.php
+++ b/src/Controller/ProfileController.php
@@ -24,6 +24,7 @@ use App\Form\UserPreferencesForm;
 use App\Form\UserRolesType;
 use App\Form\UserTeamsType;
 use App\Form\UserTwoFactorType;
+use App\Model\AppConnectPayload;
 use App\Repository\AccessTokenRepository;
 use App\Repository\Query\TimesheetStatisticQuery;
 use App\Repository\TeamRepository;
@@ -253,15 +254,7 @@ final class ProfileController extends AbstractController
         $qrCodePayload = null;
 
         if ($createdToken !== null) {
-            // this payload is a public contract with the mobile apps: only add fields, never rename or remove them.
-            // example: {"type":"kimai","version":1,"url":"https://127.0.0.1:8000","token":"6ccc2932be3a7e8fa1dd2c254"}
-            // "version" has to be raised, if the meaning of an existing field changes.
-            $qrCodePayload = json_encode([
-                'type' => 'kimai',
-                'version' => 1,
-                'url' => $baseUrl,
-                'token' => $createdToken->getToken(),
-            ], JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES);
+            $qrCodePayload = (new AppConnectPayload($baseUrl, $createdToken->getToken()))->toJson();
         }
 
         return $this->render('user/api-token.html.twig', [

--- a/src/Model/AppConnectPayload.php
+++ b/src/Model/AppConnectPayload.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of the Kimai time-tracking app.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Model;
+
+/**
+ * The payload that is encoded into the QR code, which is shown once after an API token was created.
+ *
+ * This is a public contract with the Kimai apps:
+ * - fields may only be added, they must never be renamed or removed
+ * - VERSION has to be raised, if the meaning of an existing field changes
+ *
+ * The "url" field is the Kimai base URL: the very same value that a user would enter manually.
+ * It never ends with a slash and it does NOT contain the "/api" path, because apps append that
+ * themselves - exactly like they do it with a manually entered URL.
+ *
+ * Example: {"type":"kimai","version":1,"url":"https://127.0.0.1:8000","token":"6ccc2932be3a7e8fa1dd2c254"}
+ */
+final class AppConnectPayload
+{
+    public const TYPE = 'kimai';
+    public const VERSION = 1;
+
+    private readonly string $url;
+
+    public function __construct(string $url, private readonly string $token)
+    {
+        $this->url = rtrim($url, '/');
+    }
+
+    public function toJson(): string
+    {
+        // JSON_UNESCAPED_SLASHES keeps the URL readable and the QR code as small as possible
+        return json_encode([
+            'type' => self::TYPE,
+            'version' => self::VERSION,
+            'url' => $this->url,
+            'token' => $this->token,
+        ], JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES);
+    }
+}

--- a/templates/user/api-token.html.twig
+++ b/templates/user/api-token.html.twig
@@ -10,7 +10,7 @@
                     {{ 'api_password.intro'|trans }}
                 </p>
                 <p>
-                    <strong>URL</strong>: {{ url('api.swagger_ui', {}, false)|replace({'/doc': ''}) }}
+                    <strong>URL</strong>: {{ api_url }}
                 </p>
             </div>
 
@@ -34,6 +34,15 @@
                         </div>
                         <pre><code>{{ created_token.token }}</code></pre>
                     </div>
+                    {% if qr_code_payload is not null %}
+                        <p class="mt-3 mb-1">
+                            <img style="max-width: 200px; max-height: 200px;" alt="API QR code" src="{{ qr_code_data_uri(qr_code_payload) }}" />
+                        </p>
+                        <p class="text-secondary">
+                            <i class="{{ 'info'|icon(false) }}"></i>
+                            {{ 'api_token_qr_hint'|trans }}
+                        </p>
+                    {% endif %}
                 </div>
             </div>
         {% endif %}

--- a/tests/Controller/ProfileControllerTest.php
+++ b/tests/Controller/ProfileControllerTest.php
@@ -279,7 +279,6 @@ class ProfileControllerTest extends AbstractControllerBaseTestCase
         self::assertEquals(1, $copy->count());
         $code = $block->filter('pre code');
         self::assertEquals(1, $code->count());
-        self::assertEquals(1, $copy->filter('button[data-clipboard-text]')->count());
 
         $tokens = $tokenRepository->findForUser($user);
         self::assertCount(2, $tokens);

--- a/tests/Controller/ProfileControllerTest.php
+++ b/tests/Controller/ProfileControllerTest.php
@@ -279,11 +279,19 @@ class ProfileControllerTest extends AbstractControllerBaseTestCase
         self::assertEquals(1, $copy->count());
         $code = $block->filter('pre code');
         self::assertEquals(1, $code->count());
+        self::assertEquals(1, $copy->filter('button[data-clipboard-text]')->count());
 
         $tokens = $tokenRepository->findForUser($user);
         self::assertCount(2, $tokens);
         self::assertEquals('Demo', $tokens[1]->getName());
         self::assertEquals($code->innerText(), $tokens[1]->getToken());
+
+        // the QR code is only rendered together with the one-time token display
+        self::assertEquals(1, $crawler->filter('img[src^="data:image/png"]')->count());
+
+        $this->request($client, '/profile/' . UserFixtures::USERNAME_USER . '/api-token');
+        self::assertTrue($client->getResponse()->isSuccessful());
+        self::assertEquals(0, $client->getCrawler()->filter('img[src^="data:image/png"]')->count());
     }
 
     #[Group('legacy')]

--- a/tests/Controller/ProfileControllerTest.php
+++ b/tests/Controller/ProfileControllerTest.php
@@ -285,6 +285,9 @@ class ProfileControllerTest extends AbstractControllerBaseTestCase
         self::assertEquals('Demo', $tokens[1]->getName());
         self::assertEquals($code->innerText(), $tokens[1]->getToken());
 
+        // the base URL for manual configuration, the QR code contains it without the "/api" suffix
+        self::assertStringContainsString('URL: http://localhost/api', $crawler->text());
+
         // the QR code is only rendered together with the one-time token display
         self::assertEquals(1, $crawler->filter('img[src^="data:image/png"]')->count());
 

--- a/tests/Model/AppConnectPayloadTest.php
+++ b/tests/Model/AppConnectPayloadTest.php
@@ -1,0 +1,82 @@
+<?php
+
+/*
+ * This file is part of the Kimai time-tracking app.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Tests\Model;
+
+use App\Model\AppConnectPayload;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(AppConnectPayload::class)]
+class AppConnectPayloadTest extends TestCase
+{
+    /**
+     * This payload is a public contract with the Kimai apps.
+     * If this test fails, existing apps will break: add fields instead of changing them
+     * and raise AppConnectPayload::VERSION if the meaning of a field changed.
+     */
+    public function testJsonIsStableContract(): void
+    {
+        $sut = new AppConnectPayload('https://127.0.0.1:8000', '6ccc2932be3a7e8fa1dd2c254');
+
+        self::assertEquals(
+            '{"type":"kimai","version":1,"url":"https://127.0.0.1:8000","token":"6ccc2932be3a7e8fa1dd2c254"}',
+            $sut->toJson()
+        );
+    }
+
+    public function testFieldsAreNotRenamed(): void
+    {
+        $sut = new AppConnectPayload('https://www.kimai.org', 'foo-bar');
+
+        $result = json_decode($sut->toJson(), true);
+
+        self::assertIsArray($result);
+        self::assertSame(['type', 'version', 'url', 'token'], array_keys($result));
+        self::assertSame('kimai', $result['type']);
+        self::assertSame(1, $result['version']);
+        self::assertSame('https://www.kimai.org', $result['url']);
+        self::assertSame('foo-bar', $result['token']);
+    }
+
+    public function testUrlIsTheBaseUrlWithoutApiPath(): void
+    {
+        // apps append "/api" themselves, just like they do with a manually entered URL
+        $sut = new AppConnectPayload('https://www.kimai.org', 'foo-bar');
+
+        self::assertStringNotContainsString('/api', $sut->toJson());
+    }
+
+    public function testTrailingSlashIsRemoved(): void
+    {
+        $sut = new AppConnectPayload('https://www.kimai.org/', 'foo-bar');
+
+        $result = json_decode($sut->toJson(), true);
+
+        self::assertIsArray($result);
+        self::assertSame('https://www.kimai.org', $result['url']);
+    }
+
+    public function testSubdirectoryIsKept(): void
+    {
+        $sut = new AppConnectPayload('https://www.kimai.org/kimai/', 'foo-bar');
+
+        $result = json_decode($sut->toJson(), true);
+
+        self::assertIsArray($result);
+        self::assertSame('https://www.kimai.org/kimai', $result['url']);
+    }
+
+    public function testSlashesAreNotEscaped(): void
+    {
+        $sut = new AppConnectPayload('https://www.kimai.org/kimai', 'foo-bar');
+
+        self::assertStringNotContainsString('\/', $sut->toJson());
+    }
+}

--- a/translations/messages.de.xlf
+++ b/translations/messages.de.xlf
@@ -1770,6 +1770,10 @@
         <source>api_token_hidden</source>
         <target>Dies ist das einzige Mal, dass der Token angezeigt wird! Bewahren Sie ihn gut auf und vergewissern Sie sich, dass Sie ihn notiert haben, bevor Sie dieses Fenster schließen.</target>
       </trans-unit>
+      <trans-unit id="G8ZoGoA" resname="api_token_qr_hint">
+        <source>api_token_qr_hint</source>
+        <target>Sie können diesen QR-Code mit einer mobilen App scannen, um Server-URL und Token in einem Schritt zu konfigurieren.</target>
+      </trans-unit>
       <trans-unit id="TCr2ArH" resname="api_password_deprecated" xml:space="preserve" approved="yes">
         <source>api_password_deprecated</source>
         <target state="final">API-Passwörter sind veraltet: bitte nutzen Sie stattdessen API-Tokens.</target>

--- a/translations/messages.de.xlf
+++ b/translations/messages.de.xlf
@@ -1772,7 +1772,7 @@
       </trans-unit>
       <trans-unit id="G8ZoGoA" resname="api_token_qr_hint">
         <source>api_token_qr_hint</source>
-        <target>Sie können diesen QR-Code mit einer mobilen App scannen, um Server-URL und Token in einem Schritt zu konfigurieren.</target>
+        <target>Sie können diesen QR-Code mit einer mobilen App scannen, um Server-URL und Token in einem Schritt zu konfigurieren. Teilen Sie dieses Bild nicht: Es enthält Ihren API-Token.</target>
       </trans-unit>
       <trans-unit id="TCr2ArH" resname="api_password_deprecated" xml:space="preserve" approved="yes">
         <source>api_password_deprecated</source>

--- a/translations/messages.en.xlf
+++ b/translations/messages.en.xlf
@@ -1770,6 +1770,10 @@
         <source>api_token_hidden</source>
         <target>This is the only time this key will ever be displayed! So keep it safe and make sure you've copied it down before closing this window.</target>
       </trans-unit>
+      <trans-unit id="G8ZoGoA" resname="api_token_qr_hint">
+        <source>api_token_qr_hint</source>
+        <target>You can scan this QR code with a mobile app, to configure server URL and token in one step.</target>
+      </trans-unit>
       <trans-unit id="TCr2ArH" resname="api_password_deprecated">
         <source>api_password_deprecated</source>
         <target>API passwords are outdated: please use API tokens instead.</target>

--- a/translations/messages.en.xlf
+++ b/translations/messages.en.xlf
@@ -1772,7 +1772,7 @@
       </trans-unit>
       <trans-unit id="G8ZoGoA" resname="api_token_qr_hint">
         <source>api_token_qr_hint</source>
-        <target>You can scan this QR code with a mobile app, to configure server URL and token in one step.</target>
+        <target>You can scan this QR code with a mobile app, to configure server URL and token in one step. Do not share this image: it contains your API token.</target>
       </trans-unit>
       <trans-unit id="TCr2ArH" resname="api_password_deprecated">
         <source>api_password_deprecated</source>


### PR DESCRIPTION
## Description

This takes the idea from #5613 and displays a QR code when a user created an API token.
<img width="757" height="419" alt="image" src="https://github.com/user-attachments/assets/89ccfb58-56e1-4f21-9810-124125dcae54" />

The QR code can be used by Kimai apps for a user-friendly connection process.

The QR contains a JSON string like this:
```json
{"type":"kimai","version":1,"url":"https://127.0.0.1:8000","token":"6ccc2932be3a7e8fa1dd2c254"}
```

The app can now use the URL field as base URL. If someone hosts under a subdirectory, it would include the subdirectory:
```json
{"type":"kimai","version":1,"url":"https://127.0.0.1:8000/kimai","token":"6ccc2932be3a7e8fa1dd2c254"}
```

Be aware: 
- **The URL ends withou trailing slash**
- The token can be used for the auth header. 

You can use code like this to build the API requests:
```php
$base = rtim($json['url'], '/') . '/api';
$endpoint = $base . '/users/me';
$header = 'Authorization: Bearer ' . $json['token'];
```

Here is an example QR code for testing:

<img width="320" height="320" alt="kimai-qr" src="https://github.com/user-attachments/assets/86d34a41-58ba-437a-928c-c1db2d8c6e79" />

New docs available at https://github.com/kimai/www.kimai.org/pull/752

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] I verified that my code applies to the guidelines (`composer code-check`)
- [x] I updated the documentation (see [here](https://github.com/kimai/www.kimai.org/tree/master/_documentation))
- [x] I agree that this code is used in Kimai (see [license](https://github.com/kimai/kimai/blob/main/LICENSE))
