### PR TITLE
Configure default uri in .env

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -52,3 +52,6 @@ APP_SECRET=
 
 #================================================================================
 CORS_ALLOW_ORIGIN=^https?://localhost(:[0-9]+)?$
+
+# The base URL of your Kimai installation, e.g. used in commands
+DEFAULT_URI=https://127.0.0.1:8000/

--- a/.env.dist
+++ b/.env.dist
@@ -1,57 +1,30 @@
-#
-# Do NOT use this file in production, but instead move the environment variables to one of:
-# - your webserver configuration
-# - your Docker environment
-# - the place where you define your application environment variables
-#
-# The .env file is existing to simplify the initial (test) setup!
-#
-
 #================================================================================
-# Configure your database connection and set the correct server version.
-#
-# You have to replace the following values with your defaults:
-# - the version "10.5.8-MariaDB" (the database server version)
-# - the database "user"
-# - the database "password"
-# - the database schema "database"
-# - you might have to adapt port "3306" and server IP "127.0.0.1" as well
-#
-# For MySQL that would be "serverVersion=5.7" as in:
-#    DATABASE_URL=mysql://user:password@127.0.0.1:3306/database?charset=utf8mb4&serverVersion=5.7
-#
-# For MariaDB it would be "serverVersion=10.5.8-MariaDB":
-#    DATABASE_URL=mysql://user:password@127.0.0.1:3306/database?charset=utf8mb4&serverVersion=10.5.8-MariaDB
-#
+# READ THIS FIRST: https://www.kimai.org/documentation/local-yaml.html
+#================================================================================
+
+# Configure your database connection and the correct server version - find it with: SELECT VERSION();
 DATABASE_URL=mysql://user:password@127.0.0.1:3306/database?charset=utf8mb4&serverVersion=10.5.8-MariaDB
 
-#================================================================================
-# The full documentation can be found at https://www.kimai.org/documentation/emails.html
-#
-# Email will be sent with this address as sender:
-MAILER_FROM=kimai@example.com
-# Email connection (disabled by default) - see documentation for the format
-MAILER_URL=null://null
-
-#================================================================================
-# do not change, unless you are developing for Kimai
-APP_ENV=prod
-
-#================================================================================
-# You MUST change this to a long and random character sequence!
+# You MUST change this to a long and random character sequence, e.g.: php -r 'echo bin2hex(random_bytes(32));'
 APP_SECRET=
 
-#================================================================================
-# For security reasons, you SHOULD configure the domain names for your Kimai
-# See https://symfony.com/doc/current/reference/configuration/framework.html#trusted-hosts
+# The base URL of your Kimai installation
+DEFAULT_URI=https://127.0.0.1:8000/
+
+# SECURITY WARNING: you SHOULD configure the allowed domain names for your installation
 # TRUSTED_HOSTS=localhost|example.com
 
-#================================================================================
+# Outgoing emails use this email-address as sender
+MAILER_FROM=kimai@example.com
+
+# Email connection - see https://www.kimai.org/documentation/emails.html
+MAILER_URL=null://null
+
 # Running behind reverse proxies? Try these:
 # TRUSTED_PROXIES=127.0.0.1,127.0.0.2
 
-#================================================================================
+# regexp to define allowed frontend origins for API requests
 CORS_ALLOW_ORIGIN=^https?://localhost(:[0-9]+)?$
 
-# The base URL of your Kimai installation, e.g. used in commands
-DEFAULT_URI=https://127.0.0.1:8000/
+# only change to "dev" if you are developing with/for Kimai
+APP_ENV=prod

--- a/.env.dist
+++ b/.env.dist
@@ -9,7 +9,7 @@ DATABASE_URL=mysql://user:password@127.0.0.1:3306/database?charset=utf8mb4&serve
 APP_SECRET=
 
 # The base URL of your Kimai installation
-DEFAULT_URI=https://127.0.0.1:8000/
+DEFAULT_URI=https://127.0.0.1:8000
 
 # SECURITY WARNING: you SHOULD configure the allowed domain names for your installation
 # TRUSTED_HOSTS=localhost|example.com

--- a/config/packages/routing.yaml
+++ b/config/packages/routing.yaml
@@ -1,3 +1,6 @@
+parameters:
+    env(DEFAULT_URI): 'http://localhost'
+
 framework:
     router:
         utf8: true

--- a/config/packages/routing.yaml
+++ b/config/packages/routing.yaml
@@ -5,7 +5,8 @@ framework:
 
         # Configure how to generate URLs in non-HTTP contexts, such as CLI commands.
         # See https://symfony.com/doc/current/routing.html#generating-urls-in-commands
-        #default_uri: http://localhost
+        default_uri: '%env(DEFAULT_URI)%'
+
 
 when@test:
     framework:


### PR DESCRIPTION
## Description

When generating emails from the command line, the framework needs to know the base URL of your Kimai installation.
This PR simplifies the setup by adding the `DEFAULT_URI` key in `.env`.

As a by product I simplified the .env.dist file to simplify the setup process. 

Most of the inline documentation was moved to https://www.kimai.org/documentation/local-yaml.html
So we have a single source of truth. Previously it was inside the user .env file and likely never updated.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] I verified that my code applies to the guidelines (`composer code-check`)
- [x] I updated the documentation (see [here](https://github.com/kimai/www.kimai.org/tree/master/_documentation))
- [x] I agree that this code is used in Kimai (see [license](https://github.com/kimai/kimai/blob/main/LICENSE))
