### PR TITLE
Add customer filter to the user list reports

### DIFF
--- a/src/Controller/Reporting/ReportUsersMonthController.php
+++ b/src/Controller/Reporting/ReportUsersMonthController.php
@@ -109,6 +109,7 @@ final class ReportUsersMonthController extends AbstractController
         if (!empty($allUsers)) {
             $statsQuery = new TimesheetStatisticQuery($start, $end, $allUsers);
             $statsQuery->setProject($values->getProject());
+            $statsQuery->setCustomer($values->getCustomer());
             $dayStats = $statisticService->getDailyStatistics($statsQuery);
         }
 

--- a/src/Controller/Reporting/ReportUsersWeekController.php
+++ b/src/Controller/Reporting/ReportUsersWeekController.php
@@ -105,6 +105,7 @@ final class ReportUsersWeekController extends AbstractController
         if (!empty($allUsers)) {
             $statsQuery = new TimesheetStatisticQuery($start, $end, $allUsers);
             $statsQuery->setProject($values->getProject());
+            $statsQuery->setCustomer($values->getCustomer());
             $dayStats = $statisticService->getDailyStatistics($statsQuery);
         }
 

--- a/src/Controller/Reporting/ReportUsersYearController.php
+++ b/src/Controller/Reporting/ReportUsersYearController.php
@@ -110,6 +110,7 @@ final class ReportUsersYearController extends AbstractController
         if (!empty($allUsers)) {
             $statsQuery = new TimesheetStatisticQuery($start, $end, $allUsers);
             $statsQuery->setProject($values->getProject());
+            $statsQuery->setCustomer($values->getCustomer());
             $monthStats = $statisticService->getMonthlyStats($statsQuery);
         }
 

--- a/src/Reporting/AbstractUserList.php
+++ b/src/Reporting/AbstractUserList.php
@@ -9,6 +9,7 @@
 
 namespace App\Reporting;
 
+use App\Entity\Customer;
 use App\Entity\Project;
 use App\Entity\Team;
 
@@ -19,6 +20,7 @@ abstract class AbstractUserList
     private string $sumType = 'duration';
     private ?Team $team = null;
     private ?Project $project = null;
+    private ?Customer $customer = null;
 
     public function getDate(): ?\DateTimeInterface
     {
@@ -72,5 +74,15 @@ abstract class AbstractUserList
     public function setProject(?Project $project): void
     {
         $this->project = $project;
+    }
+
+    public function getCustomer(): ?Customer
+    {
+        return $this->customer;
+    }
+
+    public function setCustomer(?Customer $customer = null): void
+    {
+        $this->customer = $customer;
     }
 }

--- a/src/Reporting/CustomerMonthlyProjects/CustomerMonthlyProjects.php
+++ b/src/Reporting/CustomerMonthlyProjects/CustomerMonthlyProjects.php
@@ -9,20 +9,8 @@
 
 namespace App\Reporting\CustomerMonthlyProjects;
 
-use App\Entity\Customer;
 use App\Reporting\AbstractUserList;
 
 final class CustomerMonthlyProjects extends AbstractUserList
 {
-    private ?Customer $customer = null;
-
-    public function getCustomer(): ?Customer
-    {
-        return $this->customer;
-    }
-
-    public function setCustomer(?Customer $customer): void
-    {
-        $this->customer = $customer;
-    }
 }

--- a/src/Reporting/MonthlyUserList/MonthlyUserListForm.php
+++ b/src/Reporting/MonthlyUserList/MonthlyUserListForm.php
@@ -9,6 +9,7 @@
 
 namespace App\Reporting\MonthlyUserList;
 
+use App\Form\Type\CustomerType;
 use App\Form\Type\MonthPickerType;
 use App\Form\Type\ProjectType;
 use App\Form\Type\ReportSumType;
@@ -31,6 +32,10 @@ final class MonthlyUserListForm extends AbstractType
         ]);
         $builder->add('team', TeamType::class, [
             'multiple' => false,
+            'required' => false,
+            'width' => false,
+        ]);
+        $builder->add('customer', CustomerType::class, [
             'required' => false,
             'width' => false,
         ]);

--- a/src/Reporting/WeeklyUserList/WeeklyUserListForm.php
+++ b/src/Reporting/WeeklyUserList/WeeklyUserListForm.php
@@ -9,6 +9,7 @@
 
 namespace App\Reporting\WeeklyUserList;
 
+use App\Form\Type\CustomerType;
 use App\Form\Type\ProjectType;
 use App\Form\Type\ReportSumType;
 use App\Form\Type\TeamType;
@@ -31,6 +32,10 @@ final class WeeklyUserListForm extends AbstractType
         ]);
         $builder->add('team', TeamType::class, [
             'multiple' => false,
+            'required' => false,
+            'width' => false,
+        ]);
+        $builder->add('customer', CustomerType::class, [
             'required' => false,
             'width' => false,
         ]);

--- a/src/Reporting/YearlyUserList/YearlyUserListForm.php
+++ b/src/Reporting/YearlyUserList/YearlyUserListForm.php
@@ -9,6 +9,7 @@
 
 namespace App\Reporting\YearlyUserList;
 
+use App\Form\Type\CustomerType;
 use App\Form\Type\ProjectType;
 use App\Form\Type\ReportSumType;
 use App\Form\Type\TeamType;
@@ -31,6 +32,10 @@ final class YearlyUserListForm extends AbstractType
         ]);
         $builder->add('team', TeamType::class, [
             'multiple' => false,
+            'required' => false,
+            'width' => false,
+        ]);
+        $builder->add('customer', CustomerType::class, [
             'required' => false,
             'width' => false,
         ]);

--- a/src/Repository/Query/TimesheetStatisticQuery.php
+++ b/src/Repository/Query/TimesheetStatisticQuery.php
@@ -9,12 +9,14 @@
 
 namespace App\Repository\Query;
 
+use App\Entity\Customer;
 use App\Entity\Project;
 use App\Entity\User;
 
 final class TimesheetStatisticQuery
 {
     private ?Project $project = null;
+    private ?Customer $customer = null;
 
     /**
      * @param array<User> $users
@@ -53,5 +55,15 @@ final class TimesheetStatisticQuery
     public function setProject(?Project $project): void
     {
         $this->project = $project;
+    }
+
+    public function getCustomer(): ?Customer
+    {
+        return $this->customer;
+    }
+
+    public function setCustomer(?Customer $customer): void
+    {
+        $this->customer = $customer;
     }
 }

--- a/src/Timesheet/TimesheetStatisticService.php
+++ b/src/Timesheet/TimesheetStatisticService.php
@@ -35,6 +35,7 @@ final class TimesheetStatisticService
         $end = $query->getEnd();
         $users = $query->getUsers();
         $project = $query->getProject();
+        $customer = $query->getCustomer();
 
         /** @var DailyStatistic[] $stats */
         $stats = [];
@@ -73,6 +74,14 @@ final class TimesheetStatisticService
             $qb
                 ->andWhere($qb->expr()->eq('t.project', ':project'))
                 ->setParameter('project', $project)
+            ;
+        }
+
+        if ($customer !== null) {
+            $qb
+                ->join('t.project', 'p')
+                ->andWhere($qb->expr()->eq('p.customer', ':customer'))
+                ->setParameter('customer', $customer)
             ;
         }
 
@@ -287,6 +296,7 @@ final class TimesheetStatisticService
         $end = $query->getEnd();
         $users = $query->getUsers();
         $project = $query->getProject();
+        $customer = $query->getCustomer();
 
         /** @var MonthlyStatistic[] $stats */
         $stats = [];
@@ -322,6 +332,14 @@ final class TimesheetStatisticService
             $qb
                 ->andWhere($qb->expr()->eq('t.project', ':project'))
                 ->setParameter('project', $project)
+            ;
+        }
+
+        if ($customer !== null) {
+            $qb
+                ->join('t.project', 'p')
+                ->andWhere($qb->expr()->eq('p.customer', ':customer'))
+                ->setParameter('customer', $customer)
             ;
         }
 

--- a/templates/reporting/report_user_list_layout.html.twig
+++ b/templates/reporting/report_user_list_layout.html.twig
@@ -5,6 +5,9 @@
     {% if form.team is defined %}
         {{ form_widget(form.team, {'label': false, 'placeholder': 'team'}) }}
     {% endif %}
+    {% if form.customer is defined %}
+        {{ form_widget(form.customer, {'label': false, 'placeholder': 'customer'}) }}
+    {% endif %}
     {% if form.project is defined %}
         {{ form_widget(form.project, {'label': false, 'placeholder': 'project'}) }}
     {% endif %}

--- a/tests/Controller/Reporting/AbstractUsersPeriodControllerTestCase.php
+++ b/tests/Controller/Reporting/AbstractUsersPeriodControllerTestCase.php
@@ -9,6 +9,7 @@
 
 namespace App\Tests\Controller\Reporting;
 
+use App\Entity\Customer;
 use App\Entity\User;
 use App\Tests\Controller\AbstractControllerBaseTestCase;
 use App\Tests\DataFixtures\TimesheetFixtures;
@@ -71,6 +72,32 @@ abstract class AbstractUsersPeriodControllerTestCase extends AbstractControllerB
         self::assertEquals(0, $select->count());
         $cell = $client->getCrawler()->filterXPath("//th[contains(@class, 'reportDataTypeTitle')]");
         self::assertEquals($title, $cell->text());
+    }
+
+    public function testUsersPeriodReportHasCustomerFilter(): void
+    {
+        $client = $this->getClientForAuthenticatedUser(User::ROLE_SUPER_ADMIN);
+        $this->importReportingFixture(User::ROLE_SUPER_ADMIN);
+        $this->assertAccessIsGranted($client, $this->getReportUrl());
+        $select = $client->getCrawler()->filterXPath("//select[@id='customer']");
+        self::assertEquals(1, $select->count());
+    }
+
+    public function testUsersPeriodReportWithCustomerFilter(): void
+    {
+        $client = $this->getClientForAuthenticatedUser(User::ROLE_SUPER_ADMIN);
+        $this->importReportingFixture(User::ROLE_SUPER_ADMIN);
+
+        $customer = $this->getEntityManager()->getRepository(Customer::class)->findOneBy([]);
+        self::assertInstanceOf(Customer::class, $customer);
+
+        $this->assertAccessIsGranted($client, \sprintf('%s?date=12999119191&customer=%s', $this->getReportUrl(), $customer->getId()));
+
+        $box = $client->getCrawler()->filterXPath(\sprintf("//div[contains(@class, '%s')]", $this->getBoxId()));
+        self::assertEquals(1, $box->count());
+
+        $selected = $client->getCrawler()->filterXPath("//select[@id='customer']/option[@selected]");
+        self::assertEquals((string) $customer->getId(), $selected->attr('value'));
     }
 
     #[DataProvider('getTestData')]

--- a/tests/Reporting/AbstractUserListTestCase.php
+++ b/tests/Reporting/AbstractUserListTestCase.php
@@ -9,6 +9,8 @@
 
 namespace App\Tests\Reporting;
 
+use App\Entity\Customer;
+use App\Entity\Project;
 use App\Reporting\AbstractUserList;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
@@ -24,6 +26,9 @@ abstract class AbstractUserListTestCase extends TestCase
         self::assertNull($sut->getDate());
         self::assertEquals('duration', $sut->getSumType());
         self::assertFalse($sut->isDecimal());
+        self::assertNull($sut->getTeam());
+        self::assertNull($sut->getProject());
+        self::assertNull($sut->getCustomer());
     }
 
     public function testSetter(): void
@@ -49,6 +54,24 @@ abstract class AbstractUserListTestCase extends TestCase
 
         $sut->setDecimal(false);
         self::assertFalse($sut->isDecimal());
+
+        $project = new Project();
+        $sut->setProject($project);
+        self::assertSame($project, $sut->getProject());
+
+        $sut->setProject(null);
+        self::assertNull($sut->getProject());
+
+        $customer = new Customer('foo');
+        $sut->setCustomer($customer);
+        self::assertSame($customer, $sut->getCustomer());
+
+        $sut->setCustomer(null);
+        self::assertNull($sut->getCustomer());
+
+        $sut->setCustomer($customer);
+        $sut->setCustomer();
+        self::assertNull($sut->getCustomer());
     }
 
     public function testInvalidSumType(): void

--- a/tests/Repository/Query/TimesheetStatisticQueryTest.php
+++ b/tests/Repository/Query/TimesheetStatisticQueryTest.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * This file is part of the Kimai time-tracking app.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Tests\Repository\Query;
+
+use App\Entity\Customer;
+use App\Entity\Project;
+use App\Entity\User;
+use App\Repository\Query\TimesheetStatisticQuery;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(TimesheetStatisticQuery::class)]
+class TimesheetStatisticQueryTest extends TestCase
+{
+    public function testDefaultValues(): void
+    {
+        $begin = new \DateTime('2019-05-27');
+        $end = new \DateTime('2019-06-27');
+        $user = new User();
+
+        $sut = new TimesheetStatisticQuery($begin, $end, [$user]);
+
+        self::assertSame($begin, $sut->getBegin());
+        self::assertSame($end, $sut->getEnd());
+        self::assertSame([$user], $sut->getUsers());
+        self::assertNull($sut->getProject());
+        self::assertNull($sut->getCustomer());
+    }
+
+    public function testSetterAndGetter(): void
+    {
+        $sut = new TimesheetStatisticQuery(new \DateTime('2019-05-27'), new \DateTime('2019-06-27'), []);
+
+        $project = new Project();
+        $sut->setProject($project);
+        self::assertSame($project, $sut->getProject());
+
+        $sut->setProject(null);
+        self::assertNull($sut->getProject());
+
+        $customer = new Customer('foo');
+        $sut->setCustomer($customer);
+        self::assertSame($customer, $sut->getCustomer());
+
+        $sut->setCustomer(null);
+        self::assertNull($sut->getCustomer());
+    }
+}

--- a/tests/Timesheet/TimesheetStatisticServiceTest.php
+++ b/tests/Timesheet/TimesheetStatisticServiceTest.php
@@ -1,0 +1,165 @@
+<?php
+
+/*
+ * This file is part of the Kimai time-tracking app.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Tests\Timesheet;
+
+use App\Entity\Customer;
+use App\Entity\Timesheet;
+use App\Entity\User;
+use App\Model\DateStatisticInterface;
+use App\Repository\Query\TimesheetStatisticQuery;
+use App\Tests\DataFixtures\CustomerFixtures;
+use App\Tests\DataFixtures\TimesheetFixtures;
+use App\Tests\KernelTestTrait;
+use App\Timesheet\TimesheetStatisticService;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+#[CoversClass(TimesheetStatisticService::class)]
+#[Group('integration')]
+class TimesheetStatisticServiceTest extends KernelTestCase
+{
+    use KernelTestTrait;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        self::bootKernel();
+    }
+
+    private function getSut(): TimesheetStatisticService
+    {
+        /** @var TimesheetStatisticService $service */
+        $service = self::getContainer()->get(TimesheetStatisticService::class);
+
+        return $service;
+    }
+
+    private function createUserWithTimesheets(): User
+    {
+        $user = $this->getUserByRole(User::ROLE_USER);
+
+        $fixture = new TimesheetFixtures();
+        $fixture->setAmount(20);
+        $fixture->setUser($user);
+        $fixture->setStartDate(new \DateTime('2020-01-01'));
+        $this->importFixture($fixture);
+
+        return $user;
+    }
+
+    /**
+     * A range that is guaranteed to contain every imported timesheet.
+     *
+     * @return array{0: \DateTime, 1: \DateTime}
+     */
+    private function getFullRange(): array
+    {
+        return [new \DateTime('2000-01-01'), new \DateTime('2100-01-01')];
+    }
+
+    /**
+     * @param DateStatisticInterface[] $statistics
+     */
+    private function getTotalDuration(array $statistics): int
+    {
+        $duration = 0;
+        foreach ($statistics as $statistic) {
+            foreach ($statistic->getData() as $date) {
+                $duration += $date->getTotalDuration();
+            }
+        }
+
+        return $duration;
+    }
+
+    private function getCustomerWithTimesheets(User $user): Customer
+    {
+        $timesheet = $this->getEntityManager()->getRepository(Timesheet::class)->findOneBy(['user' => $user->getId()]);
+        self::assertInstanceOf(Timesheet::class, $timesheet);
+
+        $project = $timesheet->getProject();
+        self::assertNotNull($project);
+
+        $customer = $project->getCustomer();
+        self::assertInstanceOf(Customer::class, $customer);
+
+        return $customer;
+    }
+
+    public function testGetDailyStatisticsFilteredByCustomer(): void
+    {
+        $user = $this->createUserWithTimesheets();
+        [$begin, $end] = $this->getFullRange();
+        $sut = $this->getSut();
+
+        $query = new TimesheetStatisticQuery($begin, $end, [$user]);
+        $total = $this->getTotalDuration($sut->getDailyStatistics($query));
+        self::assertGreaterThan(0, $total);
+
+        $query = new TimesheetStatisticQuery($begin, $end, [$user]);
+        $query->setCustomer($this->getCustomerWithTimesheets($user));
+        $filtered = $this->getTotalDuration($sut->getDailyStatistics($query));
+
+        self::assertGreaterThan(0, $filtered);
+        self::assertLessThanOrEqual($total, $filtered);
+    }
+
+    public function testGetDailyStatisticsWithCustomerWithoutTimesheets(): void
+    {
+        $user = $this->createUserWithTimesheets();
+        [$begin, $end] = $this->getFullRange();
+
+        $customers = $this->importFixture(new CustomerFixtures(1));
+
+        $query = new TimesheetStatisticQuery($begin, $end, [$user]);
+        $query->setCustomer($customers[0]);
+
+        $statistics = $this->getSut()->getDailyStatistics($query);
+
+        // one statistic per user is always returned, but it must not contain any duration
+        self::assertCount(1, $statistics);
+        self::assertEquals(0, $this->getTotalDuration($statistics));
+    }
+
+    public function testGetMonthlyStatsFilteredByCustomer(): void
+    {
+        $user = $this->createUserWithTimesheets();
+        [$begin, $end] = $this->getFullRange();
+        $sut = $this->getSut();
+
+        $query = new TimesheetStatisticQuery($begin, $end, [$user]);
+        $total = $this->getTotalDuration($sut->getMonthlyStats($query));
+        self::assertGreaterThan(0, $total);
+
+        $query = new TimesheetStatisticQuery($begin, $end, [$user]);
+        $query->setCustomer($this->getCustomerWithTimesheets($user));
+        $filtered = $this->getTotalDuration($sut->getMonthlyStats($query));
+
+        self::assertGreaterThan(0, $filtered);
+        self::assertLessThanOrEqual($total, $filtered);
+    }
+
+    public function testGetMonthlyStatsWithCustomerWithoutTimesheets(): void
+    {
+        $user = $this->createUserWithTimesheets();
+        [$begin, $end] = $this->getFullRange();
+
+        $customers = $this->importFixture(new CustomerFixtures(1));
+
+        $query = new TimesheetStatisticQuery($begin, $end, [$user]);
+        $query->setCustomer($customers[0]);
+
+        $statistics = $this->getSut()->getMonthlyStats($query);
+
+        self::assertCount(1, $statistics);
+        self::assertEquals(0, $this->getTotalDuration($statistics));
+    }
+}


### PR DESCRIPTION
## Motivation
I want to see all hours booked by each person for all projects across a customer.
The monthly total just shows total hours per customer, with no ability to filter for persons.

## Description
The weekly, monthly and yearly "users" reports could only be narrowed down by project, so there was no way to see how much time each person booked across all projects of one customer.

Adds a customer select next to the existing team and project filters. The filter is applied in TimesheetStatisticService by joining the project and matching its customer, mirroring the existing project filter. Both filters combine.

Also drops the duplicate customer property from CustomerMonthlyProjects, which shadowed the one now provided by AbstractUserList. Its public API is unchanged.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] I verified that my code applies to the guidelines (`composer code-check`)
- [ ] I updated the documentation (see [here](https://github.com/kimai/www.kimai.org/tree/master/_documentation))
- [x] I agree that this code is used in Kimai (see [license](https://github.com/kimai/kimai/blob/main/LICENSE))
