### PR TITLE
Preload customer, project and activity teams - fixes N+1

### DIFF
--- a/src/Repository/Loader/TimesheetLoader.php
+++ b/src/Repository/Loader/TimesheetLoader.php
@@ -73,12 +73,30 @@ final class TimesheetLoader implements LoaderInterface
                 ->getQuery()
                 ->execute();
 
-            if ($this->query !== null && $this->query->hasQueryHint(TimesheetQueryHint::CUSTOMER_META_FIELDS)) {
-                $customerIds = array_filter(array_unique(array_map(function (Project $project) {
-                    return $project->getCustomer()?->getId();
-                }, $projects)), function ($value) { return $value !== null; });
+            // the voter checks the teams of project, customer and activity for every row that
+            // is rendered, so load them upfront instead of once per record
+            $qb = $em->createQueryBuilder();
+            $qb->select('PARTIAL p.{id}', 'teams')
+                ->from(Project::class, 'p')
+                ->leftJoin('p.teams', 'teams')
+                ->andWhere($qb->expr()->in('p.id', $projectIds))
+                ->getQuery()
+                ->execute();
 
-                if (\count($customerIds) > 0) {
+            $customerIds = array_filter(array_unique(array_map(function (Project $project) {
+                return $project->getCustomer()?->getId();
+            }, $projects)), function ($value) { return $value !== null; });
+
+            if (\count($customerIds) > 0) {
+                $qb = $em->createQueryBuilder();
+                $qb->select('PARTIAL c.{id}', 'teams')
+                    ->from(Customer::class, 'c')
+                    ->leftJoin('c.teams', 'teams')
+                    ->andWhere($qb->expr()->in('c.id', $customerIds))
+                    ->getQuery()
+                    ->execute();
+
+                if ($this->query !== null && $this->query->hasQueryHint(TimesheetQueryHint::CUSTOMER_META_FIELDS)) {
                     $qb = $em->createQueryBuilder();
                     $qb->select('PARTIAL c.{id}', 'meta')
                         ->from(Customer::class, 'c')
@@ -90,22 +108,28 @@ final class TimesheetLoader implements LoaderInterface
             }
         }
 
-        if ($this->query !== null && $this->query->hasQueryHint(TimesheetQueryHint::ACTIVITY_META_FIELDS)) {
-            $activityIds = array_filter(array_map(function (Timesheet $timesheet) {
-                return $timesheet->getActivity()?->getId();
-            }, $results), function ($id): bool {
-                return $id !== null;
-            });
+        $activityIds = array_filter(array_unique(array_map(function (Timesheet $timesheet) {
+            return $timesheet->getActivity()?->getId();
+        }, $results)), function ($value) { return $value !== null; });
 
-            if (\count($activityIds) > 0) {
-                $qb = $em->createQueryBuilder();
-                $qb->select('PARTIAL a.{id}', 'meta')
-                    ->from(Activity::class, 'a')
-                    ->leftJoin('a.meta', 'meta')
-                    ->andWhere($qb->expr()->in('a.id', $activityIds))
-                    ->getQuery()
-                    ->execute();
-            }
+        if (\count($activityIds) > 0) {
+            $qb = $em->createQueryBuilder();
+            $qb->select('PARTIAL a.{id}', 'teams')
+                ->from(Activity::class, 'a')
+                ->leftJoin('a.teams', 'teams')
+                ->andWhere($qb->expr()->in('a.id', $activityIds))
+                ->getQuery()
+                ->execute();
+        }
+
+        if (\count($activityIds) > 0 && $this->query !== null && $this->query->hasQueryHint(TimesheetQueryHint::ACTIVITY_META_FIELDS)) {
+            $qb = $em->createQueryBuilder();
+            $qb->select('PARTIAL a.{id}', 'meta')
+                ->from(Activity::class, 'a')
+                ->leftJoin('a.meta', 'meta')
+                ->andWhere($qb->expr()->in('a.id', $activityIds))
+                ->getQuery()
+                ->execute();
         }
 
         if ($this->query !== null && $this->query->hasQueryHint(TimesheetQueryHint::USER_PREFERENCES)) {

--- a/tests/Repository/TimesheetRepositoryTest.php
+++ b/tests/Repository/TimesheetRepositoryTest.php
@@ -10,8 +10,10 @@
 namespace App\Tests\Repository;
 
 use App\Entity\Activity;
+use App\Entity\Customer;
 use App\Entity\Project;
 use App\Entity\Tag;
+use App\Entity\Team;
 use App\Entity\Timesheet;
 use App\Entity\User;
 use App\Repository\ActivityRepository;
@@ -20,6 +22,7 @@ use App\Repository\Query\TimesheetQuery;
 use App\Repository\Query\TimesheetQueryHint;
 use App\Repository\TimesheetRepository;
 use App\Utils\Pagination;
+use Doctrine\ORM\PersistentCollection;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Group;
 
@@ -162,5 +165,77 @@ class TimesheetRepositoryTest extends AbstractRepositoryTestCase
         self::assertNotNull($timesheet->getTags()->get(0)->getId());
         self::assertEquals('Picture', $timesheet->getTags()->get(1)->getName());
         self::assertNotNull($timesheet->getTags()->get(1)->getId());
+    }
+
+    /**
+     * The voters check the teams of project, customer and activity for every rendered row.
+     * If those collections are not preloaded, Doctrine resolves them one by one, which adds
+     * two queries per distinct project to every listing page.
+     */
+    public function testTimesheetResultPreloadsTeamAssignments(): void
+    {
+        $em = $this->getEntityManager();
+
+        $user = $this->getUserByRole(User::ROLE_USER);
+
+        $team = new Team('preload team');
+        $team->addTeamlead($user);
+        $em->persist($team);
+
+        $customer = new Customer('preload customer');
+        $customer->setCountry('DE');
+        $customer->setTimezone('Europe/Berlin');
+        $team->addCustomer($customer);
+        $em->persist($customer);
+
+        $project = new Project();
+        $project->setName('preload project');
+        $project->setCustomer($customer);
+        $team->addProject($project);
+        $em->persist($project);
+
+        $activity = new Activity();
+        $activity->setName('preload activity');
+        $activity->setProject($project);
+        $team->addActivity($activity);
+        $em->persist($activity);
+
+        $em->flush();
+
+        $timesheet = new Timesheet();
+        $timesheet->setBegin(new \DateTime('2021-04-01 10:00:00'))
+            ->setEnd(new \DateTime('2021-04-01 11:00:00'))
+            ->setUser($user)
+            ->setProject($project)
+            ->setActivity($activity);
+        $em->persist($timesheet);
+        $em->flush();
+        $em->clear();
+
+        /** @var TimesheetRepository $repository */
+        $repository = $em->getRepository(Timesheet::class);
+
+        $query = new TimesheetQuery();
+        $query->setUser($this->getUserByRole(User::ROLE_USER));
+
+        $results = $repository->getTimesheetResult($query)->getResults();
+        self::assertNotEmpty($results);
+
+        foreach ($results as $loaded) {
+            $loadedProject = $loaded->getProject();
+            self::assertInstanceOf(Project::class, $loadedProject);
+            self::assertInstanceOf(PersistentCollection::class, $loadedProject->getTeams());
+            self::assertTrue($loadedProject->getTeams()->isInitialized(), 'Project teams were not preloaded');
+
+            $loadedCustomer = $loadedProject->getCustomer();
+            self::assertInstanceOf(Customer::class, $loadedCustomer);
+            self::assertInstanceOf(PersistentCollection::class, $loadedCustomer->getTeams());
+            self::assertTrue($loadedCustomer->getTeams()->isInitialized(), 'Customer teams were not preloaded');
+
+            $loadedActivity = $loaded->getActivity();
+            self::assertInstanceOf(Activity::class, $loadedActivity);
+            self::assertInstanceOf(PersistentCollection::class, $loadedActivity->getTeams());
+            self::assertTrue($loadedActivity->getTeams()->isInitialized(), 'Activity teams were not preloaded');
+        }
     }
 }


### PR DESCRIPTION
## Description

Fixes a N+1 query for teamleads on "all times"

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] I verified that my code applies to the guidelines (`composer code-check`)
- [ ] I updated the documentation (see [here](https://github.com/kimai/www.kimai.org/tree/master/_documentation))
- [x] I agree that this code is used in Kimai (see [license](https://github.com/kimai/kimai/blob/main/LICENSE))
