### PR TITLE
Fix weekly invoice grouping merging the same week from different years

### DIFF
--- a/src/Invoice/Calculator/WeeklyInvoiceCalculator.php
+++ b/src/Invoice/Calculator/WeeklyInvoiceCalculator.php
@@ -24,7 +24,10 @@ final class WeeklyInvoiceCalculator extends AbstractSumInvoiceCalculator impleme
         }
 
         return [
-            $invoiceItem->getBegin()->format('W')
+            // The ISO week-numbering year ("o"), not the calendar year, because an
+            // ISO week can span two calendar years. Without a year the same week
+            // number from different years would be summed into one invoice entry.
+            $invoiceItem->getBegin()->format('o-W')
         ];
     }
 

--- a/tests/Invoice/Calculator/WeeklyInvoiceCalculatorTest.php
+++ b/tests/Invoice/Calculator/WeeklyInvoiceCalculatorTest.php
@@ -20,6 +20,7 @@ use App\Invoice\Calculator\AbstractMergedCalculator;
 use App\Invoice\Calculator\AbstractSumInvoiceCalculator;
 use App\Invoice\Calculator\WeeklyInvoiceCalculator;
 use App\Invoice\CalculatorInterface;
+use App\Invoice\InvoiceItem;
 use App\Repository\Query\InvoiceQuery;
 use App\Tests\Invoice\DebugFormatter;
 use App\Tests\Mocks\InvoiceModelFactoryFactory;
@@ -129,16 +130,39 @@ class WeeklyInvoiceCalculatorTest extends AbstractCalculatorTestCase
 
     public function testSameWeekNumberInDifferentYearsIsNotMerged(): void
     {
+        // Both dates are ISO week 30, one year apart. Keying only on the week
+        // number would sum them into a single invoice entry.
+        $entries = $this->calculateEntriesForBeginDates(['2025-07-21 12:00:00', '2026-07-20 12:00:00']);
+
+        self::assertCount(2, $entries);
+    }
+
+    public function testIsoWeekSpanningTwoCalendarYearsIsMerged(): void
+    {
+        // Both dates belong to ISO week 1 of 2025, but to different calendar
+        // years. Keying on the calendar year ("Y-W") instead of the ISO
+        // week-numbering year ("o-W") would split them into two entries.
+        $entries = $this->calculateEntriesForBeginDates(['2024-12-30 12:00:00', '2025-01-02 12:00:00']);
+
+        self::assertCount(1, $entries);
+        self::assertEquals(7200, $entries[0]->getDuration());
+        self::assertEquals(200, $entries[0]->getRate());
+    }
+
+    /**
+     * @param array<string> $beginDates
+     * @return array<InvoiceItem>
+     */
+    private function calculateEntriesForBeginDates(array $beginDates): array
+    {
         $customer = new Customer('foo');
         $template = new InvoiceTemplate();
         $template->setVat(19);
         $project = (new Project())->setName('project');
         $user = new User();
 
-        // Both dates are ISO week 30, one year apart. Keying only on the week
-        // number would sum them into a single invoice entry.
         $entries = [];
-        foreach (['2025-07-21 12:00:00', '2026-07-20 12:00:00'] as $begin) {
+        foreach ($beginDates as $begin) {
             $timesheet = new Timesheet();
             $timesheet->setBegin(new DateTime($begin));
             $timesheet->setEnd(new DateTime($begin));
@@ -159,7 +183,7 @@ class WeeklyInvoiceCalculatorTest extends AbstractCalculatorTestCase
         $sut = $this->getCalculator();
         $sut->setModel($model);
 
-        self::assertCount(2, $sut->getEntries());
+        return $sut->getEntries();
     }
 
     public function testDescriptionByTimesheet(): void

--- a/tests/Invoice/Calculator/WeeklyInvoiceCalculatorTest.php
+++ b/tests/Invoice/Calculator/WeeklyInvoiceCalculatorTest.php
@@ -127,6 +127,41 @@ class WeeklyInvoiceCalculatorTest extends AbstractCalculatorTestCase
         self::assertEquals(2143.1, $entries[0]->getRate());
     }
 
+    public function testSameWeekNumberInDifferentYearsIsNotMerged(): void
+    {
+        $customer = new Customer('foo');
+        $template = new InvoiceTemplate();
+        $template->setVat(19);
+        $project = (new Project())->setName('project');
+        $user = new User();
+
+        // Both dates are ISO week 30, one year apart. Keying only on the week
+        // number would sum them into a single invoice entry.
+        $entries = [];
+        foreach (['2025-07-21 12:00:00', '2026-07-20 12:00:00'] as $begin) {
+            $timesheet = new Timesheet();
+            $timesheet->setBegin(new DateTime($begin));
+            $timesheet->setEnd(new DateTime($begin));
+            $timesheet->setDuration(3600);
+            $timesheet->setRate(100);
+            $timesheet->setUser($user);
+            $timesheet->setActivity((new Activity())->setName('foo'));
+            $timesheet->setProject($project);
+            $entries[] = $timesheet;
+        }
+
+        $query = new InvoiceQuery();
+        $query->setProjects([$project]);
+
+        $model = (new InvoiceModelFactoryFactory($this))->create()->createModel(new DebugFormatter(), $customer, $template, $query);
+        $model->addEntries($entries);
+
+        $sut = $this->getCalculator();
+        $sut->setModel($model);
+
+        self::assertCount(2, $sut->getEntries());
+    }
+
     public function testDescriptionByTimesheet(): void
     {
         $this->assertDescription($this->getCalculator(), false, false);


### PR DESCRIPTION
## Problem

`WeeklyInvoiceCalculator::getIdentifiers()` groups invoice items by `format('W')`, which is the ISO week number on its own with no year:

```php
return [
    $invoiceItem->getBegin()->format('W')
];
```

So an invoice covering more than one year sums unrelated weeks into a single line. Timesheets from 2025-07-21 and 2026-07-20 are both week `30` and land in the same entry, with their durations and rates added together.

Every other calculator keys on a fully qualified value (`DateInvoiceCalculator` uses `Y-m-d`), so the bare week number looks like an oversight rather than a deliberate choice.

## Fix

Group on `format('o-W')`.

`o` is the ISO week-numbering year, which is the correct partner for `W` and not interchangeable with `Y`: 2024-12-30 belongs to ISO week 1 of 2025, so `Y-W` would key it as `2024-01` and split one ISO week across two invoice entries. `o-W` keys it as `2025-01`, together with 2025-01-02.

| date | `W` | `o-W` | `Y-W` |
|---|---|---|---|
| 2025-07-21 | 30 | 2025-30 | 2025-30 |
| 2026-07-20 | 30 | 2026-30 | 2026-30 |
| 2024-12-30 | 01 | 2025-01 | 2024-01 |

## Tests

Added `testSameWeekNumberInDifferentYearsIsNotMerged`, which feeds the calculator two timesheets one year apart in the same ISO week and asserts two entries come back. It fails before the change (actual size 1) and passes after.

Full `tests/Invoice/` suite is green: 207 tests, 1466 assertions.

## AI disclosure

Written with Claude (Claude Code). I verified the failing-before and passing-after states locally and checked the `o` versus `Y` distinction against real dates.