### PR TITLE
form not visible for 2fa with saml and deactivated login form

### DIFF
--- a/templates/security/login.html.twig
+++ b/templates/security/login.html.twig
@@ -75,7 +75,7 @@
 {% endblock %}
 
 {% block login_box %}
-    {% if config('loginFormActive') %}
+    {% if config('loginFormActive') or is_granted('IS_AUTHENTICATED_2FA_IN_PROGRESS') %}
         {{ parent() }}
     {% endif %}
 {% endblock %}

--- a/tests/Controller/Security/TwoFactorLoginTest.php
+++ b/tests/Controller/Security/TwoFactorLoginTest.php
@@ -1,0 +1,99 @@
+<?php
+
+/*
+ * This file is part of the Kimai time-tracking app.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Tests\Controller\Security;
+
+use App\DataFixtures\UserFixtures;
+use App\Tests\Controller\AbstractControllerBaseTestCase;
+use PHPUnit\Framework\Attributes\Group;
+use Symfony\Component\HttpKernel\HttpKernelBrowser;
+
+/**
+ * Makes sure the two-factor authentication form is usable, even if the
+ * login form was deactivated (SAML only setup without local password login).
+ */
+#[Group('integration')]
+class TwoFactorLoginTest extends AbstractControllerBaseTestCase
+{
+    private const TOTP_SECRET = 'JBSWY3DPEHPK3PXP';
+    private const URL_2FA = '/auth/2fa';
+
+    private function activateTwoFactor(string $username): void
+    {
+        $em = $this->getEntityManager();
+        $user = $this->getUserByName($username);
+        $user->setTotpSecret(self::TOTP_SECRET);
+        $user->enableTotpAuthentication();
+        $em->persist($user);
+        $em->flush();
+    }
+
+    /**
+     * Logs in with username and password, which is only the first step:
+     * the user is not authenticated before the TOTP code was validated.
+     */
+    private function startTwoFactorLogin(HttpKernelBrowser $client): void
+    {
+        $this->request($client, '/login');
+        self::assertTrue($client->getResponse()->isSuccessful());
+
+        $form = $client->getCrawler()->filter('body form')->form();
+        $client->submit($form, [
+            '_username' => UserFixtures::USERNAME_USER,
+            '_password' => UserFixtures::DEFAULT_PASSWORD,
+        ]);
+
+        $this->assertIsRedirect($client); // redirect to root URL
+        $client->followRedirect();
+
+        $this->assertIsRedirect($client, $this->createUrl(self::URL_2FA));
+    }
+
+    public function testTwoFactorFormIsRenderedWithActiveLoginForm(): void
+    {
+        $client = self::createClient();
+        $this->activateTwoFactor(UserFixtures::USERNAME_USER);
+        $this->startTwoFactorLogin($client);
+
+        $this->request($client, self::URL_2FA);
+        self::assertTrue($client->getResponse()->isSuccessful());
+
+        $content = $client->getResponse()->getContent();
+        self::assertNotFalse($content);
+        self::assertStringContainsString('<input id="_auth_code" type="text" name="_auth_code"', $content);
+    }
+
+    /**
+     * @see https://github.com/kimai/kimai/pull/6136
+     */
+    public function testTwoFactorFormIsRenderedWithDeactivatedLoginForm(): void
+    {
+        $client = self::createClient();
+        $this->activateTwoFactor(UserFixtures::USERNAME_USER);
+        $this->startTwoFactorLogin($client);
+
+        // company uses SAML and forbids local password logins: the login form is hidden ...
+        $this->setSystemConfiguration('saml.activate', true);
+        $this->setSystemConfiguration('user.login', false);
+
+        $this->request($client, self::URL_2FA);
+        self::assertTrue($client->getResponse()->isSuccessful());
+
+        $content = $client->getResponse()->getContent();
+        self::assertNotFalse($content);
+
+        // ... but the 2FA code form has to stay visible, otherwise the user cannot finish the login
+        self::assertStringContainsString('<input id="_auth_code" type="text" name="_auth_code"', $content);
+        self::assertStringContainsString('/auth/2fa_check', $content);
+
+        // the deactivated login form is still hidden
+        self::assertStringNotContainsString('name="_password"', $content);
+        self::assertStringNotContainsString('/login_check', $content);
+    }
+}


### PR DESCRIPTION
## Description

If : 
- SAML is activated
- The login form was deactivated (AKA "SAML only")
-  And a user has 2FA activated

then the user could not enter the 2FA code, because the form was hidden.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] I verified that my code applies to the guidelines (`composer code-check`)
- [ ] I updated the documentation (see [here](https://github.com/kimai/www.kimai.org/tree/master/_documentation))
- [x] I agree that this code is used in Kimai (see [license](https://github.com/kimai/kimai/blob/main/LICENSE))
