### PR TITLE
Calendar: add extension points for plugins

### DIFF
--- a/assets/js/widgets/KimaiCalendar.js
+++ b/assets/js/widgets/KimaiCalendar.js
@@ -261,6 +261,14 @@ export default class KimaiCalendar {
                         }, (e) => { console.log('Failed to load actions for context menu', e); });
                     }
                 });
+
+                // Extension point: plugins can listen for this event and manipulate
+                // the entry's DOM element directly (e.g. append a badge or icon).
+                if (this.isKimaiSource(arg.event)) {
+                    document.dispatchEvent(new CustomEvent('kimai.calendar.eventContent', {
+                        detail: {event: arg.event.extendedProps, element: arg.el}
+                    }));
+                }
             },
 
             // called after all events of one source were set, so this can
@@ -645,6 +653,7 @@ export default class KimaiCalendar {
             project: apiItem.project.name,
             customer: apiItem.project.customer.name,
             tags: apiItem.tags,
+            metaFields: apiItem.metaFields ?? [],
             color: color,
             textColor: KimaiColor.calculateContrastColor(color),
         };
@@ -667,6 +676,12 @@ export default class KimaiCalendar {
             }
         }
 
+        // Extension point: plugins can listen for this event and push HTML into
+        // detail.content, which is read back synchronously right after dispatch.
+        const detail = {event: eventObj, content: []};
+        document.dispatchEvent(new CustomEvent('kimai.calendar.eventPopover', {detail: detail}));
+        const extensionHtml = detail.content.join('');
+
         return escaper.sanitize(`
             <div class="calendar-entry">
                 <ul>
@@ -674,8 +689,8 @@ export default class KimaiCalendar {
                     <li>` + this.options['translations']['project'] + `: ` + escaper.escapeForHtml(eventObj.project) + `</li>
                     <li>` + this.options['translations']['activity'] + `: ` + escaper.escapeForHtml(eventObj.activity) + `</li>
                 </ul>` +
-                (eventObj.description !== null || eventObj.tags.length > 0 ? '<hr>' : '') +
-                (eventObj.description ? '<div>' + escaper.escapeForHtml(eventObj.description) + '</div>' : '') + tags + `
+                (eventObj.description !== null || eventObj.tags.length > 0 || extensionHtml !== '' ? '<hr>' : '') +
+                (eventObj.description ? '<div>' + escaper.escapeForHtml(eventObj.description) + '</div>' : '') + tags + extensionHtml + `
             </div>`);
     }
 


### PR DESCRIPTION
## Description

Dispatch custom events so plugins can hook into the calendar rendering without modifying the core:
- `kimai.calendar.eventContent`: allows manipulating an event's DOM element directly in `eventDidMount` (e.g. adding badges or icons)
- `kimai.calendar.eventPopover`: allows injecting additional HTML into the event popover content in `renderEventPopoverContent`

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] I verified that my code applies to the guidelines (`composer code-check`)
- [ ] I updated the documentation (see [here](https://github.com/kimai/www.kimai.org/tree/master/_documentation))
- [x] I agree that this code is used in Kimai (see [license](https://github.com/kimai/kimai/blob/main/LICENSE))
