### PR TITLE
Remove Symfony cache from Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -285,7 +285,7 @@ RUN \
     composer --no-ansi clearcache && \
     cp /usr/local/etc/php/php.ini-development /usr/local/etc/php/php.ini && \
     chown -R www-data:www-data /opt/kimai /usr/local/etc/php/php.ini && \
-    mkdir -p /opt/kimai/var/logs && chmod 777 /opt/kimai/var/logs && \
+    mkdir -p /opt/kimai/var/log && chmod 777 /opt/kimai/var/log && \
     sed "s/128M/-1/g" /usr/local/etc/php/php.ini-development > /opt/kimai/php-cli.ini && \
     sed -i "s/env php/env -S php -c \/opt\/kimai\/php-cli.ini/g" /opt/kimai/bin/console && \
     /opt/kimai/bin/console kimai:version | awk '{print $2}' > /opt/kimai/version.txt
@@ -312,7 +312,7 @@ RUN \
     sed -i "s/;opcache.max_accelerated_files=10000/opcache.max_accelerated_files=100000/g" /usr/local/etc/php/php.ini && \
     sed -i "s/opcache.validate_timestamps=1/opcache.validate_timestamps=0/g" /usr/local/etc/php/php.ini && \
     sed -i "s/session.gc_maxlifetime = 1440/session.gc_maxlifetime = 604800/g" /usr/local/etc/php/php.ini && \
-    mkdir -p /opt/kimai/var/logs && chmod 777 /opt/kimai/var/logs && \
+    mkdir -p /opt/kimai/var/log && chmod 777 /opt/kimai/var/log && \
     sed "s/128M/-1/g" /usr/local/etc/php/php.ini-development > /opt/kimai/php-cli.ini && \
     chown -R www-data:www-data /opt/kimai /usr/local/etc/php/php.ini && \
     /opt/kimai/bin/console kimai:version | awk '{print $2}' > /opt/kimai/version.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -288,7 +288,8 @@ RUN \
     mkdir -p /opt/kimai/var/log && chmod 777 /opt/kimai/var/log && \
     sed "s/128M/-1/g" /usr/local/etc/php/php.ini-development > /opt/kimai/php-cli.ini && \
     sed -i "s/env php/env -S php -c \/opt\/kimai\/php-cli.ini/g" /opt/kimai/bin/console && \
-    /opt/kimai/bin/console kimai:version | awk '{print $2}' > /opt/kimai/version.txt
+    /opt/kimai/bin/console kimai:version | awk '{print $2}' > /opt/kimai/version.txt && \
+    rm -rf /opt/kimai/var/cache/*
 ENV APP_ENV=dev
 ENV DATABASE_URL=
 ENV memory_limit=512M
@@ -315,7 +316,8 @@ RUN \
     mkdir -p /opt/kimai/var/log && chmod 777 /opt/kimai/var/log && \
     sed "s/128M/-1/g" /usr/local/etc/php/php.ini-development > /opt/kimai/php-cli.ini && \
     chown -R www-data:www-data /opt/kimai /usr/local/etc/php/php.ini && \
-    /opt/kimai/bin/console kimai:version | awk '{print $2}' > /opt/kimai/version.txt
+    /opt/kimai/bin/console kimai:version | awk '{print $2}' > /opt/kimai/version.txt && \
+    rm -rf /opt/kimai/var/cache/*
 ENV APP_ENV=prod
 ENV DATABASE_URL=
 ENV memory_limit=512M


### PR DESCRIPTION
## Description

- Fixes an invalid directory name (unused log dorectory)
- Removes the Symfony cache before finalizing the build layer to remove 45MB cache

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] I verified that my code applies to the guidelines (`composer code-check`)
- [ ] I updated the documentation (see [here](https://github.com/kimai/www.kimai.org/tree/master/_documentation))
- [x] I agree that this code is used in Kimai (see [license](https://github.com/kimai/kimai/blob/main/LICENSE))
