### PR TITLE
Timesheet API improvements

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -10,13 +10,14 @@ Perform EACH version specific task between your version and the new one, otherwi
 
 ## [2.66.0](https://github.com/kimai/kimai/releases/tag/2.66.0)
 
-The timesheet API now honours the `view_rate_own_timesheet` and `view_rate_other_timesheet`
+The timesheet API now honors the `view_rate_own_timesheet` and `view_rate_other_timesheet`
 permissions, which the UI, the export and the reporting always enforced.
 
 The fields `rate`, `internalRate`, `hourlyRate` and `fixedRate` are no longer part of the
-JSON response for users without those permissions. The default `ROLE_USER` does not hold
-them, so API clients running with a plain user account have to grant the permission if they
-rely on those fields.
+JSON response collectionfor records the user may not see the rates of. The permission is applied per
+record, so a  can contain records with and without these fields - treat them as
+optional. The default `ROLE_USER` does not hold the permissions, so API clients running
+with a plain user account have to grant them if they rely on those fields.
 
 ## [2.65.0](https://github.com/kimai/kimai/releases/tag/2.65.0)
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -14,8 +14,8 @@ The timesheet API now honors the `view_rate_own_timesheet` and `view_rate_other_
 permissions, which the UI, the export and the reporting always enforced.
 
 The fields `rate`, `internalRate`, `hourlyRate` and `fixedRate` are no longer part of the
-JSON response collectionfor records the user may not see the rates of. The permission is applied per
-record, so a  can contain records with and without these fields - treat them as
+JSON response for records the user may not see the rates of. The permission is applied per
+record, so a collection can contain records with and without these fields - treat them as
 optional. The default `ROLE_USER` does not hold the permissions, so API clients running
 with a plain user account have to grant them if they rely on those fields.
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -8,6 +8,16 @@ you can upgrade your Kimai installation to the latest stable release.
 Check below if there are more version specific steps required, which need to be executed after the normal update process.
 Perform EACH version specific task between your version and the new one, otherwise you risk data inconsistency or a broken installation.
 
+## [2.66.0](https://github.com/kimai/kimai/releases/tag/2.66.0)
+
+The timesheet API now honours the `view_rate_own_timesheet` and `view_rate_other_timesheet`
+permissions, which the UI, the export and the reporting always enforced.
+
+The fields `rate`, `internalRate`, `hourlyRate` and `fixedRate` are no longer part of the
+JSON response for users without those permissions. The default `ROLE_USER` does not hold
+them, so API clients running with a plain user account have to grant the permission if they
+rely on those fields.
+
 ## [2.65.0](https://github.com/kimai/kimai/releases/tag/2.65.0)
 
 These three API endpoints were removed, because they were technically broken and could not be fixed without breaking changes:

--- a/config/packages/nelmio_api_doc.yaml
+++ b/config/packages/nelmio_api_doc.yaml
@@ -28,10 +28,10 @@ nelmio_api_doc:
             - { alias: TagEditForm,                 type: App\Form\API\TagApiEditForm,              groups: [Default, Entity, Tag] }
             - { alias: TagEntity,                   type: App\Entity\Tag,                           groups: [Default, Entity, Tag] }
             - { alias: TimesheetEditForm,           type: App\Form\API\TimesheetApiEditForm,        groups: [Default, Entity, Timesheet, Not_Expanded] }
-            - { alias: TimesheetEntity,             type: App\Entity\Timesheet,                     groups: [Default, Entity, Timesheet, Timesheet_Entity, Rates, Not_Expanded] }
-            - { alias: TimesheetExpanded,           type: App\Entity\Timesheet,                     groups: [Default, Entity, Timesheet, Timesheet_Entity, Rates, Expanded] }
-            - { alias: TimesheetCollection,         type: App\Entity\Timesheet,                     groups: [Default, Collection, Timesheet, Rates, Not_Expanded] }
-            - { alias: TimesheetCollectionExpanded, type: App\Entity\Timesheet,                     groups: [Default, Collection, Timesheet, Rates, Expanded] }
+            - { alias: TimesheetEntity,             type: App\Entity\Timesheet,                     groups: [Default, Entity, Timesheet, Timesheet_Entity, Timesheet_Rate, Timesheet_Entity_Rate, Not_Expanded] }
+            - { alias: TimesheetExpanded,           type: App\Entity\Timesheet,                     groups: [Default, Entity, Timesheet, Timesheet_Entity, Timesheet_Rate, Timesheet_Entity_Rate, Expanded] }
+            - { alias: TimesheetCollection,         type: App\Entity\Timesheet,                     groups: [Default, Collection, Timesheet, Timesheet_Rate, Not_Expanded] }
+            - { alias: TimesheetCollectionExpanded, type: App\Entity\Timesheet,                     groups: [Default, Collection, Timesheet, Timesheet_Rate, Expanded] }
             - { alias: UserCreateForm,              type: App\Form\API\UserApiCreateForm,           groups: [Default, Entity, User, User_Entity] }
             - { alias: UserEditForm,                type: App\Form\API\UserApiEditForm,             groups: [Default, Entity, User, User_Entity] }
             - { alias: User,                        type: App\Entity\User,                          groups: [Default] }

--- a/config/packages/nelmio_api_doc.yaml
+++ b/config/packages/nelmio_api_doc.yaml
@@ -28,10 +28,10 @@ nelmio_api_doc:
             - { alias: TagEditForm,                 type: App\Form\API\TagApiEditForm,              groups: [Default, Entity, Tag] }
             - { alias: TagEntity,                   type: App\Entity\Tag,                           groups: [Default, Entity, Tag] }
             - { alias: TimesheetEditForm,           type: App\Form\API\TimesheetApiEditForm,        groups: [Default, Entity, Timesheet, Not_Expanded] }
-            - { alias: TimesheetEntity,             type: App\Entity\Timesheet,                     groups: [Default, Entity, Timesheet, Timesheet_Entity, Not_Expanded] }
-            - { alias: TimesheetExpanded,           type: App\Entity\Timesheet,                     groups: [Default, Entity, Timesheet, Timesheet_Entity, Expanded] }
-            - { alias: TimesheetCollection,         type: App\Entity\Timesheet,                     groups: [Default, Collection, Timesheet, Not_Expanded] }
-            - { alias: TimesheetCollectionExpanded, type: App\Entity\Timesheet,                     groups: [Default, Collection, Timesheet, Expanded] }
+            - { alias: TimesheetEntity,             type: App\Entity\Timesheet,                     groups: [Default, Entity, Timesheet, Timesheet_Entity, Rates, Not_Expanded] }
+            - { alias: TimesheetExpanded,           type: App\Entity\Timesheet,                     groups: [Default, Entity, Timesheet, Timesheet_Entity, Rates, Expanded] }
+            - { alias: TimesheetCollection,         type: App\Entity\Timesheet,                     groups: [Default, Collection, Timesheet, Rates, Not_Expanded] }
+            - { alias: TimesheetCollectionExpanded, type: App\Entity\Timesheet,                     groups: [Default, Collection, Timesheet, Rates, Expanded] }
             - { alias: UserCreateForm,              type: App\Form\API\UserApiCreateForm,           groups: [Default, Entity, User, User_Entity] }
             - { alias: UserEditForm,                type: App\Form\API\UserApiEditForm,             groups: [Default, Entity, User, User_Entity] }
             - { alias: User,                        type: App\Entity\User,                          groups: [Default] }

--- a/src/API/Serializer/RateExclusionStrategy.php
+++ b/src/API/Serializer/RateExclusionStrategy.php
@@ -19,7 +19,7 @@ use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 
 /**
  * Removes the monetary fields from serialized timesheets, unless the current
- * user is granted the "view_rate" permission for that record: see GHSA-fq95-vwvx-w88f.
+ * user is granted the "view_rate" permission for that record.
  *
  * The decision is made per record, so a collection can contain records of
  * multiple users, each one serialized according to the callers permission.

--- a/src/API/Serializer/RateExclusionStrategy.php
+++ b/src/API/Serializer/RateExclusionStrategy.php
@@ -1,0 +1,64 @@
+<?php
+
+/*
+ * This file is part of the Kimai time-tracking app.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\API\Serializer;
+
+use App\Entity\Timesheet;
+use JMS\Serializer\Context;
+use JMS\Serializer\Exclusion\ExclusionStrategyInterface;
+use JMS\Serializer\Metadata\ClassMetadata;
+use JMS\Serializer\Metadata\PropertyMetadata;
+use JMS\Serializer\SerializationContext;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
+
+/**
+ * Removes the monetary fields from serialized timesheets, unless the current
+ * user is granted the "view_rate" permission for that record: see GHSA-fq95-vwvx-w88f.
+ *
+ * The decision is made per record, so a collection can contain records of
+ * multiple users, each one serialized according to the callers permission.
+ */
+final class RateExclusionStrategy implements ExclusionStrategyInterface
+{
+    private const RATE_FIELDS = ['rate', 'internalRate', 'fixedRate', 'hourlyRate'];
+
+    /**
+     * @var \SplObjectStorage<Timesheet, bool>
+     */
+    private \SplObjectStorage $decisions;
+
+    public function __construct(private readonly AuthorizationCheckerInterface $security)
+    {
+        $this->decisions = new \SplObjectStorage();
+    }
+
+    public function shouldSkipClass(ClassMetadata $metadata, Context $context): bool
+    {
+        return false;
+    }
+
+    public function shouldSkipProperty(PropertyMetadata $property, Context $context): bool
+    {
+        if ($property->class !== Timesheet::class || !\in_array($property->name, self::RATE_FIELDS, true)) {
+            return false;
+        }
+
+        $timesheet = $context instanceof SerializationContext ? $context->getObject() : null;
+        if (!$timesheet instanceof Timesheet) {
+            // there is no record to check the permission on: never expose rates
+            return true;
+        }
+
+        if (!$this->decisions->offsetExists($timesheet)) {
+            $this->decisions[$timesheet] = !$this->security->isGranted('view_rate', $timesheet);
+        }
+
+        return $this->decisions[$timesheet];
+    }
+}

--- a/src/API/TimesheetController.php
+++ b/src/API/TimesheetController.php
@@ -119,7 +119,7 @@ final class TimesheetController extends BaseApiController
         if ($timesheets instanceof \IteratorAggregate) {
             $timesheets = $timesheets->getIterator();
         }
-        $view->getContext()->setGroups($this->getCollectionSerializationGroups($timesheets, $groups));
+        $view->getContext()->setGroups($this->getCollectionSerializationGroups($timesheets, $groups)); // @phpstan-ignore argument.type
 
         return $this->viewHandler->handle($view);
     }
@@ -310,7 +310,7 @@ final class TimesheetController extends BaseApiController
             $groups = self::GROUPS_COLLECTION_FULL;
         }
 
-        return $this->renderCollection($data, $groups); // @phpstan-ignore argument.type
+        return $this->renderCollection($data, $groups);
     }
 
     /**

--- a/src/API/TimesheetController.php
+++ b/src/API/TimesheetController.php
@@ -68,6 +68,74 @@ final class TimesheetController extends BaseApiController
     }
 
     /**
+     * Rate fields are only serialized if the user may see them for every given record.
+     *
+     * @param array<string> $groups
+     * @param array<string> $rateGroups
+     * @param iterable<Timesheet> $timesheets
+     * @return array<string>
+     */
+    private function addRateGroups(array $groups, array $rateGroups, iterable $timesheets): array
+    {
+        foreach ($timesheets as $timesheet) {
+            if (!$timesheet instanceof Timesheet) {
+                continue;
+            }
+
+            if (!$this->isGranted('view_rate', $timesheet)) {
+                return $groups;
+            }
+        }
+
+        return array_merge($groups, $rateGroups);
+    }
+
+    /**
+     * @param iterable<Timesheet> $timesheets
+     * @param array<string> $groups
+     * @return array<string>
+     */
+    private function getCollectionSerializationGroups(iterable $timesheets, array $groups): array
+    {
+        return $this->addRateGroups($groups, ['Timesheet_Rate'], $timesheets);
+    }
+
+    /**
+     * @param array<string> $groups
+     * @return array<string>
+     */
+    private function getEntitySerializationGroups(Timesheet $timesheet, array $groups): array
+    {
+        return $this->addRateGroups($groups, ['Timesheet_Rate', 'Timesheet_Entity_Rate'], [$timesheet]);
+    }
+
+    /**
+     * @param iterable<Timesheet> $timesheets
+     * @param array<string> $groups
+     */
+    private function renderCollection(iterable $timesheets, array $groups): Response
+    {
+        $view = new View($timesheets, Response::HTTP_OK);
+        if ($timesheets instanceof \IteratorAggregate) {
+            $timesheets = $timesheets->getIterator();
+        }
+        $view->getContext()->setGroups($this->getCollectionSerializationGroups($timesheets, $groups));
+
+        return $this->viewHandler->handle($view);
+    }
+
+    /**
+     * @param array<string> $groups
+     */
+    private function renderEntity(Timesheet $timesheet, array $groups): Response
+    {
+        $view = new View($timesheet, Response::HTTP_OK);
+        $view->getContext()->setGroups($this->getEntitySerializationGroups($timesheet, $groups));
+
+        return $this->viewHandler->handle($view);
+    }
+
+    /**
      * Fetch timesheets
      */
     #[IsGranted(new Expression("is_granted('view_own_timesheet') or is_granted('view_other_timesheet')"))]
@@ -234,16 +302,15 @@ final class TimesheetController extends BaseApiController
         }
 
         $data = $this->repository->getPagerfantaForQuery($query);
-        $view = new View($data, 200);
+
+        $groups = self::GROUPS_COLLECTION;
 
         $full = $paramFetcher->get('full');
         if ($full === '1' || $full === 'true') {
-            $view->getContext()->setGroups(self::GROUPS_COLLECTION_FULL);
-        } else {
-            $view->getContext()->setGroups(self::GROUPS_COLLECTION);
+            $groups = self::GROUPS_COLLECTION_FULL;
         }
 
-        return $this->viewHandler->handle($view);
+        return $this->renderCollection($data, $groups); // @phpstan-ignore argument.type
     }
 
     /**
@@ -255,10 +322,7 @@ final class TimesheetController extends BaseApiController
     #[Route(methods: ['GET'], path: '/{id}', name: 'get_timesheet', requirements: ['id' => '\d+'])]
     public function getAction(Timesheet $timesheet): Response
     {
-        $view = new View($timesheet, 200);
-        $view->getContext()->setGroups(self::GROUPS_ENTITY);
-
-        return $this->viewHandler->handle($view);
+        return $this->renderEntity($timesheet, self::GROUPS_ENTITY);
     }
 
     /**
@@ -294,15 +358,11 @@ final class TimesheetController extends BaseApiController
             try {
                 $this->service->saveTimesheet($timesheet);
 
-                $view = new View($timesheet, 200);
-
                 if (null !== $paramFetcher->get('full')) {
-                    $view->getContext()->setGroups(self::GROUPS_ENTITY_FULL);
-                } else {
-                    $view->getContext()->setGroups(self::GROUPS_ENTITY);
+                    return $this->renderEntity($timesheet, self::GROUPS_ENTITY_FULL);
                 }
 
-                return $this->viewHandler->handle($view);
+                return $this->renderEntity($timesheet, self::GROUPS_ENTITY);
             } catch (ValidationFailedException $ex) {
                 $form->addError(new FormError($ex->getMessage()));
             }
@@ -351,10 +411,7 @@ final class TimesheetController extends BaseApiController
 
         $this->service->saveTimesheet($timesheet);
 
-        $view = new View($timesheet, Response::HTTP_OK);
-        $view->getContext()->setGroups(self::GROUPS_ENTITY);
-
-        return $this->viewHandler->handle($view);
+        return $this->renderEntity($timesheet, self::GROUPS_ENTITY);
     }
 
     /**
@@ -402,10 +459,9 @@ final class TimesheetController extends BaseApiController
         $recentActivity = new RecentActivityEvent($user, $data);
         $this->dispatcher->dispatch($recentActivity);
 
-        $view = new View($recentActivity->getRecentActivities(), 200);
-        $view->getContext()->setGroups(self::GROUPS_COLLECTION_FULL);
+        $recent = $recentActivity->getRecentActivities();
 
-        return $this->viewHandler->handle($view);
+        return $this->renderCollection($recent, self::GROUPS_COLLECTION_FULL);
     }
 
     /**
@@ -421,10 +477,7 @@ final class TimesheetController extends BaseApiController
 
         $data = $this->repository->getActiveEntries($user);
 
-        $view = new View($data, 200);
-        $view->getContext()->setGroups(self::GROUPS_COLLECTION_FULL);
-
-        return $this->viewHandler->handle($view);
+        return $this->renderCollection($data, self::GROUPS_COLLECTION_FULL);
     }
 
     /**
@@ -438,10 +491,7 @@ final class TimesheetController extends BaseApiController
     {
         $this->service->stopTimesheet($timesheet);
 
-        $view = new View($timesheet, 200);
-        $view->getContext()->setGroups(self::GROUPS_ENTITY);
-
-        return $this->viewHandler->handle($view);
+        return $this->renderEntity($timesheet, self::GROUPS_ENTITY);
     }
 
     /**
@@ -500,10 +550,7 @@ final class TimesheetController extends BaseApiController
 
         $this->service->restartTimesheet($copyTimesheet, $timesheet);
 
-        $view = new View($copyTimesheet, 200);
-        $view->getContext()->setGroups(self::GROUPS_ENTITY);
-
-        return $this->viewHandler->handle($view);
+        return $this->renderEntity($copyTimesheet, self::GROUPS_ENTITY);
     }
 
     /**
@@ -521,10 +568,7 @@ final class TimesheetController extends BaseApiController
         $this->service->saveTimesheet($copyTimesheet);
         $this->dispatcher->dispatch(new TimesheetDuplicatePostEvent($copyTimesheet, $timesheet));
 
-        $view = new View($copyTimesheet, 200);
-        $view->getContext()->setGroups(self::GROUPS_ENTITY);
-
-        return $this->viewHandler->handle($view);
+        return $this->renderEntity($copyTimesheet, self::GROUPS_ENTITY);
     }
 
     /**
@@ -544,10 +588,7 @@ final class TimesheetController extends BaseApiController
 
         $this->service->saveTimesheet($timesheet);
 
-        $view = new View($timesheet, 200);
-        $view->getContext()->setGroups(self::GROUPS_ENTITY);
-
-        return $this->viewHandler->handle($view);
+        return $this->renderEntity($timesheet, self::GROUPS_ENTITY);
     }
 
     /**
@@ -574,9 +615,6 @@ final class TimesheetController extends BaseApiController
 
         $this->service->saveTimesheet($timesheet);
 
-        $view = new View($timesheet, 200);
-        $view->getContext()->setGroups(self::GROUPS_ENTITY);
-
-        return $this->viewHandler->handle($view);
+        return $this->renderEntity($timesheet, self::GROUPS_ENTITY);
     }
 }

--- a/src/API/TimesheetController.php
+++ b/src/API/TimesheetController.php
@@ -72,7 +72,7 @@ final class TimesheetController extends BaseApiController
 
     /**
      * The rate groups are always requested, the per-record permission filtering
-     * is applied by the RateExclusionStrategy: see GHSA-fq95-vwvx-w88f.
+     * is applied by the RateExclusionStrategy.
      *
      * @param array<string> $groups
      * @param array<string> $rateGroups

--- a/src/API/TimesheetController.php
+++ b/src/API/TimesheetController.php
@@ -9,6 +9,7 @@
 
 namespace App\API;
 
+use App\API\Serializer\RateExclusionStrategy;
 use App\Entity\Timesheet;
 use App\Entity\User;
 use App\Event\RecentActivityEvent;
@@ -39,6 +40,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
 use Symfony\Component\Validator\Constraints;
 
@@ -58,7 +60,8 @@ final class TimesheetController extends BaseApiController
         private readonly TimesheetRepository $repository,
         private readonly TagRepository $tagRepository,
         private readonly EventDispatcherInterface $dispatcher,
-        private readonly TimesheetService $service
+        private readonly TimesheetService $service,
+        private readonly AuthorizationCheckerInterface $security
     ) {
     }
 
@@ -68,45 +71,19 @@ final class TimesheetController extends BaseApiController
     }
 
     /**
-     * Rate fields are only serialized if the user may see them for every given record.
+     * The rate groups are always requested, the per-record permission filtering
+     * is applied by the RateExclusionStrategy: see GHSA-fq95-vwvx-w88f.
      *
      * @param array<string> $groups
      * @param array<string> $rateGroups
-     * @param iterable<Timesheet> $timesheets
-     * @return array<string>
      */
-    private function addRateGroups(array $groups, array $rateGroups, iterable $timesheets): array
+    private function renderRateAwareView(View $view, array $groups, array $rateGroups): Response
     {
-        foreach ($timesheets as $timesheet) {
-            if (!$timesheet instanceof Timesheet) {
-                continue;
-            }
+        $context = $view->getContext();
+        $context->setGroups(array_merge($groups, $rateGroups));
+        $context->addExclusionStrategy(new RateExclusionStrategy($this->security));
 
-            if (!$this->isGranted('view_rate', $timesheet)) {
-                return $groups;
-            }
-        }
-
-        return array_merge($groups, $rateGroups);
-    }
-
-    /**
-     * @param iterable<Timesheet> $timesheets
-     * @param array<string> $groups
-     * @return array<string>
-     */
-    private function getCollectionSerializationGroups(iterable $timesheets, array $groups): array
-    {
-        return $this->addRateGroups($groups, ['Timesheet_Rate'], $timesheets);
-    }
-
-    /**
-     * @param array<string> $groups
-     * @return array<string>
-     */
-    private function getEntitySerializationGroups(Timesheet $timesheet, array $groups): array
-    {
-        return $this->addRateGroups($groups, ['Timesheet_Rate', 'Timesheet_Entity_Rate'], [$timesheet]);
+        return $this->viewHandler->handle($view);
     }
 
     /**
@@ -115,13 +92,7 @@ final class TimesheetController extends BaseApiController
      */
     private function renderCollection(iterable $timesheets, array $groups): Response
     {
-        $view = new View($timesheets, Response::HTTP_OK);
-        if ($timesheets instanceof \IteratorAggregate) {
-            $timesheets = $timesheets->getIterator();
-        }
-        $view->getContext()->setGroups($this->getCollectionSerializationGroups($timesheets, $groups)); // @phpstan-ignore argument.type
-
-        return $this->viewHandler->handle($view);
+        return $this->renderRateAwareView(new View($timesheets, Response::HTTP_OK), $groups, ['Timesheet_Rate']);
     }
 
     /**
@@ -129,10 +100,7 @@ final class TimesheetController extends BaseApiController
      */
     private function renderEntity(Timesheet $timesheet, array $groups): Response
     {
-        $view = new View($timesheet, Response::HTTP_OK);
-        $view->getContext()->setGroups($this->getEntitySerializationGroups($timesheet, $groups));
-
-        return $this->viewHandler->handle($view);
+        return $this->renderRateAwareView(new View($timesheet, Response::HTTP_OK), $groups, ['Timesheet_Rate', 'Timesheet_Entity_Rate']);
     }
 
     /**

--- a/src/Entity/Timesheet.php
+++ b/src/Entity/Timesheet.php
@@ -165,21 +165,21 @@ class Timesheet implements EntityWithMetaFields, ExportableItem, ModifiedAt
     #[Assert\GreaterThanOrEqual(0)]
     #[Assert\NotNull]
     #[Serializer\Expose]
-    #[Serializer\Groups(['Timesheet_Rate', 'Rates'])]
+    #[Serializer\Groups(['Timesheet_Rate'])]
     private float $rate = 0.00;
     #[ORM\Column(name: 'internal_rate', type: Types::FLOAT, nullable: true)]
     #[Serializer\Expose]
-    #[Serializer\Groups(['Timesheet_Rate', 'Rates'])]
+    #[Serializer\Groups(['Timesheet_Rate'])]
     private ?float $internalRate = null;
     #[ORM\Column(name: 'fixed_rate', type: Types::FLOAT, nullable: true)]
     #[Assert\GreaterThanOrEqual(0)]
     #[Serializer\Expose]
-    #[Serializer\Groups(['Timesheet_Entity_Rate', 'Rates'])]
+    #[Serializer\Groups(['Timesheet_Entity_Rate'])]
     private ?float $fixedRate = null;
     #[ORM\Column(name: 'hourly_rate', type: Types::FLOAT, nullable: true)]
     #[Assert\GreaterThanOrEqual(0)]
     #[Serializer\Expose]
-    #[Serializer\Groups(['Timesheet_Entity_Rate', 'Rates'])]
+    #[Serializer\Groups(['Timesheet_Entity_Rate'])]
     private ?float $hourlyRate = null;
     #[ORM\Column(name: 'exported', type: Types::BOOLEAN, nullable: false, options: ['default' => false])]
     #[Assert\NotNull]

--- a/src/Entity/Timesheet.php
+++ b/src/Entity/Timesheet.php
@@ -132,6 +132,9 @@ class Timesheet implements EntityWithMetaFields, ExportableItem, ModifiedAt
     #[Serializer\Expose]
     #[Serializer\Groups(['Default'])]
     private ?int $duration = 0;
+    /**
+     * Break duration for this record in seconds, can be null.
+     */
     #[Serializer\Expose]
     #[Serializer\Groups(['Default'])]
     #[ORM\Column(name: 'break', type: Types::INTEGER, nullable: true)]
@@ -163,7 +166,8 @@ class Timesheet implements EntityWithMetaFields, ExportableItem, ModifiedAt
     private ?string $description = null;
     /**
      * Total rate for this timesheet.
-     * Each API result can be returned with or without this field (depends on the `view_rate_own_timesheet` and `view_rate_other_timesheet` permissions).
+     *
+     * Optional. Only included if the current user may see the rates of this record: `view_rate_own_timesheet` permission for own records, `view_rate_other_timesheet` for records of other users.
      */
     #[ORM\Column(name: 'rate', type: Types::FLOAT, nullable: false)]
     #[Assert\GreaterThanOrEqual(0)]
@@ -173,7 +177,8 @@ class Timesheet implements EntityWithMetaFields, ExportableItem, ModifiedAt
     private float $rate = 0.00;
     /**
      * Total internal-rate for this timesheet.
-     * Each API result can be returned with or without this field (depends on the `view_rate_own_timesheet` and `view_rate_other_timesheet` permissions).
+     *
+     * Optional. Only included if the current user may see the rates of this record: `view_rate_own_timesheet` permission for own records, `view_rate_other_timesheet` for records of other users.
      */
     #[ORM\Column(name: 'internal_rate', type: Types::FLOAT, nullable: true)]
     #[Serializer\Expose]
@@ -181,7 +186,8 @@ class Timesheet implements EntityWithMetaFields, ExportableItem, ModifiedAt
     private ?float $internalRate = null;
     /**
      * If this timesheet has a fixed rate, this field is not `null`.
-     * Each API result can be returned with or without this field (depends on the `view_rate_own_timesheet` and `view_rate_other_timesheet` permissions).
+     *
+     * Optional. Only included if the current user may see the rates of this record: `view_rate_own_timesheet` permission for own records, `view_rate_other_timesheet` for records of other users.
      */
     #[ORM\Column(name: 'fixed_rate', type: Types::FLOAT, nullable: true)]
     #[Assert\GreaterThanOrEqual(0)]
@@ -190,18 +196,27 @@ class Timesheet implements EntityWithMetaFields, ExportableItem, ModifiedAt
     private ?float $fixedRate = null;
     /**
      * The hourly rate of this timesheet, `null` if the timesheet has a fixed rate.
-     * Each API result can be returned with or without this field (depends on the `view_rate_own_timesheet` and `view_rate_other_timesheet` permissions).
+     *
+     * Optional. Only included if the current user may see the rates of this record: `view_rate_own_timesheet` permission for own records, `view_rate_other_timesheet` for records of other users.
      */
     #[ORM\Column(name: 'hourly_rate', type: Types::FLOAT, nullable: true)]
     #[Assert\GreaterThanOrEqual(0)]
     #[Serializer\Expose]
     #[Serializer\Groups(['Timesheet_Entity_Rate'])]
     private ?float $hourlyRate = null;
+    /**
+     * Whether this timesheet was already exported.
+     *
+     * Exported timesheets cannot be edited any more by regular users.
+     */
     #[ORM\Column(name: 'exported', type: Types::BOOLEAN, nullable: false, options: ['default' => false])]
     #[Assert\NotNull]
     #[Serializer\Expose]
     #[Serializer\Groups(['Default'])]
     private bool $exported = false;
+    /**
+     * Whether this timesheet is billable.
+     */
     #[ORM\Column(name: 'billable', type: Types::BOOLEAN, nullable: false, options: ['default' => true])]
     #[Assert\NotNull]
     #[Serializer\Expose]

--- a/src/Entity/Timesheet.php
+++ b/src/Entity/Timesheet.php
@@ -165,21 +165,21 @@ class Timesheet implements EntityWithMetaFields, ExportableItem, ModifiedAt
     #[Assert\GreaterThanOrEqual(0)]
     #[Assert\NotNull]
     #[Serializer\Expose]
-    #[Serializer\Groups(['Default'])]
+    #[Serializer\Groups(['Timesheet_Rate', 'Rates'])]
     private float $rate = 0.00;
     #[ORM\Column(name: 'internal_rate', type: Types::FLOAT, nullable: true)]
     #[Serializer\Expose]
-    #[Serializer\Groups(['Default'])]
+    #[Serializer\Groups(['Timesheet_Rate', 'Rates'])]
     private ?float $internalRate = null;
     #[ORM\Column(name: 'fixed_rate', type: Types::FLOAT, nullable: true)]
     #[Assert\GreaterThanOrEqual(0)]
     #[Serializer\Expose]
-    #[Serializer\Groups(['Entity'])]
+    #[Serializer\Groups(['Timesheet_Entity_Rate', 'Rates'])]
     private ?float $fixedRate = null;
     #[ORM\Column(name: 'hourly_rate', type: Types::FLOAT, nullable: true)]
     #[Assert\GreaterThanOrEqual(0)]
     #[Serializer\Expose]
-    #[Serializer\Groups(['Entity'])]
+    #[Serializer\Groups(['Timesheet_Entity_Rate', 'Rates'])]
     private ?float $hourlyRate = null;
     #[ORM\Column(name: 'exported', type: Types::BOOLEAN, nullable: false, options: ['default' => false])]
     #[Assert\NotNull]

--- a/src/Entity/Timesheet.php
+++ b/src/Entity/Timesheet.php
@@ -161,21 +161,37 @@ class Timesheet implements EntityWithMetaFields, ExportableItem, ModifiedAt
     #[Serializer\Expose]
     #[Serializer\Groups(['Default'])]
     private ?string $description = null;
+    /**
+     * Total rate for this timesheet.
+     * Each API result can be returned with or without this field (depends on the `view_rate_own_timesheet` and `view_rate_other_timesheet` permissions).
+     */
     #[ORM\Column(name: 'rate', type: Types::FLOAT, nullable: false)]
     #[Assert\GreaterThanOrEqual(0)]
     #[Assert\NotNull]
     #[Serializer\Expose]
     #[Serializer\Groups(['Timesheet_Rate'])]
     private float $rate = 0.00;
+    /**
+     * Total internal-rate for this timesheet.
+     * Each API result can be returned with or without this field (depends on the `view_rate_own_timesheet` and `view_rate_other_timesheet` permissions).
+     */
     #[ORM\Column(name: 'internal_rate', type: Types::FLOAT, nullable: true)]
     #[Serializer\Expose]
     #[Serializer\Groups(['Timesheet_Rate'])]
     private ?float $internalRate = null;
+    /**
+     * If this timesheet has a fixed rate, this field is not `null`.
+     * Each API result can be returned with or without this field (depends on the `view_rate_own_timesheet` and `view_rate_other_timesheet` permissions).
+     */
     #[ORM\Column(name: 'fixed_rate', type: Types::FLOAT, nullable: true)]
     #[Assert\GreaterThanOrEqual(0)]
     #[Serializer\Expose]
     #[Serializer\Groups(['Timesheet_Entity_Rate'])]
     private ?float $fixedRate = null;
+    /**
+     * The hourly rate of this timesheet, `null` if the timesheet has a fixed rate.
+     * Each API result can be returned with or without this field (depends on the `view_rate_own_timesheet` and `view_rate_other_timesheet` permissions).
+     */
     #[ORM\Column(name: 'hourly_rate', type: Types::FLOAT, nullable: true)]
     #[Assert\GreaterThanOrEqual(0)]
     #[Serializer\Expose]

--- a/src/Repository/Loader/TimesheetLoader.php
+++ b/src/Repository/Loader/TimesheetLoader.php
@@ -132,14 +132,26 @@ final class TimesheetLoader implements LoaderInterface
                 ->execute();
         }
 
-        if ($this->query !== null && $this->query->hasQueryHint(TimesheetQueryHint::USER_PREFERENCES)) {
-            $userIds = array_filter(array_map(function (Timesheet $timesheet) {
-                return $timesheet->getUser()?->getId();
-            }, $results), function ($id): bool {
-                return $id !== null;
-            });
+        $userIds = array_filter(array_unique(array_map(function (Timesheet $timesheet) {
+            return $timesheet->getUser()?->getId();
+        }, $results)), function ($id): bool {
+            return $id !== null;
+        });
 
-            if (\count($userIds) > 0) {
+        if (\count($userIds) > 0) {
+            // the voter checks the team memberships of the record owner for every
+            // row (RolePermissionManager::checkTeamLeadAccess), load them upfront
+            // instead of once per user
+            $qb = $em->createQueryBuilder();
+            $qb->select('PARTIAL u.{id}', 'memberships', 'PARTIAL team.{id}')
+                ->from(User::class, 'u')
+                ->leftJoin('u.memberships', 'memberships')
+                ->leftJoin('memberships.team', 'team')
+                ->andWhere($qb->expr()->in('u.id', $userIds))
+                ->getQuery()
+                ->execute();
+
+            if ($this->query !== null && $this->query->hasQueryHint(TimesheetQueryHint::USER_PREFERENCES)) {
                 $qb = $em->createQueryBuilder();
                 $qb->select('PARTIAL u.{id}', 'preferences')
                     ->from(User::class, 'u')

--- a/tests/API/APIControllerBaseTestCase.php
+++ b/tests/API/APIControllerBaseTestCase.php
@@ -821,11 +821,17 @@ abstract class APIControllerBaseTestCase extends AbstractControllerBaseTestCase
      *
      * @param string $type
      * @param array $result
+     * @param array<string> $removeFields fields which are not part of the response, eg. because a permission is missing
      * @throws \Exception
      */
-    protected static function assertApiResponseTypeStructure(string $type, array $result): void
+    protected static function assertApiResponseTypeStructure(string $type, array $result, array $removeFields = []): void
     {
         $expected = self::getExpectedResponseStructure($type);
+
+        foreach ($removeFields as $field) {
+            unset($expected[$field]);
+        }
+
         $expectedKeys = array_keys($expected);
 
         $actual = array_keys($result);

--- a/tests/API/Serializer/RateExclusionStrategyTest.php
+++ b/tests/API/Serializer/RateExclusionStrategyTest.php
@@ -1,0 +1,140 @@
+<?php
+
+/*
+ * This file is part of the Kimai time-tracking app.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Tests\API\Serializer;
+
+use App\API\Serializer\RateExclusionStrategy;
+use App\Entity\Activity;
+use App\Entity\Timesheet;
+use JMS\Serializer\DeserializationContext;
+use JMS\Serializer\Metadata\ClassMetadata;
+use JMS\Serializer\Metadata\PropertyMetadata;
+use JMS\Serializer\SerializationContext;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
+
+#[CoversClass(RateExclusionStrategy::class)]
+class RateExclusionStrategyTest extends TestCase
+{
+    private const RATE_FIELDS = ['rate', 'internalRate', 'fixedRate', 'hourlyRate'];
+
+    /**
+     * @return SerializationContext&\PHPUnit\Framework\MockObject\MockObject
+     */
+    private function createContext(?Timesheet $timesheet)
+    {
+        $context = $this->createMock(SerializationContext::class);
+        $context->method('getObject')->willReturn($timesheet);
+
+        return $context;
+    }
+
+    public function testShouldNeverSkipAClass(): void
+    {
+        $security = $this->createMock(AuthorizationCheckerInterface::class);
+        $security->expects(self::never())->method('isGranted');
+
+        $sut = new RateExclusionStrategy($security);
+
+        self::assertFalse($sut->shouldSkipClass(new ClassMetadata(Timesheet::class), $this->createContext(new Timesheet())));
+    }
+
+    public function testShouldNeverSkipPropertiesOfOtherClasses(): void
+    {
+        $security = $this->createMock(AuthorizationCheckerInterface::class);
+        $security->expects(self::never())->method('isGranted');
+
+        $sut = new RateExclusionStrategy($security);
+        $context = $this->createContext(new Timesheet());
+
+        self::assertFalse($sut->shouldSkipProperty(new PropertyMetadata(Activity::class, 'name'), $context));
+    }
+
+    public function testShouldNeverSkipOtherTimesheetProperties(): void
+    {
+        $security = $this->createMock(AuthorizationCheckerInterface::class);
+        $security->expects(self::never())->method('isGranted');
+
+        $sut = new RateExclusionStrategy($security);
+        $context = $this->createContext(new Timesheet());
+
+        self::assertFalse($sut->shouldSkipProperty(new PropertyMetadata(Timesheet::class, 'description'), $context));
+    }
+
+    public function testSkipsRateFieldsWithoutPermission(): void
+    {
+        $timesheet = new Timesheet();
+
+        $security = $this->createMock(AuthorizationCheckerInterface::class);
+        // the decision is cached per record, no matter how many rate fields are serialized
+        $security->expects(self::once())->method('isGranted')->with('view_rate', $timesheet)->willReturn(false);
+
+        $sut = new RateExclusionStrategy($security);
+        $context = $this->createContext($timesheet);
+
+        foreach (self::RATE_FIELDS as $field) {
+            self::assertTrue($sut->shouldSkipProperty(new PropertyMetadata(Timesheet::class, $field), $context));
+        }
+    }
+
+    public function testSerializesRateFieldsWithPermission(): void
+    {
+        $timesheet = new Timesheet();
+
+        $security = $this->createMock(AuthorizationCheckerInterface::class);
+        $security->expects(self::once())->method('isGranted')->with('view_rate', $timesheet)->willReturn(true);
+
+        $sut = new RateExclusionStrategy($security);
+        $context = $this->createContext($timesheet);
+
+        foreach (self::RATE_FIELDS as $field) {
+            self::assertFalse($sut->shouldSkipProperty(new PropertyMetadata(Timesheet::class, $field), $context));
+        }
+    }
+
+    public function testDecidesPerRecord(): void
+    {
+        $mine = new Timesheet();
+        $foreign = new Timesheet();
+
+        $security = $this->createMock(AuthorizationCheckerInterface::class);
+        $security->expects(self::exactly(2))->method('isGranted')->willReturnCallback(
+            function (string $attribute, Timesheet $timesheet) use ($mine): bool {
+                self::assertEquals('view_rate', $attribute);
+
+                return $timesheet === $mine;
+            }
+        );
+
+        $sut = new RateExclusionStrategy($security);
+        $property = new PropertyMetadata(Timesheet::class, 'rate');
+
+        self::assertFalse($sut->shouldSkipProperty($property, $this->createContext($mine)));
+        self::assertTrue($sut->shouldSkipProperty($property, $this->createContext($foreign)));
+        // cached decisions
+        self::assertFalse($sut->shouldSkipProperty($property, $this->createContext($mine)));
+        self::assertTrue($sut->shouldSkipProperty($property, $this->createContext($foreign)));
+    }
+
+    public function testSkipsRateFieldsWithoutRecordToCheckPermissionsOn(): void
+    {
+        $security = $this->createMock(AuthorizationCheckerInterface::class);
+        $security->expects(self::never())->method('isGranted');
+
+        $sut = new RateExclusionStrategy($security);
+
+        // no object is being visited
+        self::assertTrue($sut->shouldSkipProperty(new PropertyMetadata(Timesheet::class, 'rate'), $this->createContext(null)));
+
+        // not a serialization context
+        $deserialization = $this->createMock(DeserializationContext::class);
+        self::assertTrue($sut->shouldSkipProperty(new PropertyMetadata(Timesheet::class, 'rate'), $deserialization));
+    }
+}

--- a/tests/API/TimesheetControllerTest.php
+++ b/tests/API/TimesheetControllerTest.php
@@ -33,6 +33,10 @@ class TimesheetControllerTest extends APIControllerBaseTestCase
     public const DATE_FORMAT = 'Y-m-d H:i:s';
     public const DATE_FORMAT_HTML5 = 'Y-m-d\TH:i:s';
     public const TEST_TIMEZONE = 'Europe/London';
+    /**
+     * Rate fields only for users with the "view_rate" permission: GHSA-fq95-vwvx-w88f
+     */
+    private const TIMESHEET_RATE_FIELDS = ['rate', 'internalRate', 'fixedRate', 'hourlyRate'];
 
     /**
      * @return Timesheet[]
@@ -75,7 +79,7 @@ class TimesheetControllerTest extends APIControllerBaseTestCase
         self::assertNotEmpty($result);
         self::assertEquals(10, \count($result));
         self::assertIsArray($result[0]);
-        self::assertApiResponseTypeStructure('TimesheetCollection', $result[0]);
+        self::assertApiResponseTypeStructure('TimesheetCollection', $result[0], self::TIMESHEET_RATE_FIELDS);
     }
 
     public function testGetCollectionFull(): void
@@ -92,7 +96,7 @@ class TimesheetControllerTest extends APIControllerBaseTestCase
         self::assertNotEmpty($result);
         self::assertEquals(10, \count($result));
         self::assertIsArray($result[0]);
-        self::assertApiResponseTypeStructure('TimesheetCollectionFull', $result[0]);
+        self::assertApiResponseTypeStructure('TimesheetCollectionFull', $result[0], self::TIMESHEET_RATE_FIELDS);
     }
 
     public function testGetCollectionForOtherUser(): void
@@ -240,7 +244,7 @@ class TimesheetControllerTest extends APIControllerBaseTestCase
         self::assertNotEmpty($result);
         self::assertEquals(10, \count($result));
         self::assertIsArray($result[0]);
-        self::assertApiResponseTypeStructure('TimesheetCollection', $result[0]);
+        self::assertApiResponseTypeStructure('TimesheetCollection', $result[0], self::TIMESHEET_RATE_FIELDS);
     }
 
     public function testGetCollectionForAllUser(): void
@@ -323,7 +327,7 @@ class TimesheetControllerTest extends APIControllerBaseTestCase
         self::assertNotEmpty($result);
         self::assertEquals(4, \count($result));
         self::assertIsArray($result[0]);
-        self::assertApiResponseTypeStructure('TimesheetCollection', $result[0]);
+        self::assertApiResponseTypeStructure('TimesheetCollection', $result[0], self::TIMESHEET_RATE_FIELDS);
     }
 
     public function testGetCollectionWithQueryFailsWith404OnOutOfRangedPage(): void
@@ -376,7 +380,7 @@ class TimesheetControllerTest extends APIControllerBaseTestCase
         self::assertNotEmpty($result);
         self::assertEquals(5, \count($result));
         self::assertIsArray($result[0]);
-        self::assertApiResponseTypeStructure('TimesheetCollection', $result[0]);
+        self::assertApiResponseTypeStructure('TimesheetCollection', $result[0], self::TIMESHEET_RATE_FIELDS);
     }
 
     public function testExportedFilter(): void
@@ -416,7 +420,7 @@ class TimesheetControllerTest extends APIControllerBaseTestCase
         self::assertNotEmpty($result);
         self::assertEquals(7, \count($result));
         self::assertIsArray($result[0]);
-        self::assertApiResponseTypeStructure('TimesheetCollection', $result[0]);
+        self::assertApiResponseTypeStructure('TimesheetCollection', $result[0], self::TIMESHEET_RATE_FIELDS);
 
         $query = [
             'page' => 1,
@@ -435,7 +439,7 @@ class TimesheetControllerTest extends APIControllerBaseTestCase
         self::assertNotEmpty($result);
         self::assertEquals(10, \count($result));
         self::assertIsArray($result[0]);
-        self::assertApiResponseTypeStructure('TimesheetCollection', $result[0]);
+        self::assertApiResponseTypeStructure('TimesheetCollection', $result[0], self::TIMESHEET_RATE_FIELDS);
 
         $query = [
             'page' => 1,
@@ -452,7 +456,7 @@ class TimesheetControllerTest extends APIControllerBaseTestCase
         self::assertNotEmpty($result);
         self::assertEquals(17, \count($result));
         self::assertIsArray($result[0]);
-        self::assertApiResponseTypeStructure('TimesheetCollection', $result[0]);
+        self::assertApiResponseTypeStructure('TimesheetCollection', $result[0], self::TIMESHEET_RATE_FIELDS);
     }
 
     public function testGetEntity(): void
@@ -490,7 +494,7 @@ class TimesheetControllerTest extends APIControllerBaseTestCase
         $result = json_decode($content, true);
 
         self::assertIsArray($result);
-        self::assertApiResponseTypeStructure('TimesheetEntity', $result);
+        self::assertApiResponseTypeStructure('TimesheetEntity', $result, self::TIMESHEET_RATE_FIELDS);
 
         $expected = [
             'activity' => 1,
@@ -507,13 +511,77 @@ class TimesheetControllerTest extends APIControllerBaseTestCase
             'duration' => 46500, // 12,916 => rounded 12,92 * 137,21 = 46512
             'exported' => true,
             'metaFields' => [],
-            'hourlyRate' => 137.21,
-            'rate' => 1772.2958,
-            'internalRate' => 1772.2958,
         ];
 
         foreach ($expected as $key => $value) {
             self::assertEquals($value, $result[$key], \sprintf('Field %s has invalid value', $key));
+        }
+
+        // a plain user does not hold "view_rate_own_timesheet", so the monetary
+        // values must not be part of the response, see GHSA-fq95-vwvx-w88f
+        foreach (self::TIMESHEET_RATE_FIELDS as $field) {
+            self::assertArrayNotHasKey($field, $result);
+        }
+    }
+
+    /**
+     * Regression test for GHSA-fq95-vwvx-w88f: the API has to honour the
+     * "view_rate" permission, which the UI, the export and the reporting enforce.
+     */
+    public function testGetEntityRatesAreVisibleWithPermission(): void
+    {
+        $client = $this->getClientForAuthenticatedUser(User::ROLE_TEAMLEAD);
+        $em = $this->getEntityManager();
+
+        $startDate = new \DateTime('2020-03-27 14:35:59', new \DateTimeZone('Pacific/Tongatapu'));
+        $endDate = (clone $startDate)->modify('+ 46385 seconds');
+
+        $timesheet = new Timesheet();
+        $timesheet
+            ->setHourlyRate(137.21)
+            ->setBegin($startDate)
+            ->setEnd($endDate)
+            ->setUser($this->getUserByRole(User::ROLE_TEAMLEAD))
+            ->setProject($em->getRepository(Project::class)->find(1))
+            ->setActivity($em->getRepository(Activity::class)->find(1))
+        ;
+        $em->persist($timesheet);
+        $em->flush();
+
+        $this->assertAccessIsGranted($client, '/api/timesheets/' . $timesheet->getId());
+        $content = $client->getResponse()->getContent();
+        self::assertIsString($content);
+        $result = json_decode($content, true);
+
+        self::assertIsArray($result);
+        self::assertApiResponseTypeStructure('TimesheetEntity', $result);
+        self::assertEquals(137.21, $result['hourlyRate']);
+        self::assertEquals(1772.2958, $result['rate']);
+        self::assertEquals(1772.2958, $result['internalRate']);
+    }
+
+    /**
+     * Regression test for GHSA-fq95-vwvx-w88f: the collection endpoint must not
+     * leak rate data either.
+     */
+    public function testGetCollectionHidesRatesWithoutPermission(): void
+    {
+        $client = $this->getClientForAuthenticatedUser(User::ROLE_USER);
+        $this->importFixtureForUser(User::ROLE_USER, 3);
+
+        $this->assertAccessIsGranted($client, '/api/timesheets');
+        $content = $client->getResponse()->getContent();
+        self::assertIsString($content);
+        $result = json_decode($content, true);
+
+        self::assertIsArray($result);
+        self::assertNotEmpty($result);
+
+        foreach ($result as $row) {
+            self::assertIsArray($row);
+            foreach (self::TIMESHEET_RATE_FIELDS as $field) {
+                self::assertArrayNotHasKey($field, $row);
+            }
         }
     }
 
@@ -984,7 +1052,7 @@ class TimesheetControllerTest extends APIControllerBaseTestCase
         $result = json_decode($content, true);
 
         self::assertIsArray($result);
-        self::assertApiResponseTypeStructure('TimesheetEntity', $result);
+        self::assertApiResponseTypeStructure('TimesheetEntity', $result, self::TIMESHEET_RATE_FIELDS);
         self::assertSame($allowedProject->getId(), $result['project']);
         self::assertNotSame($restrictedProject->getId(), $result['project']);
     }
@@ -1059,7 +1127,7 @@ class TimesheetControllerTest extends APIControllerBaseTestCase
         $result = json_decode($content, true);
 
         self::assertIsArray($result);
-        self::assertApiResponseTypeStructure('TimesheetEntity', $result);
+        self::assertApiResponseTypeStructure('TimesheetEntity', $result, self::TIMESHEET_RATE_FIELDS);
         self::assertNotEmpty($result['id']);
         self::assertIsNumeric($result['id']);
         $id = $result['id'];
@@ -1192,7 +1260,7 @@ class TimesheetControllerTest extends APIControllerBaseTestCase
         self::assertEquals(3, \count($result));
         foreach ($result as $timesheet) {
             self::assertIsArray($timesheet);
-            self::assertApiResponseTypeStructure('TimesheetCollectionFull', $timesheet);
+            self::assertApiResponseTypeStructure('TimesheetCollectionFull', $timesheet, self::TIMESHEET_RATE_FIELDS);
         }
     }
 
@@ -1224,7 +1292,7 @@ class TimesheetControllerTest extends APIControllerBaseTestCase
 
         self::assertIsArray($result);
         self::assertNotEmpty($result);
-        self::assertApiResponseTypeStructure('TimesheetEntity', $result);
+        self::assertApiResponseTypeStructure('TimesheetEntity', $result, self::TIMESHEET_RATE_FIELDS);
 
         $em = $this->getEntityManager();
         /** @var Timesheet $timesheet */
@@ -1311,7 +1379,7 @@ class TimesheetControllerTest extends APIControllerBaseTestCase
         self::assertNotEmpty($result);
         self::assertEquals(10, \count($result));
         self::assertIsArray($result[0]);
-        self::assertApiResponseTypeStructure('TimesheetCollection', $result[0]);
+        self::assertApiResponseTypeStructure('TimesheetCollection', $result[0], self::TIMESHEET_RATE_FIELDS);
 
         $query = ['tags' => ['Test', 'Admin']];
         $this->assertAccessIsGranted($client, '/api/timesheets', 'GET', $query);
@@ -1324,7 +1392,7 @@ class TimesheetControllerTest extends APIControllerBaseTestCase
         self::assertNotEmpty($result);
         self::assertEquals(10, \count($result));
         self::assertIsArray($result[0]);
-        self::assertApiResponseTypeStructure('TimesheetCollection', $result[0]);
+        self::assertApiResponseTypeStructure('TimesheetCollection', $result[0], self::TIMESHEET_RATE_FIELDS);
 
         $query = ['tags' => ['Nothing-2-see', 'not-existing-here']];
         $this->request($client, '/api/timesheets', 'GET', $query);
@@ -1353,7 +1421,7 @@ class TimesheetControllerTest extends APIControllerBaseTestCase
         $result = json_decode($content, true);
 
         self::assertIsArray($result);
-        self::assertApiResponseTypeStructure('TimesheetEntity', $result);
+        self::assertApiResponseTypeStructure('TimesheetEntity', $result, self::TIMESHEET_RATE_FIELDS);
         self::assertEmpty($result['description']);
         self::assertEmpty($result['tags']);
 
@@ -1391,7 +1459,7 @@ class TimesheetControllerTest extends APIControllerBaseTestCase
         $result = json_decode($content, true);
 
         self::assertIsArray($result);
-        self::assertApiResponseTypeStructure('TimesheetEntity', $result);
+        self::assertApiResponseTypeStructure('TimesheetEntity', $result, self::TIMESHEET_RATE_FIELDS);
         self::assertEmpty($result['description']);
         self::assertEmpty($result['tags']);
 
@@ -1437,7 +1505,7 @@ class TimesheetControllerTest extends APIControllerBaseTestCase
         $result = json_decode($content, true);
 
         self::assertIsArray($result);
-        self::assertApiResponseTypeStructure('TimesheetEntity', $result);
+        self::assertApiResponseTypeStructure('TimesheetEntity', $result, self::TIMESHEET_RATE_FIELDS);
         self::assertEquals('foo', $result['description']);
         self::assertEquals([['name' => 'sdfsdf', 'value' => 'nnnnn'], ['name' => '1234567890', 'value' => '1234567890']], $result['metaFields']);
         self::assertEquals(['another', 'testing', 'bar'], $result['tags']);
@@ -1708,7 +1776,7 @@ class TimesheetControllerTest extends APIControllerBaseTestCase
         $result = json_decode($content, true);
 
         self::assertIsArray($result);
-        self::assertApiResponseTypeStructure('TimesheetEntity', $result);
+        self::assertApiResponseTypeStructure('TimesheetEntity', $result, self::TIMESHEET_RATE_FIELDS);
         self::assertEquals(['name' => 'metatestmock', 'value' => 'another,testing,bar'], $result['metaFields'][0]);
 
         $em = $this->getEntityManager();

--- a/tests/API/TimesheetControllerTest.php
+++ b/tests/API/TimesheetControllerTest.php
@@ -13,6 +13,8 @@ use App\API\BaseApiController;
 use App\Entity\Activity;
 use App\Entity\Customer;
 use App\Entity\Project;
+use App\Entity\Role;
+use App\Entity\RolePermission;
 use App\Entity\Tag;
 use App\Entity\Team;
 use App\Entity\Timesheet;
@@ -21,11 +23,13 @@ use App\Entity\User;
 use App\Tests\DataFixtures\TimesheetFixtures;
 use App\Tests\Mocks\TimesheetTestMetaFieldSubscriberMock;
 use App\Timesheet\DateTimeFactory;
+use App\User\PermissionService;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\HttpKernelBrowser;
+use Symfony\Contracts\Cache\CacheInterface;
 
 #[Group('integration')]
 class TimesheetControllerTest extends APIControllerBaseTestCase
@@ -531,22 +535,7 @@ class TimesheetControllerTest extends APIControllerBaseTestCase
     public function testGetEntityRatesAreVisibleWithPermission(): void
     {
         $client = $this->getClientForAuthenticatedUser(User::ROLE_TEAMLEAD);
-        $em = $this->getEntityManager();
-
-        $startDate = new \DateTime('2020-03-27 14:35:59', new \DateTimeZone('Pacific/Tongatapu'));
-        $endDate = (clone $startDate)->modify('+ 46385 seconds');
-
-        $timesheet = new Timesheet();
-        $timesheet
-            ->setHourlyRate(137.21)
-            ->setBegin($startDate)
-            ->setEnd($endDate)
-            ->setUser($this->getUserByRole(User::ROLE_TEAMLEAD))
-            ->setProject($em->getRepository(Project::class)->find(1))
-            ->setActivity($em->getRepository(Activity::class)->find(1))
-        ;
-        $em->persist($timesheet);
-        $em->flush();
+        $timesheet = $this->createRatedTimesheet($this->getUserByRole(User::ROLE_TEAMLEAD));
 
         $this->assertAccessIsGranted($client, '/api/timesheets/' . $timesheet->getId());
         $content = $client->getResponse()->getContent();
@@ -576,6 +565,205 @@ class TimesheetControllerTest extends APIControllerBaseTestCase
 
         self::assertIsArray($result);
         self::assertNotEmpty($result);
+
+        foreach ($result as $row) {
+            self::assertIsArray($row);
+            foreach (self::TIMESHEET_RATE_FIELDS as $field) {
+                self::assertArrayNotHasKey($field, $row);
+            }
+        }
+    }
+
+    /**
+     * Creates a stopped timesheet for the given owner, whose calculated rate
+     * and internal rate are known upfront: 12,92h * 137,21 = 1772,2958.
+     */
+    private function createRatedTimesheet(User $owner): Timesheet
+    {
+        $em = $this->getEntityManager();
+
+        $startDate = new \DateTime('2020-03-27 14:35:59', new \DateTimeZone('Pacific/Tongatapu'));
+        $endDate = (clone $startDate)->modify('+ 46385 seconds');
+
+        $timesheet = new Timesheet();
+        $timesheet
+            ->setHourlyRate(137.21)
+            ->setBegin($startDate)
+            ->setEnd($endDate)
+            ->setUser($owner)
+            ->setProject($em->getRepository(Project::class)->find(1))
+            ->setActivity($em->getRepository(Activity::class)->find(1))
+        ;
+        $em->persist($timesheet);
+        $em->flush();
+
+        return $timesheet;
+    }
+
+    /**
+     * GHSA-fq95-vwvx-w88f: a teamlead holds "view_rate_other_timesheet", so the
+     * rates of another users record (without restricting teams) are serialized.
+     */
+    public function testGetEntityRatesAreVisibleForOtherUsersRecordWithPermission(): void
+    {
+        $client = $this->getClientForAuthenticatedUser(User::ROLE_TEAMLEAD);
+        $timesheet = $this->createRatedTimesheet($this->getUserByRole(User::ROLE_USER));
+
+        $this->assertAccessIsGranted($client, '/api/timesheets/' . $timesheet->getId());
+        $content = $client->getResponse()->getContent();
+        self::assertIsString($content);
+        $result = json_decode($content, true);
+
+        self::assertIsArray($result);
+        self::assertApiResponseTypeStructure('TimesheetEntity', $result);
+        self::assertEquals(137.21, $result['hourlyRate']);
+        self::assertEquals(1772.2958, $result['rate']);
+        self::assertEquals(1772.2958, $result['internalRate']);
+    }
+
+    /**
+     * GHSA-fq95-vwvx-w88f, the high impact configuration from the advisory: a
+     * custom role may see the records of other users ("view_other_timesheet"),
+     * but not their monetary values (no "view_rate_other_timesheet").
+     */
+    public function testGetEntityHidesRatesForOtherUsersRecordWithoutRatePermission(): void
+    {
+        $client = $this->getClientForAuthenticatedUser(User::ROLE_USER);
+        $this->grantPermissions(User::ROLE_USER, 'TEST_VIEW_OTHER_NO_RATES', ['view_other_timesheet']);
+
+        $timesheet = $this->createRatedTimesheet($this->getUserByRole(User::ROLE_TEAMLEAD));
+
+        $this->assertAccessIsGranted($client, '/api/timesheets/' . $timesheet->getId());
+        $content = $client->getResponse()->getContent();
+        self::assertIsString($content);
+        $result = json_decode($content, true);
+
+        self::assertIsArray($result);
+        self::assertApiResponseTypeStructure('TimesheetEntity', $result, self::TIMESHEET_RATE_FIELDS);
+
+        foreach (self::TIMESHEET_RATE_FIELDS as $field) {
+            self::assertArrayNotHasKey($field, $result);
+        }
+    }
+
+    /**
+     * GHSA-fq95-vwvx-w88f: rate fields are only serialized if the permission is
+     * granted for EVERY record of the response. A teamlead whose role has
+     * "view_rate_other_timesheet" revoked may see his own rates, but not the
+     * rates of his team members - so a mixed page is serialized entirely
+     * without rate fields, while the single-record route still returns the
+     * rates of his own record.
+     */
+    public function testGetCollectionWithMixedRatePermissionHidesAllRates(): void
+    {
+        $client = $this->getClientForAuthenticatedUser(User::ROLE_TEAMLEAD);
+        $em = $this->getEntityManager();
+
+        $teamlead = $this->getUserByRole(User::ROLE_TEAMLEAD);
+        $owner = $this->getUserByRole(User::ROLE_USER);
+
+        $team = new Team('GHSA-fq95 mixed team');
+        $team->addTeamlead($teamlead);
+        $team->addUser($owner);
+        $em->persist($team);
+        $em->flush();
+
+        // revoke the rate permission for other users records, as an admin would
+        // do it in the permission screen: with a DB override for the built-in role
+        $role = (new Role())->setName(User::ROLE_TEAMLEAD);
+        $em->persist($role);
+        $permissionService = self::getContainer()->get(PermissionService::class);
+        self::assertInstanceOf(PermissionService::class, $permissionService);
+        $revoked = (new RolePermission())->setRole($role)->setPermission('view_rate_other_timesheet')->setAllowed(false);
+        $permissionService->saveRolePermission($revoked);
+
+        try {
+            $own = $this->createRatedTimesheet($teamlead);
+            $this->createRatedTimesheet($owner);
+
+            $query = ['user' => 'all'];
+            $this->assertAccessIsGranted($client, '/api/timesheets', 'GET', $query);
+            $content = $client->getResponse()->getContent();
+            self::assertIsString($content);
+            $result = json_decode($content, true);
+
+            self::assertIsArray($result);
+            self::assertCount(2, $result);
+
+            foreach ($result as $row) {
+                self::assertIsArray($row);
+                foreach (self::TIMESHEET_RATE_FIELDS as $field) {
+                    self::assertArrayNotHasKey($field, $row);
+                }
+            }
+
+            // the single-record route serializes the rates of the own record
+            $this->assertAccessIsGranted($client, '/api/timesheets/' . $own->getId());
+            $content = $client->getResponse()->getContent();
+            self::assertIsString($content);
+            $result = json_decode($content, true);
+
+            self::assertIsArray($result);
+            self::assertEquals(1772.2958, $result['rate']);
+        } finally {
+            // the DB override is rolled back with the test transaction, but the
+            // shared permission cache (PermissionService) survives the test run:
+            // reset it, so later tests (and runs) see the default permissions again
+            $cache = self::getContainer()->get('cache.app');
+            self::assertInstanceOf(CacheInterface::class, $cache);
+            $cache->delete('permissions');
+        }
+    }
+
+    /**
+     * GHSA-fq95-vwvx-w88f: the recent endpoint must not leak rate data either.
+     */
+    public function testRecentActionHidesRatesWithoutPermission(): void
+    {
+        $client = $this->getClientForAuthenticatedUser(User::ROLE_USER);
+        $this->createRatedTimesheet($this->getUserByRole(User::ROLE_USER));
+
+        $query = ['begin' => '2020-01-01T00:00:00'];
+        $this->assertAccessIsGranted($client, '/api/timesheets/recent', 'GET', $query);
+        $content = $client->getResponse()->getContent();
+        self::assertIsString($content);
+        $result = json_decode($content, true);
+
+        self::assertIsArray($result);
+        self::assertNotEmpty($result);
+
+        foreach ($result as $row) {
+            self::assertIsArray($row);
+            self::assertApiResponseTypeStructure('TimesheetCollectionFull', $row, self::TIMESHEET_RATE_FIELDS);
+            foreach (self::TIMESHEET_RATE_FIELDS as $field) {
+                self::assertArrayNotHasKey($field, $row);
+            }
+        }
+    }
+
+    /**
+     * GHSA-fq95-vwvx-w88f: the active endpoint must not leak rate data either.
+     */
+    public function testActiveActionHidesRatesWithoutPermission(): void
+    {
+        $client = $this->getClientForAuthenticatedUser(User::ROLE_USER);
+
+        $fixture = new TimesheetFixtures($this->getUserByRole(User::ROLE_USER));
+        $fixture->setFixedRate(true);
+        $fixture->setHourlyRate(true);
+        $fixture->setStartDate(new \DateTime('-2 hours'));
+        $fixture->setAmountRunning(1);
+        $this->importFixture($fixture);
+
+        $this->request($client, '/api/timesheets/active');
+        self::assertTrue($client->getResponse()->isSuccessful());
+
+        $content = $client->getResponse()->getContent();
+        self::assertIsString($content);
+        $result = json_decode($content, true);
+
+        self::assertIsArray($result);
+        self::assertCount(1, $result);
 
         foreach ($result as $row) {
             self::assertIsArray($row);

--- a/tests/API/TimesheetControllerTest.php
+++ b/tests/API/TimesheetControllerTest.php
@@ -647,14 +647,12 @@ class TimesheetControllerTest extends APIControllerBaseTestCase
     }
 
     /**
-     * GHSA-fq95-vwvx-w88f: rate fields are only serialized if the permission is
-     * granted for EVERY record of the response. A teamlead whose role has
-     * "view_rate_other_timesheet" revoked may see his own rates, but not the
-     * rates of his team members - so a mixed page is serialized entirely
-     * without rate fields, while the single-record route still returns the
-     * rates of his own record.
+     * GHSA-fq95-vwvx-w88f: the rate permission is applied per record. A teamlead
+     * whose role has "view_rate_other_timesheet" revoked may see his own rates,
+     * but not the rates of his team members - so a mixed page contains the rate
+     * fields only on his own records.
      */
-    public function testGetCollectionWithMixedRatePermissionHidesAllRates(): void
+    public function testGetCollectionWithMixedRatePermissionShowsOnlyOwnRates(): void
     {
         $client = $this->getClientForAuthenticatedUser(User::ROLE_TEAMLEAD);
         $em = $this->getEntityManager();
@@ -692,8 +690,14 @@ class TimesheetControllerTest extends APIControllerBaseTestCase
 
             foreach ($result as $row) {
                 self::assertIsArray($row);
-                foreach (self::TIMESHEET_RATE_FIELDS as $field) {
-                    self::assertArrayNotHasKey($field, $row);
+                if ($row['user'] === $teamlead->getId()) {
+                    self::assertEquals(1772.2958, $row['rate']);
+                    self::assertEquals(1772.2958, $row['internalRate']);
+                } else {
+                    self::assertEquals($owner->getId(), $row['user']);
+                    foreach (self::TIMESHEET_RATE_FIELDS as $field) {
+                        self::assertArrayNotHasKey($field, $row);
+                    }
                 }
             }
 


### PR DESCRIPTION
## Description

- Adds a new ExclusionStrategy to the Timesheet API view
- Improve readability of API docs by adding more details
- Rate fields are optional now (potential BCs for API users, if they treat them as required)
- Prevent N+1 calls on multi-user listing pages for non admins

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] I verified that my code applies to the guidelines (`composer code-check`)
- [x] I updated the documentation (see [here](https://github.com/kimai/www.kimai.org/tree/master/_documentation))
- [x] I agree that this code is used in Kimai (see [license](https://github.com/kimai/kimai/blob/main/LICENSE))
