### PR TITLE
API: include optional budget fields in collection

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -19,6 +19,12 @@ record, so a collection can contain records with and without these fields - trea
 optional. The default `ROLE_USER` does not hold the permissions, so API clients running
 with a plain user account have to grant them if they rely on those fields.
 
+The customer, project and activity APIs apply the `budget` and `time` permissions per
+record as well. The budget fields `budget`, `timeBudget` and `budgetType` are now also part 
+of the collection responses (`GET /api/customers`, `GET /api/projects`, `GET /api/activities`)
+for records the user may see the budgets of.
+Like the rate fields: treat them as optional.
+
 ## [2.65.0](https://github.com/kimai/kimai/releases/tag/2.65.0)
 
 These three API endpoints were removed, because they were technically broken and could not be fixed without breaking changes:

--- a/config/packages/nelmio_api_doc.yaml
+++ b/config/packages/nelmio_api_doc.yaml
@@ -6,25 +6,25 @@ nelmio_api_doc:
             - { alias: Comment,                     type: App\Entity\CommentTableTypeTrait,         groups: [Default] }
             - { alias: CommentForm,                 type: App\Form\API\CommentApiForm,              groups: [Default] }
             - { alias: CustomerEditForm,            type: App\Form\API\CustomerApiEditForm,         groups: [Default, Entity, Customer, Customer_Entity] }
-            - { alias: CustomerEntity,              type: App\Entity\Customer,                      groups: [Default, Entity, Customer, Customer_Entity, Budgets, Not_Expanded] }
+            - { alias: CustomerEntity,              type: App\Entity\Customer,                      groups: [Default, Entity, Customer, Customer_Entity, Budget_Money, Budget_Time, Not_Expanded] }
             - { alias: Customer,                    type: App\Entity\Customer,                      groups: [Default, Not_Expanded] }
             - { alias: CustomerRate,                type: App\Entity\CustomerRate,                  groups: [Default, Entity, Customer_Rate] }
             - { alias: CustomerRateForm,            type: App\Form\API\CustomerRateApiForm,         groups: [Default, Entity, Customer_Rate] }
-            - { alias: CustomerCollection,          type: App\Entity\Customer,                      groups: [Default, Collection, Customer] }
+            - { alias: CustomerCollection,          type: App\Entity\Customer,                      groups: [Default, Collection, Customer, Budget_Money, Budget_Time] }
             - { alias: ProjectEditForm,             type: App\Form\API\ProjectApiEditForm,          groups: [Default, Entity, Project, Project_Entity] }
-            - { alias: ProjectEntity,               type: App\Entity\Project,                       groups: [Default, Entity, Project, Project_Entity, Budgets, Not_Expanded] }
+            - { alias: ProjectEntity,               type: App\Entity\Project,                       groups: [Default, Entity, Project, Project_Entity, Budget_Money, Budget_Time, Not_Expanded] }
             - { alias: Project,                     type: App\Entity\Project,                       groups: [Default, Not_Expanded] }
             - { alias: ProjectExpanded,             type: App\Entity\Project,                       groups: [Default, Expanded] }
             - { alias: ProjectRate,                 type: App\Entity\ProjectRate,                   groups: [Default, Entity, Project_Rate] }
             - { alias: ProjectRateForm,             type: App\Form\API\ProjectRateApiForm,          groups: [Default, Entity, Project_Rate] }
-            - { alias: ProjectCollection,           type: App\Entity\Project,                       groups: [Default, Collection, Project] }
+            - { alias: ProjectCollection,           type: App\Entity\Project,                       groups: [Default, Collection, Project, Budget_Money, Budget_Time] }
             - { alias: ActivityEditForm,            type: App\Form\API\ActivityApiEditForm,         groups: [Default, Entity, Activity, Activity_Entity] }
-            - { alias: ActivityEntity,              type: App\Entity\Activity,                      groups: [Default, Entity, Activity, Activity_Entity, Budgets, Not_Expanded] }
+            - { alias: ActivityEntity,              type: App\Entity\Activity,                      groups: [Default, Entity, Activity, Activity_Entity, Budget_Money, Budget_Time, Not_Expanded] }
             - { alias: Activity,                    type: App\Entity\Activity,                      groups: [Default, Not_Expanded] }
             - { alias: ActivityExpanded,            type: App\Entity\Activity,                      groups: [Default, Expanded] }
             - { alias: ActivityRate,                type: App\Entity\ActivityRate,                  groups: [Default, Entity, Activity_Rate] }
             - { alias: ActivityRateForm,            type: App\Form\API\ActivityRateApiForm,         groups: [Default, Entity, Activity_Rate] }
-            - { alias: ActivityCollection,          type: App\Entity\Activity,                      groups: [Default, Collection, Activity] }
+            - { alias: ActivityCollection,          type: App\Entity\Activity,                      groups: [Default, Collection, Activity, Budget_Money, Budget_Time] }
             - { alias: TagEditForm,                 type: App\Form\API\TagApiEditForm,              groups: [Default, Entity, Tag] }
             - { alias: TagEntity,                   type: App\Entity\Tag,                           groups: [Default, Entity, Tag] }
             - { alias: TimesheetEditForm,           type: App\Form\API\TimesheetApiEditForm,        groups: [Default, Entity, Timesheet, Not_Expanded] }

--- a/src/API/ActivityController.php
+++ b/src/API/ActivityController.php
@@ -10,6 +10,7 @@
 namespace App\API;
 
 use App\Activity\ActivityService;
+use App\API\Serializer\BudgetExclusionStrategy;
 use App\Entity\Activity;
 use App\Entity\ActivityRate;
 use App\Form\API\ActivityApiEditForm;
@@ -29,6 +30,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\GoneHttpException;
 use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
 
 #[Route(path: '/activities')]
@@ -44,34 +46,29 @@ final class ActivityController extends BaseApiController
         private readonly ViewHandlerInterface $viewHandler,
         private readonly ActivityRepository $repository,
         private readonly ActivityRateRepository $activityRateRepository,
-        private readonly ActivityService $activityService
+        private readonly ActivityService $activityService,
+        private readonly AuthorizationCheckerInterface $security
     ) {
     }
 
     /**
-     * @return array<string>
+     * The budget groups are always requested, the per-record permission filtering
+     * is applied by the BudgetExclusionStrategy.
+     *
+     * @param array<string> $groups
      */
-    private function getEntitySerializationGroups(Activity $activity): array
+    private function renderBudgetAwareView(View $view, array $groups): Response
     {
-        $groups = self::GROUPS_ENTITY;
+        $context = $view->getContext();
+        $context->setGroups(array_merge($groups, ['Budget_Money', 'Budget_Time']));
+        $context->addExclusionStrategy(new BudgetExclusionStrategy($this->security));
 
-        if ($this->isGranted('budget', $activity)) {
-            $groups = array_merge($groups, ['Budget_Money']);
-        }
-
-        if ($this->isGranted('time', $activity)) {
-            $groups = array_merge($groups, ['Budget_Time']);
-        }
-
-        return $groups;
+        return $this->viewHandler->handle($view);
     }
 
     private function renderEntity(Activity $activity): Response
     {
-        $view = new View($activity, Response::HTTP_OK);
-        $view->getContext()->setGroups($this->getEntitySerializationGroups($activity));
-
-        return $this->viewHandler->handle($view);
+        return $this->renderBudgetAwareView(new View($activity, Response::HTTP_OK), self::GROUPS_ENTITY);
     }
 
     /**
@@ -122,10 +119,8 @@ final class ActivityController extends BaseApiController
         }
 
         $data = $this->repository->getActivitiesForQuery($query);
-        $view = new View($data, 200);
-        $view->getContext()->setGroups(self::GROUPS_COLLECTION);
 
-        return $this->viewHandler->handle($view);
+        return $this->renderBudgetAwareView(new View($data, Response::HTTP_OK), self::GROUPS_COLLECTION);
     }
 
     /**

--- a/src/API/CustomerController.php
+++ b/src/API/CustomerController.php
@@ -9,6 +9,7 @@
 
 namespace App\API;
 
+use App\API\Serializer\BudgetExclusionStrategy;
 use App\Customer\CustomerService;
 use App\Entity\Customer;
 use App\Entity\CustomerComment;
@@ -31,6 +32,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\GoneHttpException;
 use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
 
 #[Route(path: '/customers')]
@@ -48,33 +50,28 @@ final class CustomerController extends BaseApiController
         private readonly CustomerRepository $repository,
         private readonly CustomerRateRepository $customerRateRepository,
         private readonly CustomerService $customerService,
+        private readonly AuthorizationCheckerInterface $security,
     ) {
     }
 
     /**
-     * @return array<string>
+     * The budget groups are always requested, the per-record permission filtering
+     * is applied by the BudgetExclusionStrategy.
+     *
+     * @param array<string> $groups
      */
-    private function getEntitySerializationGroups(Customer $customer): array
+    private function renderBudgetAwareView(View $view, array $groups): Response
     {
-        $groups = self::GROUPS_ENTITY;
+        $context = $view->getContext();
+        $context->setGroups(array_merge($groups, ['Budget_Money', 'Budget_Time']));
+        $context->addExclusionStrategy(new BudgetExclusionStrategy($this->security));
 
-        if ($this->isGranted('budget', $customer)) {
-            $groups = array_merge($groups, ['Budget_Money']);
-        }
-
-        if ($this->isGranted('time', $customer)) {
-            $groups = array_merge($groups, ['Budget_Time']);
-        }
-
-        return $groups;
+        return $this->viewHandler->handle($view);
     }
 
     private function renderEntity(Customer $customer): Response
     {
-        $view = new View($customer, Response::HTTP_OK);
-        $view->getContext()->setGroups($this->getEntitySerializationGroups($customer));
-
-        return $this->viewHandler->handle($view);
+        return $this->renderBudgetAwareView(new View($customer, Response::HTTP_OK), self::GROUPS_ENTITY);
     }
 
     /**
@@ -118,14 +115,13 @@ final class CustomerController extends BaseApiController
 
         $query->setIsApiCall(true);
         $data = $this->repository->getCustomersForQuery($query);
-        $view = new View($data, 200);
-        $view->getContext()->setGroups(self::GROUPS_COLLECTION);
 
+        $groups = self::GROUPS_COLLECTION;
         if ($paramFetcher->get('full') === '1' && $this->isGranted('details_customer')) {
-            $view->getContext()->addGroup('Customer_Details');
+            $groups = array_merge($groups, ['Customer_Details']);
         }
 
-        return $this->viewHandler->handle($view);
+        return $this->renderBudgetAwareView(new View($data, Response::HTTP_OK), $groups);
     }
 
     /**

--- a/src/API/ProjectController.php
+++ b/src/API/ProjectController.php
@@ -9,6 +9,7 @@
 
 namespace App\API;
 
+use App\API\Serializer\BudgetExclusionStrategy;
 use App\Entity\Project;
 use App\Entity\ProjectComment;
 use App\Entity\ProjectRate;
@@ -32,6 +33,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\GoneHttpException;
 use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
 use Symfony\Component\Validator\Constraints;
 
@@ -49,34 +51,29 @@ final class ProjectController extends BaseApiController
         private readonly ViewHandlerInterface $viewHandler,
         private readonly ProjectRepository $repository,
         private readonly ProjectRateRepository $projectRateRepository,
-        private readonly ProjectService $projectService
+        private readonly ProjectService $projectService,
+        private readonly AuthorizationCheckerInterface $security
     ) {
     }
 
     /**
-     * @return array<string>
+     * The budget groups are always requested, the per-record permission filtering
+     * is applied by the BudgetExclusionStrategy.
+     *
+     * @param array<string> $groups
      */
-    private function getEntitySerializationGroups(Project $project): array
+    private function renderBudgetAwareView(View $view, array $groups): Response
     {
-        $groups = self::GROUPS_ENTITY;
+        $context = $view->getContext();
+        $context->setGroups(array_merge($groups, ['Budget_Money', 'Budget_Time']));
+        $context->addExclusionStrategy(new BudgetExclusionStrategy($this->security));
 
-        if ($this->isGranted('budget', $project)) {
-            $groups = array_merge($groups, ['Budget_Money']);
-        }
-
-        if ($this->isGranted('time', $project)) {
-            $groups = array_merge($groups, ['Budget_Time']);
-        }
-
-        return $groups;
+        return $this->viewHandler->handle($view);
     }
 
     private function renderEntity(Project $project): Response
     {
-        $view = new View($project, Response::HTTP_OK);
-        $view->getContext()->setGroups($this->getEntitySerializationGroups($project));
-
-        return $this->viewHandler->handle($view);
+        return $this->renderBudgetAwareView(new View($project, Response::HTTP_OK), self::GROUPS_ENTITY);
     }
 
     /**
@@ -169,10 +166,8 @@ final class ProjectController extends BaseApiController
 
         $query->setIsApiCall(true);
         $data = $this->repository->getProjectsForQuery($query);
-        $view = new View($data, 200);
-        $view->getContext()->setGroups(self::GROUPS_COLLECTION);
 
-        return $this->viewHandler->handle($view);
+        return $this->renderBudgetAwareView(new View($data, Response::HTTP_OK), self::GROUPS_COLLECTION);
     }
 
     /**

--- a/src/API/Serializer/BudgetExclusionStrategy.php
+++ b/src/API/Serializer/BudgetExclusionStrategy.php
@@ -1,0 +1,91 @@
+<?php
+
+/*
+ * This file is part of the Kimai time-tracking app.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\API\Serializer;
+
+use App\Entity\Activity;
+use App\Entity\Customer;
+use App\Entity\Project;
+use JMS\Serializer\Context;
+use JMS\Serializer\Exclusion\ExclusionStrategyInterface;
+use JMS\Serializer\Metadata\ClassMetadata;
+use JMS\Serializer\Metadata\PropertyMetadata;
+use JMS\Serializer\SerializationContext;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
+
+/**
+ * Removes the budget fields from serialized customers, projects and activities,
+ * unless the current user is granted the "budget" (monetary) or "time"
+ * permission for that record.
+ *
+ * The decision is made per record, so a collection can contain records of
+ * multiple teams, each one serialized according to the callers permission.
+ */
+final class BudgetExclusionStrategy implements ExclusionStrategyInterface
+{
+    /**
+     * Field => the permissions revealing it. "budgetType" belongs to both
+     * budget flavors and is serialized if one of the permissions is granted.
+     */
+    private const BUDGET_FIELDS = [
+        'budget' => ['budget'],
+        'timeBudget' => ['time'],
+        'budgetType' => ['budget', 'time'],
+    ];
+
+    private const CLASSES = [Activity::class, Customer::class, Project::class];
+
+    /**
+     * @var \SplObjectStorage<object, array<string, bool>>
+     */
+    private \SplObjectStorage $decisions;
+
+    public function __construct(private readonly AuthorizationCheckerInterface $security)
+    {
+        $this->decisions = new \SplObjectStorage();
+    }
+
+    public function shouldSkipClass(ClassMetadata $metadata, Context $context): bool
+    {
+        return false;
+    }
+
+    public function shouldSkipProperty(PropertyMetadata $property, Context $context): bool
+    {
+        if (!\array_key_exists($property->name, self::BUDGET_FIELDS) || !\in_array($property->class, self::CLASSES, true)) {
+            return false;
+        }
+
+        $object = $context instanceof SerializationContext ? $context->getObject() : null;
+        if (!$object instanceof Activity && !$object instanceof Customer && !$object instanceof Project) {
+            // there is no record to check the permission on: never expose budgets
+            return true;
+        }
+
+        foreach (self::BUDGET_FIELDS[$property->name] as $permission) {
+            if ($this->isGranted($permission, $object)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private function isGranted(string $permission, object $object): bool
+    {
+        $decisions = $this->decisions->offsetExists($object) ? $this->decisions[$object] : [];
+
+        if (!\array_key_exists($permission, $decisions)) {
+            $decisions[$permission] = $this->security->isGranted($permission, $object);
+            $this->decisions[$object] = $decisions;
+        }
+
+        return $decisions[$permission];
+    }
+}

--- a/src/Entity/BudgetTrait.php
+++ b/src/Entity/BudgetTrait.php
@@ -19,32 +19,38 @@ trait BudgetTrait
 {
     /**
      * The total monetary budget (default: 0).
+     *
+     * Optional. Only included if the current user may see the monetary budget of this record (`budget_<object>` and `budget_team<lead>_<object>` permission).
      */
     #[ORM\Column(name: 'budget', type: Types::FLOAT, nullable: false)]
     #[Assert\Range(min: 0.00, max: 900000000000.00)]
     #[Assert\NotNull]
     #[Serializer\Expose]
-    #[Serializer\Groups(['Budget_Money', 'Budgets'])]
+    #[Serializer\Groups(['Budget_Money'])]
     #[Exporter\Expose(label: 'budget', type: 'float', permissions: ['budget'])]
     private float $budget = 0.00;
     /**
      * The time budget in seconds (default: 0).
+     *
+     * Optional. Only included if the current user may see the time budget of this record (`time_<object>` and `time_team<lead>_<object>` permission).
      */
     #[ORM\Column(name: 'time_budget', type: Types::INTEGER, nullable: false)]
     #[Assert\Range(min: 0, max: 2145600000)]
     #[Assert\NotNull]
     #[Serializer\Expose]
-    #[Serializer\Groups(['Budget_Time', 'Budgets'])]
+    #[Serializer\Groups(['Budget_Time'])]
     #[Exporter\Expose(label: 'timeBudget', type: 'duration', permissions: ['time'])]
     private int $timeBudget = 0;
     /**
      * The type of budget:
      *  - null = default / full time
      *  - month = monthly budget
+     *
+     * Optional. Only included if the current user may see the monetary or the time budget of this record.
      */
     #[ORM\Column(name: 'budget_type', type: Types::STRING, length: 10, nullable: true)]
     #[Serializer\Expose]
-    #[Serializer\Groups(['Budget_Money', 'Budget_Time', 'Budgets'])]
+    #[Serializer\Groups(['Budget_Money', 'Budget_Time'])]
     #[Exporter\Expose(label: 'budgetType', permissions: ['time', 'budget'])]
     private ?string $budgetType = null;
 

--- a/tests/API/APIControllerBaseTestCase.php
+++ b/tests/API/APIControllerBaseTestCase.php
@@ -504,6 +504,10 @@ abstract class APIControllerBaseTestCase extends AbstractControllerBaseTestCase
                     'phone' => '@string',
                     'metaFields' => ['result' => 'array', 'type' => 'CustomerMeta'],
                     'teams' => ['result' => 'array', 'type' => 'Team'],
+                    // only visible with the budget/time permission
+                    'budget' => 'float',
+                    'timeBudget' => 'int',
+                    'budgetType' => '@string',
                 ];
 
                 // if a list of customers is loaded
@@ -534,6 +538,10 @@ abstract class APIControllerBaseTestCase extends AbstractControllerBaseTestCase
                     'addressLine3' => '@string',
                     'city' => '@string',
                     'postCode' => '@string',
+                    // only visible with the budget/time permission
+                    'budget' => 'float',
+                    'timeBudget' => 'int',
+                    'budgetType' => '@string',
                 ];
 
                 // if a customer is loaded explicitly
@@ -569,8 +577,8 @@ abstract class APIControllerBaseTestCase extends AbstractControllerBaseTestCase
                     'postCode' => '@string',
                     'invoiceEmail' => '@string',
                     'buyerReference' => '@string',
-                    // only available in the entity itself
                     'address' => '@string', // deprecated, do not expose in collection
+                    // only visible with the budget/time permission
                     'budget' => 'float',
                     'timeBudget' => 'int',
                     'budgetType' => '@string',
@@ -636,6 +644,10 @@ abstract class APIControllerBaseTestCase extends AbstractControllerBaseTestCase
                     'metaFields' => ['result' => 'array', 'type' => 'ProjectMeta'],
                     'teams' => ['result' => 'array', 'type' => 'Team'],
                     'parentTitle' => 'string',
+                    // only visible with the budget/time permission
+                    'budget' => 'float',
+                    'timeBudget' => 'int',
+                    'budgetType' => '@string',
                 ];
 
                 // if a project is explicitly loaded
@@ -658,7 +670,7 @@ abstract class APIControllerBaseTestCase extends AbstractControllerBaseTestCase
                     'metaFields' => ['result' => 'array', 'type' => 'ProjectMeta'],
                     'teams' => ['result' => 'array', 'type' => 'Team'],
                     'parentTitle' => 'string',
-                    // only available in the entity itself
+                    // only visible with the budget/time permission
                     'budget' => 'float',
                     'timeBudget' => 'int',
                     'budgetType' => '@string',
@@ -708,6 +720,10 @@ abstract class APIControllerBaseTestCase extends AbstractControllerBaseTestCase
                     'comment' => '@string',
                     'parentTitle' => '@string',
                     'teams' => ['result' => 'array', 'type' => 'Team'],
+                    // only visible with the budget/time permission
+                    'budget' => 'float',
+                    'timeBudget' => 'int',
+                    'budgetType' => '@string',
                 ];
 
                 // if a activity is explicitly loaded
@@ -725,7 +741,7 @@ abstract class APIControllerBaseTestCase extends AbstractControllerBaseTestCase
                     'comment' => '@string',
                     'parentTitle' => '@string',
                     'teams' => ['result' => 'array', 'type' => 'Team'],
-                    // only available in the entity itself
+                    // only visible with the budget/time permission
                     'budget' => 'float',
                     'timeBudget' => 'int',
                     'budgetType' => '@string',

--- a/tests/API/ActivityControllerTest.php
+++ b/tests/API/ActivityControllerTest.php
@@ -30,6 +30,11 @@ use Symfony\Component\HttpFoundation\Response;
 #[Group('integration')]
 class ActivityControllerTest extends APIControllerBaseTestCase
 {
+    /**
+     * Budget fields are only visible for users with the "budget" / "time" permission
+     */
+    private const BUDGET_FIELDS = ['budget', 'timeBudget', 'budgetType'];
+
     use RateControllerTestTrait;
 
     protected function getRateUrlByRate(RateInterface $rate, bool $isCollection): string
@@ -180,7 +185,7 @@ class ActivityControllerTest extends APIControllerBaseTestCase
             $activity = $result[$i];
             $hasProject = $expected[$i][0];
             self::assertIsArray($activity);
-            self::assertApiResponseTypeStructure('ActivityCollection', $activity);
+            self::assertApiResponseTypeStructure('ActivityCollection', $activity, self::BUDGET_FIELDS);
             if ($hasProject && $projectId !== null) {
                 self::assertEquals($projectId, $activity['project']);
             }
@@ -205,6 +210,42 @@ class ActivityControllerTest extends APIControllerBaseTestCase
         yield ['/api/activities', 1, ['projects' => ['2'], 'visible' => VisibilityInterface::SHOW_HIDDEN], [[true, 2], [false]]];
     }
 
+    /**
+     * Budget fields are part of the collection for users with the "budget" and
+     * "time" permission, they were missing completely before 2.66.
+     */
+    public function testGetCollectionIncludesBudgetsWithPermission(): void
+    {
+        $client = $this->getClientForAuthenticatedUser(User::ROLE_ADMIN);
+        $em = $this->getEntityManager();
+
+        $activity = (new Activity())->setName('with budgets');
+        $activity->setBudget(1234.56);
+        $activity->setTimeBudget(3600);
+        $activity->setBudgetType('month');
+        $em->persist($activity);
+        $em->flush();
+
+        $this->assertAccessIsGranted($client, '/api/activities', 'GET', ['globals' => 'true']);
+        $content = $client->getResponse()->getContent();
+        self::assertIsString($content);
+        $result = json_decode($content, true);
+
+        self::assertIsArray($result);
+        $found = false;
+        foreach ($result as $row) {
+            self::assertIsArray($row);
+            self::assertApiResponseTypeStructure('ActivityCollection', $row);
+            if ($row['id'] === $activity->getId()) {
+                $found = true;
+                self::assertEquals(1234.56, $row['budget']);
+                self::assertEquals(3600, $row['timeBudget']);
+                self::assertEquals('month', $row['budgetType']);
+            }
+        }
+        self::assertTrue($found);
+    }
+
     public function testGetCollectionWithQuery(): void
     {
         $client = $this->getClientForAuthenticatedUser(User::ROLE_USER);
@@ -222,20 +263,20 @@ class ActivityControllerTest extends APIControllerBaseTestCase
         self::assertEquals(5, \count($result));
 
         self::assertIsArray($result[0]);
-        self::assertApiResponseTypeStructure('ActivityCollection', $result[0]);
+        self::assertApiResponseTypeStructure('ActivityCollection', $result[0], self::BUDGET_FIELDS);
 
         self::assertIsArray($result[2]);
-        self::assertApiResponseTypeStructure('ActivityCollection', $result[2]);
+        self::assertApiResponseTypeStructure('ActivityCollection', $result[2], self::BUDGET_FIELDS);
         self::assertArrayHasKey('project', $result[2]);
         self::assertEquals($imports[1]->getId(), $result[2]['project']);
 
         self::assertIsArray($result[3]);
-        self::assertApiResponseTypeStructure('ActivityCollection', $result[3]);
+        self::assertApiResponseTypeStructure('ActivityCollection', $result[3], self::BUDGET_FIELDS);
         self::assertArrayHasKey('project', $result[3]);
         self::assertEquals($imports[1]->getId(), $result[3]['project']);
 
         self::assertIsArray($result[4]);
-        self::assertApiResponseTypeStructure('ActivityCollection', $result[4]);
+        self::assertApiResponseTypeStructure('ActivityCollection', $result[4], self::BUDGET_FIELDS);
         self::assertArrayHasKey('project', $result[4]);
         self::assertEquals($imports[0]->getId(), $result[4]['project']);
     }

--- a/tests/API/CustomerControllerTest.php
+++ b/tests/API/CustomerControllerTest.php
@@ -30,6 +30,11 @@ use Symfony\Component\HttpFoundation\Response;
 #[Group('integration')]
 class CustomerControllerTest extends APIControllerBaseTestCase
 {
+    /**
+     * Budget fields are only visible for users with the "budget" / "time" permission
+     */
+    private const BUDGET_FIELDS = ['budget', 'timeBudget', 'budgetType'];
+
     use RateControllerTestTrait;
 
     protected function getRateUrlByRate(RateInterface $rate, bool $isCollection): string
@@ -146,7 +151,7 @@ class CustomerControllerTest extends APIControllerBaseTestCase
         self::assertNotEmpty($result);
         self::assertEquals(1, \count($result));
         self::assertIsArray($result[0]);
-        self::assertApiResponseTypeStructure('CustomerCollection', $result[0]);
+        self::assertApiResponseTypeStructure('CustomerCollection', $result[0], self::BUDGET_FIELDS);
     }
 
     public function testGetCollectionFull(): void
@@ -179,7 +184,7 @@ class CustomerControllerTest extends APIControllerBaseTestCase
         self::assertEquals(1, \count($result));
         self::assertIsArray($result[0]);
         // make sure that regular user cannot access detail fields
-        self::assertApiResponseTypeStructure('CustomerCollection', $result[0]);
+        self::assertApiResponseTypeStructure('CustomerCollection', $result[0], self::BUDGET_FIELDS);
     }
 
     public function testGetCollectionWithQuery(): void
@@ -196,7 +201,7 @@ class CustomerControllerTest extends APIControllerBaseTestCase
         self::assertNotEmpty($result);
         self::assertEquals(1, \count($result));
         self::assertIsArray($result[0]);
-        self::assertApiResponseTypeStructure('CustomerCollection', $result[0]);
+        self::assertApiResponseTypeStructure('CustomerCollection', $result[0], self::BUDGET_FIELDS);
     }
 
     public function testGetEntityIsSecure(): void

--- a/tests/API/ProjectControllerTest.php
+++ b/tests/API/ProjectControllerTest.php
@@ -31,6 +31,11 @@ use Symfony\Component\HttpFoundation\Response;
 #[Group('integration')]
 class ProjectControllerTest extends APIControllerBaseTestCase
 {
+    /**
+     * Budget fields are only visible for users with the "budget" / "time" permission
+     */
+    private const BUDGET_FIELDS = ['budget', 'timeBudget', 'budgetType'];
+
     use RateControllerTestTrait;
 
     protected function getRateUrlByRate(RateInterface $rate, bool $isCollection): string
@@ -95,6 +100,49 @@ class ProjectControllerTest extends APIControllerBaseTestCase
         $this->assertUrlIsSecured('/api/projects');
     }
 
+    /**
+     * Budget fields are part of the collection for users with the "budget" and
+     * "time" permission, they were missing completely before 2.66.
+     */
+    public function testGetCollectionIncludesBudgetsWithPermission(): void
+    {
+        $client = $this->getClientForAuthenticatedUser(User::ROLE_ADMIN);
+        $em = $this->getEntityManager();
+
+        $customer = new Customer('budget customer');
+        $customer->setCountry('DE');
+        $customer->setTimezone('Europe/Berlin');
+        $em->persist($customer);
+
+        $project = new Project();
+        $project->setName('with budgets');
+        $project->setCustomer($customer);
+        $project->setBudget(1234.56);
+        $project->setTimeBudget(3600);
+        $project->setBudgetType('month');
+        $em->persist($project);
+        $em->flush();
+
+        $this->assertAccessIsGranted($client, '/api/projects');
+        $content = $client->getResponse()->getContent();
+        self::assertIsString($content);
+        $result = json_decode($content, true);
+
+        self::assertIsArray($result);
+        $found = false;
+        foreach ($result as $row) {
+            self::assertIsArray($row);
+            self::assertApiResponseTypeStructure('ProjectCollection', $row);
+            if ($row['id'] === $project->getId()) {
+                $found = true;
+                self::assertEquals(1234.56, $row['budget']);
+                self::assertEquals(3600, $row['timeBudget']);
+                self::assertEquals('month', $row['budgetType']);
+            }
+        }
+        self::assertTrue($found);
+    }
+
     public function testGetCollection(): void
     {
         $client = $this->getClientForAuthenticatedUser(User::ROLE_USER);
@@ -108,7 +156,7 @@ class ProjectControllerTest extends APIControllerBaseTestCase
         self::assertNotEmpty($result);
         self::assertEquals(1, \count($result));
         self::assertIsArray($result[0]);
-        self::assertApiResponseTypeStructure('ProjectCollection', $result[0]);
+        self::assertApiResponseTypeStructure('ProjectCollection', $result[0], self::BUDGET_FIELDS);
     }
 
     /**
@@ -228,10 +276,16 @@ class ProjectControllerTest extends APIControllerBaseTestCase
         self::assertIsArray($result);
         self::assertEquals(\count($expected), \count($result), 'Found wrong amount of projects');
 
+        // the fixture team of the current user covers this customer, so the
+        // "time_team_project" permission of a ROLE_USER reveals the time budget
+        // fields of its projects - but never the monetary budget
+        $teamCustomerId = $imports[4]->getCustomer()?->getId();
+
         for ($i = 0; $i < \count($expected); $i++) {
             $project = $result[$i];
             self::assertIsArray($project);
-            self::assertApiResponseTypeStructure('ProjectCollection', $project);
+            $removeFields = $project['customer'] === $teamCustomerId ? ['budget'] : self::BUDGET_FIELDS;
+            self::assertApiResponseTypeStructure('ProjectCollection', $project, $removeFields);
             if ($customerId !== null) {
                 self::assertEquals($customerId, $project['customer']);
             }

--- a/tests/API/Serializer/BudgetExclusionStrategyTest.php
+++ b/tests/API/Serializer/BudgetExclusionStrategyTest.php
@@ -1,0 +1,167 @@
+<?php
+
+/*
+ * This file is part of the Kimai time-tracking app.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Tests\API\Serializer;
+
+use App\API\Serializer\BudgetExclusionStrategy;
+use App\Entity\Activity;
+use App\Entity\Customer;
+use App\Entity\Project;
+use App\Entity\Timesheet;
+use JMS\Serializer\DeserializationContext;
+use JMS\Serializer\Metadata\ClassMetadata;
+use JMS\Serializer\Metadata\PropertyMetadata;
+use JMS\Serializer\SerializationContext;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
+
+#[CoversClass(BudgetExclusionStrategy::class)]
+class BudgetExclusionStrategyTest extends TestCase
+{
+    private const BUDGET_FIELDS = ['budget', 'timeBudget', 'budgetType'];
+
+    /**
+     * @return SerializationContext&\PHPUnit\Framework\MockObject\MockObject
+     */
+    private function createContext(?object $object)
+    {
+        $context = $this->createMock(SerializationContext::class);
+        $context->method('getObject')->willReturn($object);
+
+        return $context;
+    }
+
+    public function testShouldNeverSkipAClass(): void
+    {
+        $security = $this->createMock(AuthorizationCheckerInterface::class);
+        $security->expects(self::never())->method('isGranted');
+
+        $sut = new BudgetExclusionStrategy($security);
+
+        self::assertFalse($sut->shouldSkipClass(new ClassMetadata(Project::class), $this->createContext(new Project())));
+    }
+
+    public function testShouldNeverSkipPropertiesOfOtherClasses(): void
+    {
+        $security = $this->createMock(AuthorizationCheckerInterface::class);
+        $security->expects(self::never())->method('isGranted');
+
+        $sut = new BudgetExclusionStrategy($security);
+        $context = $this->createContext(new Timesheet());
+
+        // "rate" is not a budget field and Timesheet does not use the BudgetTrait
+        self::assertFalse($sut->shouldSkipProperty(new PropertyMetadata(Timesheet::class, 'rate'), $context));
+    }
+
+    public function testShouldNeverSkipOtherProperties(): void
+    {
+        $security = $this->createMock(AuthorizationCheckerInterface::class);
+        $security->expects(self::never())->method('isGranted');
+
+        $sut = new BudgetExclusionStrategy($security);
+
+        self::assertFalse($sut->shouldSkipProperty(new PropertyMetadata(Activity::class, 'name'), $this->createContext(new Activity())));
+        self::assertFalse($sut->shouldSkipProperty(new PropertyMetadata(Customer::class, 'name'), $this->createContext(new Customer('testing'))));
+        self::assertFalse($sut->shouldSkipProperty(new PropertyMetadata(Project::class, 'name'), $this->createContext(new Project())));
+    }
+
+    public function testSkipsBudgetFieldsWithoutPermission(): void
+    {
+        $project = new Project();
+
+        $security = $this->createMock(AuthorizationCheckerInterface::class);
+        // one voter call per permission, cached per record: "budget" for the budget
+        // field, "time" for the time budget and both for the shared budget type
+        $security->expects(self::exactly(2))->method('isGranted')->willReturn(false);
+
+        $sut = new BudgetExclusionStrategy($security);
+        $context = $this->createContext($project);
+
+        foreach (self::BUDGET_FIELDS as $field) {
+            self::assertTrue($sut->shouldSkipProperty(new PropertyMetadata(Project::class, $field), $context));
+        }
+    }
+
+    public function testSerializesBudgetFieldsWithPermission(): void
+    {
+        $customer = new Customer('testing');
+
+        $security = $this->createMock(AuthorizationCheckerInterface::class);
+        $security->expects(self::exactly(2))->method('isGranted')->willReturnCallback(
+            function (string $permission, Customer $subject) use ($customer): bool {
+                self::assertSame($customer, $subject);
+                self::assertContains($permission, ['budget', 'time']);
+
+                return true;
+            }
+        );
+
+        $sut = new BudgetExclusionStrategy($security);
+        $context = $this->createContext($customer);
+
+        foreach (self::BUDGET_FIELDS as $field) {
+            self::assertFalse($sut->shouldSkipProperty(new PropertyMetadata(Customer::class, $field), $context));
+        }
+    }
+
+    public function testBudgetTypeIsSerializedWithOnlyOnePermission(): void
+    {
+        $activity = new Activity();
+
+        $security = $this->createMock(AuthorizationCheckerInterface::class);
+        $security->method('isGranted')->willReturnCallback(
+            function (string $permission): bool {
+                // "time" is granted, "budget" is not
+                return $permission === 'time';
+            }
+        );
+
+        $sut = new BudgetExclusionStrategy($security);
+        $context = $this->createContext($activity);
+
+        self::assertTrue($sut->shouldSkipProperty(new PropertyMetadata(Activity::class, 'budget'), $context));
+        self::assertFalse($sut->shouldSkipProperty(new PropertyMetadata(Activity::class, 'timeBudget'), $context));
+        self::assertFalse($sut->shouldSkipProperty(new PropertyMetadata(Activity::class, 'budgetType'), $context));
+    }
+
+    public function testDecidesPerRecord(): void
+    {
+        $mine = new Project();
+        $foreign = new Project();
+
+        $security = $this->createMock(AuthorizationCheckerInterface::class);
+        $security->method('isGranted')->willReturnCallback(
+            function (string $permission, Project $project) use ($mine): bool {
+                return $project === $mine;
+            }
+        );
+
+        $sut = new BudgetExclusionStrategy($security);
+        $property = new PropertyMetadata(Project::class, 'budget');
+
+        self::assertFalse($sut->shouldSkipProperty($property, $this->createContext($mine)));
+        self::assertTrue($sut->shouldSkipProperty($property, $this->createContext($foreign)));
+    }
+
+    public function testSkipsBudgetFieldsWithoutRecordToCheckPermissionsOn(): void
+    {
+        $security = $this->createMock(AuthorizationCheckerInterface::class);
+        $security->expects(self::never())->method('isGranted');
+
+        $sut = new BudgetExclusionStrategy($security);
+
+        // no object is being visited
+        self::assertTrue($sut->shouldSkipProperty(new PropertyMetadata(Project::class, 'budget'), $this->createContext(null)));
+
+        // not a serialization context
+        $deserialization = $this->createMock(DeserializationContext::class);
+        self::assertTrue($sut->shouldSkipProperty(new PropertyMetadata(Project::class, 'budget'), $deserialization));
+    }
+}


### PR DESCRIPTION
## Description

- Adds the `budget`, `timeBudget` and `budgetType` to the collection endpoints of customer, project and activity
- Switch to using an `ExclusionStrategy` instead of serialization groups

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] I verified that my code applies to the guidelines (`composer code-check`)
- [x] I updated the documentation (see [here](https://github.com/kimai/www.kimai.org/tree/master/_documentation))
- [x] I agree that this code is used in Kimai (see [license](https://github.com/kimai/kimai/blob/main/LICENSE))
