### PR TITLE
New API endpoint to delete invoices

### DIFF
--- a/src/API/InvoiceController.php
+++ b/src/API/InvoiceController.php
@@ -186,4 +186,20 @@ final class InvoiceController extends BaseApiController
 
         return $this->file($file->getRealPath(), $file->getBasename());
     }
+
+    /**
+     * Delete invoice
+     */
+    #[IsGranted('delete_invoice', 'invoice')]
+    #[OA\Delete(description: 'Deletes the invoice and its generated document.', responses: [new OA\Response(response: 204, description: 'Empty')])]
+    #[OA\Parameter(name: 'id', description: 'Invoice ID to delete', in: 'path', required: true)]
+    #[Route(path: '/{id}', name: 'delete_invoice', requirements: ['id' => '\d+'], methods: ['DELETE'])]
+    public function deleteInvoice(Invoice $invoice, InvoiceService $service): Response
+    {
+        $service->deleteInvoice($invoice);
+
+        $view = new View(null, Response::HTTP_NO_CONTENT);
+
+        return $this->viewHandler->handle($view);
+    }
 }

--- a/src/Controller/InvoiceController.php
+++ b/src/Controller/InvoiceController.php
@@ -274,28 +274,6 @@ final class InvoiceController extends AbstractController
         ]);
     }
 
-    #[Route(path: '/delete/{id}/{token}', name: 'admin_invoice_delete', methods: ['GET'])]
-    #[IsGranted('delete_invoice', 'invoice')]
-    public function deleteInvoiceAction(Invoice $invoice, string $token, CsrfTokenManagerInterface $csrfTokenManager, InvoiceService $service): Response
-    {
-        if (!$csrfTokenManager->isTokenValid(new CsrfToken('invoice.status', $token))) {
-            $this->flashError('action.csrf.error');
-
-            return $this->redirectToRoute('admin_invoice_list');
-        }
-
-        $csrfTokenManager->refreshToken('invoice.status');
-
-        try {
-            $service->deleteInvoice($invoice, $this->dispatcher);
-            $this->flashSuccess('action.delete.success');
-        } catch (Exception $ex) {
-            $this->flashDeleteException($ex);
-        }
-
-        return $this->redirectToRoute('admin_invoice_list');
-    }
-
     #[Route(path: '/download/{id}', name: 'admin_invoice_download', methods: ['GET'])]
     #[IsGranted('view_invoice', 'invoice')]
     public function downloadAction(Invoice $invoice, InvoiceService $service): Response

--- a/src/Controller/InvoiceController.php
+++ b/src/Controller/InvoiceController.php
@@ -169,16 +169,19 @@ final class InvoiceController extends AbstractController
         return $this->redirectToRoute('invoice');
     }
 
-    #[Route(path: '/save-invoice/{customer}/{token}', name: 'invoice_create', methods: ['GET'])]
+    #[Route(path: '/save-invoice/{customer}', name: 'invoice_create', methods: ['POST'])]
     #[IsGranted('create_invoice')]
     #[IsGranted('access', 'customer')]
-    public function createInvoiceAction(Customer $customer, string $token, Request $request, CustomerRepository $customerRepository, InvoiceService $service): Response
+    public function createInvoiceAction(Customer $customer, Request $request, CustomerRepository $customerRepository, InvoiceService $service): Response
     {
-        if (!$this->isCsrfTokenValid('invoice.create', $token)) {
+        if (!$this->isCsrfTokenValid('invoice.create', $this->getRequestToken($request))) {
             $this->flashError('action.csrf.error');
 
             return $this->redirectToRoute('invoice');
         }
+
+        // prevezt the token from becoming part of the search query
+        $request->request->remove('_token');
 
         $query = $this->getDefaultQuery();
         $query->setAllowTemplateOverwrite(false);
@@ -213,30 +216,36 @@ final class InvoiceController extends AbstractController
         return $this->redirectToRoute('invoice');
     }
 
-    #[Route(path: '/change-status/{id}/{status}/{token}', name: 'admin_invoice_status', methods: ['GET', 'POST'])]
+    /**
+     * Renders the invoice form with a pre-filled payment date, the record itself is
+     * saved by the form (see admin_invoice_edit) and not by this route.
+     */
+    #[Route(path: '/mark-paid/{id}', name: 'admin_invoice_paid', methods: ['GET'])]
     #[IsGranted('edit_invoice', 'invoice')]
-    public function changeStatusAction(Invoice $invoice, string $status, string $token, Request $request, CsrfTokenManagerInterface $csrfTokenManager, InvoiceService $InvoiceService): Response
+    public function markPaidAction(Invoice $invoice, InvoiceService $invoiceService): Response
     {
-        if (!$csrfTokenManager->isTokenValid(new CsrfToken('invoice.status', $token))) {
+        if (null === $invoice->getPaymentDate()) {
+            $invoice->setPaymentDate($this->getDateTimeFactory()->createDateTime());
+            $invoice->setIsPaid();
+        }
+
+        $form = $this->createInvoiceEditForm($invoice, $invoiceService);
+
+        return $this->render('invoice/invoice_edit.html.twig', [
+            'page_setup' => $this->createPageSetup(),
+            'invoice' => $invoice,
+            'form' => $form->createView()
+        ]);
+    }
+
+    #[Route(path: '/change-status/{id}/{status}', name: 'admin_invoice_status', methods: ['POST'])]
+    #[IsGranted('edit_invoice', 'invoice')]
+    public function changeStatusAction(Invoice $invoice, string $status, Request $request, CsrfTokenManagerInterface $csrfTokenManager, InvoiceService $InvoiceService): Response
+    {
+        if (!$csrfTokenManager->isTokenValid(new CsrfToken('invoice.status', $this->getRequestToken($request)))) {
             $this->flashError('action.csrf.error');
 
             return $this->redirectToRoute('admin_invoice_list');
-        }
-
-        if ($status === Invoice::STATUS_PAID) {
-            if (null === $invoice->getPaymentDate()) {
-                $invoice->setPaymentDate($this->getDateTimeFactory()->createDateTime());
-                $invoice->setIsPaid();
-            }
-
-            $form = $this->createInvoiceEditForm($invoice, $InvoiceService);
-            $form->handleRequest($request);
-
-            return $this->render('invoice/invoice_edit.html.twig', [
-                'page_setup' => $this->createPageSetup(),
-                'invoice' => $invoice,
-                'form' => $form->createView()
-            ]);
         }
 
         try {
@@ -764,6 +773,16 @@ final class InvoiceController extends AbstractController
         $this->dispatcher->dispatch($event);
 
         return $event->getFields();
+    }
+
+    /**
+     * CSRF tokens for state-changing routes are transported in the request body.
+     */
+    private function getRequestToken(Request $request): ?string
+    {
+        $token = $request->request->get('_token');
+
+        return \is_string($token) ? $token : null;
     }
 
     private function createInvoiceEditForm(Invoice $invoice, InvoiceService $InvoiceService): FormInterface

--- a/src/Event/PageActionsEvent.php
+++ b/src/Event/PageActionsEvent.php
@@ -188,10 +188,23 @@ class PageActionsEvent extends ThemeEvent
         $this->addAction('settings', ['url' => $url, 'title' => 'settings']);
     }
 
-    public function addDelete(string $url, bool $remoteConfirm = true): void
+    public function addDelete(string $url, bool $remoteConfirm = true, ?string $apiEvent = null): void
     {
         if ($remoteConfirm) {
             $this->addAction('trash', ['url' => $url, 'class' => 'modal-ajax-form text-red', 'title' => 'trash']);
+        } elseif ($apiEvent !== null) {
+            $this->addAction('trash', [
+                'url' => $url,
+                'class' => 'api-link text-red',
+                'attr' => [
+                    'data-event' => $apiEvent,
+                    'data-method' => 'DELETE',
+                    'data-question' => 'confirm.delete',
+                    'data-msg-error' => 'action.delete.error',
+                    'data-msg-success' => 'action.delete.success'
+                ],
+                'title' => 'trash'
+            ]);
         } else {
             $this->addAction('trash', ['url' => $url, 'class' => 'confirmation-link text-red', 'attr' => ['data-question' => 'confirm.delete'], 'title' => 'trash']);
         }

--- a/src/EventSubscriber/Actions/InvoiceSubscriber.php
+++ b/src/EventSubscriber/Actions/InvoiceSubscriber.php
@@ -19,6 +19,22 @@ final class InvoiceSubscriber extends AbstractActionsSubscriber
         return 'invoice';
     }
 
+    /**
+     * Status changes are POST requests, whose CSRF token is submitted in the request body.
+     *
+     * @return array<string, mixed>
+     */
+    private function createStatusAction(Invoice $invoice, string $status): array
+    {
+        return [
+            'url' => '#',
+            'onclick' => 'return kimaiInvoiceStatus(this)',
+            'attr' => [
+                'data-href' => $this->path('admin_invoice_status', ['id' => $invoice->getId(), 'status' => $status]),
+            ],
+        ];
+    }
+
     public function onActions(PageActionsEvent $event): void
     {
         $payload = $event->getPayload();
@@ -47,16 +63,15 @@ final class InvoiceSubscriber extends AbstractActionsSubscriber
 
         if ($allowCreate) {
             if (!$invoice->isPending()) {
-                $event->addAction('invoice.pending', ['url' => $this->path('admin_invoice_status', ['id' => $invoice->getId(), 'status' => 'pending', 'token' => $payload['token']])]);
+                $event->addAction('invoice.pending', $this->createStatusAction($invoice, 'pending'));
             } else {
-                $event->addAction('invoice.paid', ['url' => $this->path('admin_invoice_status', ['id' => $invoice->getId(), 'status' => 'paid', 'token' => $payload['token']]), 'class' => 'modal-ajax-form']);
+                $event->addAction('invoice.paid', ['url' => $this->path('admin_invoice_paid', ['id' => $invoice->getId()]), 'class' => 'modal-ajax-form']);
             }
         }
 
         $allowDelete = $this->isGranted('delete_invoice');
         if (!$invoice->isCanceled()) {
-            $id = $allowDelete ? 'invoice.cancel' : 'trash';
-            $event->addAction($id, ['url' => $this->path('admin_invoice_status', ['id' => $invoice->getId(), 'status' => 'canceled', 'token' => $payload['token']]), 'title' => 'invoice.cancel']);
+            $event->addAction('invoice.cancel', $this->createStatusAction($invoice, 'canceled'));
         }
 
         if ($allowDelete) {

--- a/src/EventSubscriber/Actions/InvoiceSubscriber.php
+++ b/src/EventSubscriber/Actions/InvoiceSubscriber.php
@@ -59,9 +59,9 @@ final class InvoiceSubscriber extends AbstractActionsSubscriber
             $event->addAction($id, ['url' => $this->path('admin_invoice_status', ['id' => $invoice->getId(), 'status' => 'canceled', 'token' => $payload['token']]), 'title' => 'invoice.cancel']);
         }
 
-        if ($this->isGranted('delete_invoice')) {
+        if ($allowDelete) {
             $event->addDivider();
-            $event->addDelete($this->path('admin_invoice_delete', ['id' => $invoice->getId(), 'token' => $payload['token']]), false);
+            $event->addDelete($this->path('delete_invoice', ['id' => $invoice->getId()]), false, 'kimai.invoiceUpdate');
         }
     }
 }

--- a/src/Invoice/InvoiceService.php
+++ b/src/Invoice/InvoiceService.php
@@ -365,7 +365,7 @@ class InvoiceService
         );
     }
 
-    public function deleteInvoice(Invoice $invoice, EventDispatcherInterface $dispatcher): void
+    public function deleteInvoice(Invoice $invoice): void
     {
         $invoiceDirectory = $this->getInvoicesDirectory();
 
@@ -374,7 +374,7 @@ class InvoiceService
         }
 
         $event = new InvoiceDeleteEvent($invoice);
-        $dispatcher->dispatch($event);
+        $this->dispatcher->dispatch($event);
 
         $this->invoiceRepository->deleteInvoice($invoice);
     }

--- a/templates/invoice/actions.html.twig
+++ b/templates/invoice/actions.html.twig
@@ -1,7 +1,7 @@
 
 {% macro invoice(invoice, view) %}
     {% import "macros/widgets.html.twig" as widgets %}
-    {% set event = actions(app.user, 'invoice', view, {'invoice': invoice, 'token': csrf_token('invoice.status')}) %}
+    {% set event = actions(app.user, 'invoice', view, {'invoice': invoice}) %}
     {{ widgets.table_actions(event.actions) }}
 {% endmacro %}
 

--- a/templates/invoice/index.html.twig
+++ b/templates/invoice/index.html.twig
@@ -136,7 +136,7 @@
                                 <td class="w-min text-center actions alwaysVisible">
                                     {% for attrs in [{'class': 'd-inline-flex d-md-none'}, {'icon': false, 'class': 'd-none d-md-inline-flex'}] %}
                                     {{ widgets.action_button('print', {'url': '#', 'onclick': 'return singleInvoice(this, true)', 'title': 'preview'|trans, 'target': '_blank', 'attr': {'data-customer': model.customer.id, 'data-href': path('invoice_preview', {'customer': model.customer.id, 'token': csrf_token('invoice.preview')})}}|merge(attrs)) }}
-                                    {{ widgets.action_button('invoice', {'url': '#', 'onclick': 'return singleInvoice(this, false)', 'title': 'action.save'|trans, 'attr': {'data-customer': model.customer.id, 'data-href': path('invoice_create', {'customer': model.customer.id, 'token': csrf_token('invoice.create')})}}|merge(attrs), 'primary') }}
+                                    {{ widgets.action_button('invoice', {'url': '#', 'onclick': 'return singleInvoice(this, false)', 'title': 'action.save'|trans, 'attr': {'data-customer': model.customer.id, 'data-href': path('invoice_create', {'customer': model.customer.id})}}|merge(attrs), 'primary') }}
                                     {% endfor %}
                                 </td>
                             </tr>
@@ -230,17 +230,33 @@
             const formPlugin = kimai.getPlugin('form');
             const overwrites = {'customers[]': link.dataset['customer'], 'template': template, 'invoiceDate': date};
             const uri = formPlugin.convertFormDataToQueryString(document.getElementById('{{ formId }}'), overwrites);
-            const invoiceUrl = link.dataset['href'] + '?' + uri;
 
             if (!preview) {
                 link.classList.toggle('disabled');
                 link.href = 'javascript: void(0)';
 
-                document.location = invoiceUrl;
+                const form = document.createElement('form');
+                form.method = 'post';
+                form.action = link.dataset['href'];
+
+                const params = new URLSearchParams(uri);
+                params.append('_token', '{{ csrf_token('invoice.create') }}');
+
+                for (const [name, value] of params) {
+                    const field = document.createElement('input');
+                    field.type = 'hidden';
+                    field.name = name;
+                    field.value = value;
+                    form.appendChild(field);
+                }
+
+                document.body.appendChild(form);
+                form.submit();
+
                 return false;
             }
 
-            link.href = invoiceUrl;
+            link.href = link.dataset['href'] + '?' + uri;
 
             return true;
         }

--- a/templates/invoice/listing.html.twig
+++ b/templates/invoice/listing.html.twig
@@ -32,13 +32,32 @@
 
 {% block javascripts %}
     {{ parent() }}
-    {% if download is not null %}
-    <script type="text/javascript">
+    <div style="display: none" id="status-token" data-value="{{ csrf_token('invoice.status') }}"></div>
+    <script>
+        function kimaiInvoiceStatus(link)
+        {
+            const form = document.createElement('form');
+            form.method = 'post';
+            form.action = link.dataset['href'];
+
+            const token = document.createElement('input');
+            token.type = 'hidden';
+            token.name = '_token';
+            token.value = document.getElementById('status-token').dataset['value'];
+            form.appendChild(token);
+
+            document.body.appendChild(form);
+            form.submit();
+
+            return false;
+        }
+
+        {% if download is not null %}
         document.addEventListener('kimai.initialized', function() {
             location.href = '{{ path('admin_invoice_download', {'id': download.id}) }}';
         });
+        {% endif %}
     </script>
-    {% endif %}
 {% endblock %}
 
 {% macro invoice_status(invoice) %}

--- a/tests/API/InvoiceControllerTest.php
+++ b/tests/API/InvoiceControllerTest.php
@@ -11,11 +11,14 @@ namespace App\Tests\API;
 
 use App\Entity\Customer;
 use App\Entity\Invoice;
+use App\Entity\Role;
+use App\Entity\RolePermission;
 use App\Entity\Team;
 use App\Entity\User;
 use App\Repository\TeamRepository;
 use App\Tests\DataFixtures\InvoiceFixtures;
 use App\Tests\Mocks\InvoiceTestMetaFieldSubscriberMock;
+use App\User\PermissionService;
 use App\Utils\FileHelper;
 use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\EventDispatcher\EventDispatcher;
@@ -352,5 +355,63 @@ class InvoiceControllerTest extends APIControllerBaseTestCase
         $invoice = $em->getRepository(Invoice::class)->find($id);
         self::assertEquals('another,testing,bar', $invoice->getMetaField('metatestmock')?->getValue());
         self::assertEquals(13081978, $invoice->getMetaField('foobar')?->getValue());
+    }
+
+    public function testDeleteIsSecure(): void
+    {
+        $this->assertUrlIsSecured('/api/invoices/1', 'DELETE');
+    }
+
+    public function testDeleteIsSecureForRole(): void
+    {
+        // no default role holds "delete_invoice", not even the super-admin
+        $client = $this->getClientForAuthenticatedUser(User::ROLE_SUPER_ADMIN);
+        $invoices = $this->importInvoiceFixtures(1);
+
+        $this->request($client, '/api/invoices/' . $invoices[0]->getId(), 'DELETE');
+        $this->assertApiResponseAccessDenied($client->getResponse());
+    }
+
+    public function testDeleteNotFound(): void
+    {
+        $client = $this->getClientForAuthenticatedUser(User::ROLE_SUPER_ADMIN);
+        $this->assertNotFoundForDelete($client, '/api/invoices/' . PHP_INT_MAX);
+    }
+
+    public function testDelete(): void
+    {
+        $client = $this->getClientForAuthenticatedUser(User::ROLE_SUPER_ADMIN);
+        $this->grantDeleteInvoicePermission();
+        $invoices = $this->importInvoiceFixtures(1);
+        $id = $invoices[0]->getId();
+        self::assertIsInt($id);
+
+        $this->request($client, '/api/invoices/' . $id, 'DELETE');
+
+        self::assertTrue($client->getResponse()->isSuccessful());
+        self::assertEquals(Response::HTTP_NO_CONTENT, $client->getResponse()->getStatusCode());
+        self::assertEmpty($client->getResponse()->getContent());
+
+        $em = $this->getEntityManager();
+        $em->clear();
+        self::assertNull($em->getRepository(Invoice::class)->find($id));
+    }
+
+    /**
+     * The "delete_invoice" permission is not part of any default role.
+     */
+    private function grantDeleteInvoicePermission(): void
+    {
+        $em = $this->getEntityManager();
+
+        $role = (new Role())->setName(User::ROLE_SUPER_ADMIN);
+        $em->persist($role);
+        $em->flush();
+
+        $permissionService = self::getContainer()->get(PermissionService::class);
+        self::assertInstanceOf(PermissionService::class, $permissionService);
+        $permissionService->saveRolePermission(
+            (new RolePermission())->setRole($role)->setPermission('delete_invoice')->setAllowed(true)
+        );
     }
 }

--- a/tests/Controller/InvoiceControllerTest.php
+++ b/tests/Controller/InvoiceControllerTest.php
@@ -11,12 +11,17 @@ namespace App\Tests\Controller;
 
 use App\Entity\Invoice;
 use App\Entity\InvoiceTemplate;
+use App\Entity\Role;
+use App\Entity\RolePermission;
 use App\Entity\Timesheet;
 use App\Entity\User;
+use App\Tests\DataFixtures\InvoiceFixtures;
 use App\Tests\DataFixtures\InvoiceTemplateFixtures;
 use App\Tests\DataFixtures\TimesheetFixtures;
+use App\User\PermissionService;
 use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
+use Symfony\Component\HttpFoundation\Response;
 
 #[Group('integration')]
 class InvoiceControllerTest extends AbstractControllerBaseTestCase
@@ -200,9 +205,11 @@ class InvoiceControllerTest extends AbstractControllerBaseTestCase
         ];
 
         $token = $client->getCrawler()->filter('div#create-token')->attr('data-value');
+        self::assertIsString($token);
 
-        $action = '/invoice/save-invoice/1/' . $token . '?' . http_build_query($urlParams);
-        $this->request($client, $action);
+        $urlParams['_token'] = $token;
+
+        $client->request('POST', $this->createUrl('/invoice/save-invoice/1'), $urlParams);
         $this->assertIsRedirect($client, '/invoice/show?id=', false);
         $client->followRedirect();
         self::assertTrue($client->getResponse()->isSuccessful());
@@ -315,15 +322,17 @@ class InvoiceControllerTest extends AbstractControllerBaseTestCase
         $this->assertDataTableRowCount($client, 'datatable_invoice_create', 20);
 
         $token = $client->getCrawler()->filter('div#create-token')->attr('data-value');
+        self::assertIsString($token);
 
         $form = $client->getCrawler()->filter('#invoice-print-form')->form();
         $node = $form->getFormNode();
-        $node->setAttribute('action', $this->createUrl('/invoice/save-invoice/1/' . $token));
-        $node->setAttribute('method', 'GET');
+        $node->setAttribute('action', $this->createUrl('/invoice/save-invoice/1'));
+        $node->setAttribute('method', 'POST');
         $client->submit($form, [
             'template' => $template->getId(),
             'daterange' => $dateRange,
             'projects' => [1],
+            '_token' => $token,
         ]);
 
         $this->assertIsRedirect($client, '/invoice/show?id=', false);
@@ -349,8 +358,14 @@ class InvoiceControllerTest extends AbstractControllerBaseTestCase
         $this->request($client, '/invoice/show');
         self::assertTrue($client->getResponse()->isSuccessful());
         $link = $client->getCrawler()->selectLink('Waiting for payment');
+        $statusUrl = $link->attr('data-href');
+        self::assertIsString($statusUrl);
+        // the status change is a POST and the token is never part of the URL
+        self::assertEquals('#', $link->attr('href'));
 
-        $this->request($client, $link->attr('href'));
+        $statusToken = $client->getCrawler()->filter('div#status-token')->attr('data-value');
+        self::assertIsString($statusToken);
+        $client->request('POST', $statusUrl, ['_token' => $statusToken]);
         $this->assertIsRedirect($client, '/invoice/show');
         $client->followRedirect();
         self::assertTrue($client->getResponse()->isSuccessful());
@@ -385,11 +400,137 @@ class InvoiceControllerTest extends AbstractControllerBaseTestCase
         $client->followRedirect();
         self::assertTrue($client->getResponse()->isSuccessful());
 
-        $token = $this->getCsrfToken($client, 'invoice.status');
-        $this->request($client, '/invoice/change-status/' . $id . '/new/' . $token->getValue());
+        $statusToken = $client->getCrawler()->filter('div#status-token')->attr('data-value');
+        self::assertIsString($statusToken);
+        $client->request('POST', $this->createUrl('/invoice/change-status/' . $id . '/new'), ['_token' => $statusToken]);
         $this->assertIsRedirect($client, '/invoice/show');
         $client->followRedirect();
         self::assertTrue($client->getResponse()->isSuccessful());
+    }
+
+    /**
+     * Regression tests for GHSA-4xmp-xqv9-pcrf.
+     *
+     * Creating an invoice is a state-changing operation: it must not be reachable via
+     * GET and the CSRF token must be sent in the request body, never in the URL.
+     */
+    public function testCreateInvoiceIsNotReachableWithGet(): void
+    {
+        $client = $this->getClientForAuthenticatedUser(User::ROLE_TEAMLEAD);
+
+        $this->request($client, '/invoice/save-invoice/1');
+        self::assertEquals(Response::HTTP_METHOD_NOT_ALLOWED, $client->getResponse()->getStatusCode());
+    }
+
+    public function testCreateInvoiceRequiresValidToken(): void
+    {
+        $client = $this->getClientForAuthenticatedUser(User::ROLE_TEAMLEAD);
+
+        $client->request('POST', $this->createUrl('/invoice/save-invoice/1'), ['_token' => 'not-a-valid-token']);
+
+        $this->assertIsRedirect($client, '/invoice/');
+        $client->followRedirect();
+        $this->assertHasFlashError($client);
+
+        self::assertCount(0, $this->getEntityManager()->getRepository(Invoice::class)->findAll());
+    }
+
+    public function testChangeStatusIsNotReachableWithGet(): void
+    {
+        $client = $this->getClientForAuthenticatedUser(User::ROLE_TEAMLEAD);
+        $fixture = new InvoiceFixtures();
+        $fixture->setAmount(1);
+        $invoice = $this->importFixture($fixture)[0];
+
+        $this->request($client, '/invoice/change-status/' . $invoice->getId() . '/canceled');
+        self::assertEquals(Response::HTTP_METHOD_NOT_ALLOWED, $client->getResponse()->getStatusCode());
+    }
+
+    public function testChangeStatusRequiresValidToken(): void
+    {
+        $client = $this->getClientForAuthenticatedUser(User::ROLE_TEAMLEAD);
+        $fixture = new InvoiceFixtures();
+        $fixture->setAmount(1);
+        $fixture->setStatus([Invoice::STATUS_NEW]);
+        $invoice = $this->importFixture($fixture)[0];
+        $invoiceId = $invoice->getId();
+        self::assertIsInt($invoiceId);
+
+        $client->request('POST', $this->createUrl('/invoice/change-status/' . $invoiceId . '/canceled'), ['_token' => 'not-a-valid-token']);
+
+        $this->assertIsRedirect($client, '/invoice/show');
+        $client->followRedirect();
+        $this->assertHasFlashError($client);
+
+        $em = $this->getEntityManager();
+        $em->clear();
+        $reloaded = $em->getRepository(Invoice::class)->find($invoiceId);
+        self::assertInstanceOf(Invoice::class, $reloaded);
+        self::assertEquals(Invoice::STATUS_NEW, $reloaded->getStatus());
+    }
+
+    /**
+     * The invoice listing must not render the status token into any URL, as URLs end up
+     * in access logs, proxy logs, the browser history and referrer headers.
+     */
+    public function testInvoiceActionUrlsDoNotContainTheStatusToken(): void
+    {
+        $client = $this->getClientForAuthenticatedUser(User::ROLE_SUPER_ADMIN);
+
+        $em = $this->getEntityManager();
+        $role = (new Role())->setName(User::ROLE_SUPER_ADMIN);
+        $em->persist($role);
+        $em->flush();
+
+        $permissionService = self::getContainer()->get(PermissionService::class);
+        self::assertInstanceOf(PermissionService::class, $permissionService);
+        $permissionService->saveRolePermission(
+            (new RolePermission())->setRole($role)->setPermission('delete_invoice')->setAllowed(true)
+        );
+
+        $fixture = new InvoiceFixtures();
+        $fixture->setAmount(1);
+        $fixture->setStatus([Invoice::STATUS_NEW]);
+        $invoice = $this->importFixture($fixture)[0];
+
+        $this->request($client, '/invoice/show');
+        self::assertTrue($client->getResponse()->isSuccessful());
+
+        $token = $client->getCrawler()->filter('div#status-token')->attr('data-value');
+        self::assertIsString($token);
+        self::assertNotEmpty($token);
+
+        $urls = $client->getCrawler()->filter('a')->each(fn ($node) => $node->attr('href'));
+        foreach ($urls as $url) {
+            if ($url === null) {
+                continue;
+            }
+            self::assertStringNotContainsString($token, $url);
+            self::assertStringNotContainsString('/change-status/', $url);
+        }
+
+        // deleting goes through the API, which does not need a CSRF token at all
+        $delete = $client->getCrawler()->filter('a.api-link[data-method=DELETE]');
+        self::assertEquals(1, $delete->count());
+        self::assertEquals('/api/invoices/' . $invoice->getId(), $delete->attr('href'));
+    }
+
+    /**
+     * The "mark as paid" action only renders the edit form, so it may stay a GET route.
+     */
+    public function testMarkPaidActionRendersForm(): void
+    {
+        $client = $this->getClientForAuthenticatedUser(User::ROLE_TEAMLEAD);
+        $fixture = new InvoiceFixtures();
+        $fixture->setAmount(1);
+        $fixture->setStatus([Invoice::STATUS_PENDING]);
+        $invoice = $this->importFixture($fixture)[0];
+
+        $this->request($client, '/invoice/mark-paid/' . $invoice->getId());
+        self::assertTrue($client->getResponse()->isSuccessful());
+
+        $node = $client->getCrawler()->filter('form[name=invoice_edit_form]');
+        self::assertEquals(1, $node->count());
     }
 
     public function testEditTemplateAction(): void

--- a/tests/phpstan.neon
+++ b/tests/phpstan.neon
@@ -603,7 +603,7 @@ parameters:
 
         -
             message: "#^Parameter \\#2 \\$url of method App\\\\Tests\\\\Controller\\\\AbstractControllerBaseTestCase\\:\\:request\\(\\) expects string, string\\|null given\\.$#"
-            count: 2
+            count: 1
             path: Controller/InvoiceControllerTest.php
 
         -


### PR DESCRIPTION
## Description

- New reusable API endpoint: delete invoices
- Migrated some invoice routes from GET to POST requests, so CRSF token will not appear in the URL (also state change should not happen via GET)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] I verified that my code applies to the guidelines (`composer code-check`)
- [ ] I updated the documentation (see [here](https://github.com/kimai/www.kimai.org/tree/master/_documentation))
- [x] I agree that this code is used in Kimai (see [license](https://github.com/kimai/kimai/blob/main/LICENSE))
