### PR TITLE
Add per-activity time budget breakdown to project details

### DIFF
--- a/templates/macros/progressbar.html.twig
+++ b/templates/macros/progressbar.html.twig
@@ -151,3 +151,41 @@
         {{ _self.progressbar_full(options) }}
     {% endif %}
 {% endmacro %}
+
+{#
+    @param \App\Model\BudgetStatisticModelInterface budgetStatisticModel
+    @param array activities array of \App\Model\ActivityStatistic
+#}
+{% macro progressbar_timebudget_by_activity(budgetStatisticModel, activities) %}
+    {% if budgetStatisticModel.hasTimeBudget() and activities is not empty %}
+        {% set max = budgetStatisticModel.getTimeBudget() %}
+        {% set sorted = activities|sort((a, b) => b.duration <=> a.duration) %}
+        <div class="progress-group">
+            <div class="progress">
+                {% for stat in sorted %}
+                    {% set percent = 0 %}
+                    {% if max > 0 and stat.duration > 0 %}
+                        {% set percent = (stat.duration / (max / 100)) %}
+                    {% endif %}
+                    {% if percent > 0 %}
+                        <div class="progress-bar" role="progressbar"
+                             style="width: {{ percent|number_format(2, '.', '') }}%; background-color: {{ stat.activity.color|colorize(stat.activity.name) }};"
+                             title="{{ stat.name }}: {{ stat.duration|duration }}{% if stat.activity.hasTimeBudget() %}/{{ stat.activity.timeBudget|duration }}{% endif %}"
+                             aria-valuenow="{{ percent|number_format(1) }}" aria-valuemin="0" aria-valuemax="100">
+                        </div>
+                    {% endif %}
+                {% endfor %}
+            </div>
+            <small>
+                {% for stat in sorted %}
+                    {% if stat.duration > 0 %}
+                        <span class="me-3">
+                            <span style="display:inline-block;width:8px;height:8px;border-radius:50%;background-color: {{ stat.activity.color|colorize(stat.activity.name) }};"></span>
+                            {{ stat.name }} ({{ stat.duration|duration }}{% if stat.activity.hasTimeBudget() %}/{{ stat.activity.timeBudget|duration }}{% endif %})
+                        </span>
+                    {% endif %}
+                {% endfor %}
+            </small>
+        </div>
+    {% endif %}
+{% endmacro %}

--- a/templates/reporting/project_details.html.twig
+++ b/templates/reporting/project_details.html.twig
@@ -426,6 +426,16 @@
                                             {{ progress.progressbar_timebudget(budgetStats) }}
                                         </td>
                                     </tr>
+                                    {% if activities is not empty %}
+                                        <tr>
+                                            <th class="w-min">
+                                                {{ 'activity'|trans }}
+                                            </th>
+                                            <td>
+                                                {{ progress.progressbar_timebudget_by_activity(budgetStats, activities) }}
+                                            </td>
+                                        </tr>
+                                    {% endif %}
                                 {% endif %}
                                 {% if showMoneyBudget and project.hasBudget() %}
                                     <tr>


### PR DESCRIPTION
## Summary
- Adds a stacked bar under the project's "Hourly quota" (time budget) progress bar on the reporting → project details page, showing how logged time breaks down by activity, colored to match each activity's existing color.
- Legend lists each activity's logged duration against its own individually assigned time budget, e.g. `Video Content (5:30/40:00)`, falling back to duration-only when the activity has no time budget set.

## Files
- `templates/macros/progressbar.html.twig` — new `progressbar_timebudget_by_activity` macro
- `templates/reporting/project_details.html.twig` — new "Activity" row wired into the existing budget table

## Test plan
- [x] Verified locally on a Kimai 2.65.0 instance against a project with a time budget and two activities with logged time
- [x] Verify with activities that have individual time budgets set (to confirm the `/XX:XX` denominator)
- [x] Verify with a project that has no time budget (row should not render)