### PR TITLE
Shorter duration entry: Interpret ints < 10 as hours and >= 10 as minutes

### DIFF
--- a/assets/js/plugins/KimaiDateUtils.js
+++ b/assets/js/plugins/KimaiDateUtils.js
@@ -289,7 +289,11 @@ export default class KimaiDateUtils extends KimaiPlugin {
             let c = parseInt(duration);
             const d = parseInt(duration).toFixed();
             if (!isNaN(c) && duration === d) {
-                duration = (c * 3600).toString();
+                if (c < 10) {
+                    duration = (c * 3600).toString();
+                } else {
+                    duration = (c * 60).toString();
+                }
                 luxonDuration = Duration.fromISO('PT' + duration + 'S');
             }
         }


### PR DESCRIPTION
## Description

When we see a plain integer duration value greater than 9, assume the user meant minutes (instead of hours).

Rationale:  Minimally faster time entry / less hovering the keyboard.  I assume most people don't track time shorter than 10 minutes.  Should one want to, they still can, using tried and tested syntax like `0:10`. 

A time tracking software I like has a "heuristic" like this.
It's a tiny feature, but one I grew to really like.
My new employer uses Kimai for time tracking, and I miss this - it's just a very little papercut/quality of life issue, but I run into it rather frequently, having entered a duration into Kimai about 700 times over the last fours months.
 
## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] I verified that my code applies to the guidelines (`composer code-check`)
- [x] I updated the documentation (see [here](https://github.com/kimai/www.kimai.org/pull/761))
- [x] I agree that this code is used in Kimai (see [license](https://github.com/kimai/kimai/blob/main/LICENSE))
